### PR TITLE
Download page: Quality of life changes

### DIFF
--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -17,6 +17,7 @@ export interface FileItem {
   downloadSpeed?: number
   uploadSpeed?: number
   timeRemaining?: number
+  visualOrder?: number // For maintaining user's intended visual order
 }
 
 export interface ProxyNode {
@@ -80,10 +81,10 @@ export interface NetworkStats {
 
 // Sample dummy data
 const dummyFiles: FileItem[] = [
-  { id: '1', name: 'Document.pdf', hash: 'QmZ4tDuvesekqMD', size: 2048576, status: 'completed', progress: 100 },
-  { id: '2', name: 'Image.jpg', hash: 'QmZ4tDuvesekqME', size: 1024000, status: 'downloading', progress: 65 },
-  { id: '3', name: 'Video.mp4', hash: 'QmZ4tDuvesekqMF', size: 50331648, status: 'paused', progress: 30 },
-  { id: '4', name: 'Archive.zip', hash: 'QmZ4tDuvesekqMG', size: 10485760, status: 'uploaded', progress: 100 },
+  { id: '0', name: 'Image.jpg', hash: 'QmZ4tDuvesekqME', size: 1024000, status: 'downloading', progress: 50, visualOrder: 0 },
+  { id: '1', name: 'Video.mp4', hash: 'QmZ4tDuvesekqMF', size: 50331648, status: 'paused', progress: 30, visualOrder: 1 },
+  { id: '2', name: 'Document.pdf', hash: 'QmZ4tDuvesekqMD', size: 2048576, status: 'completed', progress: 100, visualOrder: 2 },
+  { id: '3', name: 'Archive.zip', hash: 'QmZ4tDuvesekqMG', size: 10485760, status: 'uploaded', progress: 100, visualOrder: 3 },
 ]
 
 const dummyProxyNodes: ProxyNode[] = [


### PR DESCRIPTION
- Added filtering tabs for All, Active, Paused, Completed, Queued, Failed downloads (this is also the default sort order on the All tab now)
- Fixed download counts so that All equals Active + Paused + Completed + Queued + Failed
- Added color-coded statuses (green=downloading, blue=completed, yellow=paused, gray=queued, red=failed)
- Progress now shows up to hundredths precision
- Centered "Open File" button and changed its icon from a clock to a file
- Enhanced empty states with specific messages for each download type
- Fixed simulated downloads (like if the user presses the resume button)