### PR TITLE
Feature: users can now sort their transactions by date and type

### DIFF
--- a/src/pages/Account.svelte
+++ b/src/pages/Account.svelte
@@ -246,7 +246,7 @@
         </button>
       </div>
     </div>
-    <div class="space-y-2">
+    <div class="space-y-2 max-h-80 overflow-y-auto pr-1">
       {#each filteredTransactions as tx}
         <div class="flex items-center justify-between p-3 bg-secondary rounded-lg">
           <div class="flex items-center gap-3">

--- a/src/pages/Account.svelte
+++ b/src/pages/Account.svelte
@@ -235,7 +235,7 @@
       </div>
       <div>
         <label class="block text-xs font-medium mb-1">Sort</label>
-        <button type="button" class="border rounded px-3 py-1 text-sm bg-muted hover:bg-muted/70 transition-colors w-full" on:click={() => { sortDescending = !sortDescending; }}>
+        <button type="button" class="border rounded px-3 py-1 text-sm bg-white hover:bg-gray-100 transition-colors w-full" on:click={() => { sortDescending = !sortDescending; }}>
           {sortDescending ? 'Newest → Oldest' : 'Oldest → Newest'}
         </button>
       </div>


### PR DESCRIPTION
The transaction history section now has options to sort transactions by date and type. Users can also select specific dates to view transactions. A reset option was also added to sort transactions by their default state. 
<img width="3186" height="861" alt="image" src="https://github.com/user-attachments/assets/030419fb-3cd0-4fc0-a924-c50ca870af20" />