### PR TITLE
Unified site icons (Mining + Analytics) with Lucide

### DIFF
--- a/src/pages/Analytics.svelte
+++ b/src/pages/Analytics.svelte
@@ -96,7 +96,9 @@
             +12.5% this week
           </p>
         </div>
-        <DollarSign class="h-8 w-8 text-muted-foreground" />
+        <div class="p-2 bg-green-500/10 rounded-lg">
+          <DollarSign class="h-5 w-5 text-green-500" />
+        </div>
       </div>
     </Card>
     
@@ -107,7 +109,9 @@
           <p class="text-2xl font-bold">{formatSize(storageUsed)}</p>
           <Progress value={storageUsed} max={10737418240} class="mt-2 h-1" />
         </div>
-        <HardDrive class="h-8 w-8 text-muted-foreground" />
+        <div class="p-2 bg-purple-500/10 rounded-lg">
+          <HardDrive class="h-5 w-5 text-purple-500" />
+        </div>
       </div>
     </Card>
     
@@ -120,7 +124,9 @@
             {downloadedFiles.length} downloaded
           </p>
         </div>
-        <Upload class="h-8 w-8 text-muted-foreground" />
+        <div class="p-2 bg-blue-500/10 rounded-lg">
+          <Upload class="h-5 w-5 text-blue-500" />
+        </div>
       </div>
     </Card>
     
@@ -137,7 +143,9 @@
             {/each}
           </div>
         </div>
-        <Award class="h-8 w-8 text-muted-foreground" />
+        <div class="p-2 bg-yellow-500/10 rounded-lg">
+          <Award class="h-5 w-5 text-yellow-500" />
+        </div>
       </div>
     </Card>
   </div>

--- a/src/pages/Mining.svelte
+++ b/src/pages/Mining.svelte
@@ -5,7 +5,7 @@
   import Progress from '$lib/components/ui/progress.svelte'
   import Input from '$lib/components/ui/input.svelte'
   import Label from '$lib/components/ui/label.svelte'
-  import { Cpu, Zap, TrendingUp, Award, Play, Pause, Coins, ChevronsUpDown } from 'lucide-svelte'
+  import { Cpu, Zap, TrendingUp, Award, Play, Pause, Coins, ChevronsUpDown, Thermometer } from 'lucide-svelte'
   import { onDestroy } from 'svelte'
   
   // Mining state
@@ -175,7 +175,9 @@
             {selectedThreads} threads
           </p>
         </div>
-        <Cpu class="h-8 w-8 text-muted-foreground" />
+        <div class="p-2 bg-primary/10 rounded-lg">
+          <Cpu class="h-5 w-5 text-primary" />
+        </div>
       </div>
     </Card>
     
@@ -189,7 +191,9 @@
             {blocksFound} blocks found
           </p>
         </div>
-        <Coins class="h-8 w-8 text-muted-foreground" />
+        <div class="p-2 bg-yellow-500/10 rounded-lg">
+          <Coins class="h-5 w-5 text-yellow-500" />
+        </div>
       </div>
     </Card>
     
@@ -202,7 +206,9 @@
             {efficiency.toFixed(2)} H/W
           </p>
         </div>
-        <Zap class="h-8 w-8 text-muted-foreground" />
+        <div class="p-2 bg-amber-500/10 rounded-lg">
+          <Zap class="h-5 w-5 text-amber-500" />
+        </div>
       </div>
     </Card>
     
@@ -219,7 +225,9 @@
             />
           </div>
         </div>
-        <div class="text-2xl">🌡️</div>
+        <div class="p-2 bg-red-500/10 rounded-lg">
+          <Thermometer class="h-5 w-5 text-red-500" />
+        </div>
       </div>
     </Card>
   </div>


### PR DESCRIPTION
Unify icon presentation across the app by switching mining/analytics metric icons to Lucide and matching the visual pattern used in Network and Proxy

## Style I matched: 
<img width="1721" height="354" alt="image" src="https://github.com/user-attachments/assets/98535a6d-7766-431d-b747-f1a658abac91" />
<img width="1714" height="329" alt="image" src="https://github.com/user-attachments/assets/a59c935b-fe24-4306-b316-dbbbc0ec7436" />

## Before:
* Mining: <img width="1712" height="368" alt="image" src="https://github.com/user-attachments/assets/927aa420-7ae8-4ea2-b57d-953b5474e69f" />
* Analytics: <img width="1704" height="378" alt="image" src="https://github.com/user-attachments/assets/7329a838-d12c-4d1b-9702-fa44589d3f38" />

## After:
* Mining: <img width="1712" height="375" alt="image" src="https://github.com/user-attachments/assets/1e50d6c3-b721-4a7a-9977-c96dc8d20d5c" />
* Analytics: <img width="1712" height="377" alt="image" src="https://github.com/user-attachments/assets/45fb960c-8b19-4f12-b046-abd1db459fc0" />
