### PR TITLE
Tauri tick fix

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -12,7 +12,7 @@
     import NotFound from './pages/NotFound.svelte'
     import { networkStatus } from '$lib/stores'
     import { Router, type RouteConfig, goto } from '@mateothegreat/svelte5-router';
-    import {onMount} from 'svelte';
+    import {onMount, tick} from 'svelte';
 
     // gets path name not entire url:
     // ex: http://locatlhost:1420/download -> /download


### PR DESCRIPTION
Before the error "Error: ReferenceError: tick is not defined in in App.svelte" would appear after running `npm run tauri dev` because `tick` was not imported in `App.svelte`. This PR fixes this.