### PR TITLE
Page scrolling fix

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -10,11 +10,22 @@
     import SettingsPage from './pages/Settings.svelte'
     import MiningPage from './pages/Mining.svelte'
     import { networkStatus } from '$lib/stores'
-    
+    import { tick } from 'svelte'
+
     let currentPage = 'download'
     let sidebarCollapsed = false
     let mobileMenuOpen = false
-    
+
+    // Scroll to top when page changes
+    $: if (currentPage) {
+        tick().then(() => {
+            const mainContent = document.querySelector('.flex-1.overflow-auto')
+            if (mainContent) {
+                mainContent.scrollTop = 0
+            }
+        })
+    }
+
     const menuItems = [
       { id: 'download', label: 'Download', icon: Download },
       { id: 'upload', label: 'Upload', icon: Upload },


### PR DESCRIPTION
- Previously when you scrolled down on a page such as "Downloads" for example and then switched to another page such as "Mining" for example, the page would remain scrolled down. This PR fixes this.