### PR TITLE
fix(deps): bump vite to patched version to address audit advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3105,9 +3105,9 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.4.tgz",
-      "integrity": "sha512-X5QFK4SGynAeeIt+A7ZWnApdUyHYm+pzv/8/A57LqSGcI88U6R6ipOs3uCesdc6yl7nl+zNO0t8LmqAdXcQihw==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.5.tgz",
+      "integrity": "sha512-4cKBO9wR75r0BeIWWWId9XK9Lj6La5X846Zw9dFfzMRw38IlTk2iCcUt6hsyiDRcPidc55ZParFYDXi0nXOeLQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3116,7 +3116,7 @@
         "picomatch": "^4.0.3",
         "postcss": "^8.5.6",
         "rollup": "^4.43.0",
-        "tinyglobby": "^0.2.14"
+        "tinyglobby": "^0.2.15"
       },
       "bin": {
         "vite": "bin/vite.js"


### PR DESCRIPTION
## Updated package-lock.json to fix low severity vulnerability.

## Before there was a low severity vulnerability:
<img width="593" height="336" alt="image" src="https://github.com/user-attachments/assets/60845896-4446-417a-a0b8-f3abbb0d4178" />

## After: 
<img width="571" height="203" alt="image" src="https://github.com/user-attachments/assets/38f4e62b-0d54-4e7f-a1e2-740872583e86" />
