### PR TITLE
Feat/collapsible sidebar

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import './styles/globals.css'
-  import { Upload, Download, Shield, Wallet, Globe, BarChart3, Settings, Cpu } from 'lucide-svelte'
+  import { Upload, Download, Shield, Wallet, Globe, BarChart3, Settings, Cpu, Menu } from 'lucide-svelte'
   import UploadPage from './pages/Upload.svelte'
   import DownloadPage from './pages/Download.svelte'
   import ProxyPage from './pages/Proxy.svelte'
@@ -12,6 +12,7 @@
   import { networkStatus } from '$lib/stores'
   
   let currentPage = 'download'
+  let sidebarCollapsed = false
   
   const menuItems = [
     { id: 'download', label: 'Download', icon: Download },
@@ -27,21 +28,47 @@
 
 <div class="flex h-screen bg-background">
   <!-- Sidebar -->
-  <div class="w-64 bg-card border-r transition-all">
-    <nav class="p-4 space-y-2">
-      <!-- Network Status at top of sidebar -->
-      <div class="flex items-center gap-2 px-3 py-2 mb-4 text-xs">
-        <div class="w-2 h-2 rounded-full {$networkStatus === 'connected' ? 'bg-green-500' : 'bg-red-500'}"></div>
-        <span class="text-muted-foreground">{$networkStatus}</span>
+  <div class="{sidebarCollapsed ? 'w-16' : 'w-64'} bg-card border-r transition-all">
+    <nav class="p-2 space-y-2">
+      <!-- Collapse control + Network Status -->
+      <div class="flex items-center justify-between px-2 py-2 mb-2">
+        <div class="flex items-center">
+          <button
+            aria-label={sidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+            class="p-2 rounded hover:bg-accent/20"
+            on:click={() => sidebarCollapsed = !sidebarCollapsed}
+          >
+            <Menu class="h-5 w-5" />
+          </button>
+          {#if !sidebarCollapsed}
+            <span class="ml-2 font-bold text-base">Menu</span>
+          {/if}
+        </div>
+
+        {#if !sidebarCollapsed}
+          <div class="flex items-center gap-2 text-xs">
+            <div class="w-2 h-2 rounded-full {$networkStatus === 'connected' ? 'bg-green-500' : 'bg-red-500'}"></div>
+            <span class="text-muted-foreground">{$networkStatus}</span>
+          </div>
+        {:else}
+          <div class="w-2 h-2 rounded-full {$networkStatus === 'connected' ? 'bg-green-500' : 'bg-red-500'}"></div>
+        {/if}
       </div>
-      
+
       {#each menuItems as item}
         <button
           on:click={() => currentPage = item.id}
-          class="w-full flex items-center gap-3 px-3 py-2 rounded-lg text-sm transition-colors {currentPage === item.id ? 'bg-accent text-accent-foreground' : 'hover:bg-accent/50'}"
+          class="w-full group"
+          aria-current={currentPage === item.id ? 'page' : undefined}
         >
-          <svelte:component this={item.icon} class="h-4 w-4" />
-          {item.label}
+          <div class="flex items-center {sidebarCollapsed ? 'justify-center' : ''} rounded {currentPage === item.id ? 'bg-gray-200' : 'group-hover:bg-gray-100'}" style="width: 100%;">
+            <span class="flex items-center justify-center transition-colors rounded" style="width: 2.5rem; min-width: 2.5rem; height: 2.5rem;">
+              <svelte:component this={item.icon} class="h-5 w-5" style="height: 1.25rem; width: 1.25rem; min-width: 1.25rem; min-height: 1.25rem;" />
+            </span>
+            {#if !sidebarCollapsed}
+              <span class="flex-1 px-2 py-1 rounded transition-colors text-left">{item.label}</span>
+            {/if}
+          </div>
         </button>
       {/each}
     </nav>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -35,7 +35,7 @@
         <div class="flex items-center">
           <button
             aria-label={sidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-            class="p-2 rounded hover:bg-accent/20"
+            class="p-2 rounded transition-colors hover:bg-gray-100"
             on:click={() => sidebarCollapsed = !sidebarCollapsed}
           >
             <Menu class="h-5 w-5" />


### PR DESCRIPTION
**Changes:**
- Added a collapsible sidebar feature that shows only icons when collapsed and both icons and labels when expanded
- Hamburger menu button toggles state
- Added a hover highlight effect

**Before:**
<img width="1190" height="647" alt="Screenshot 2025-09-04 at 3 47 47 PM" src="https://github.com/user-attachments/assets/161ad5b9-fdcb-458c-b0a4-d3b8b8124461" />

**After:**
<img width="1317" height="654" alt="Screenshot 2025-09-05 at 1 43 08 PM" src="https://github.com/user-attachments/assets/bbaf601b-14d6-4a6e-83c9-d3d3f1b044b2" />

<img width="1315" height="657" alt="Screenshot 2025-09-05 at 1 43 21 PM" src="https://github.com/user-attachments/assets/307d603a-668f-4716-8188-f0ab4ac0fc4d" />

