### PR TITLE
fixed styles for mobile on Download, Upload, and Analytic pages.

### DIFF
--- a/src/lib/components/ui/progress.svelte
+++ b/src/lib/components/ui/progress.svelte
@@ -10,7 +10,7 @@
 </script>
 
 <div
-  class={cn('relative h-4 w-full overflow-hidden rounded-full bg-secondary', className)}
+  class={cn('relative h-4 w-full overflow-hidden rounded-full bg-white', className)}
   {...$$restProps}
 >
   <div

--- a/src/pages/Analytics.svelte
+++ b/src/pages/Analytics.svelte
@@ -529,7 +529,7 @@ function computeLatencyStats() {
   
   <Card class="p-6">
     <h2 class="text-lg font-semibold mb-4">Earnings History</h2>
-    <div class="flex gap-2 mb-4">
+    <div class="flex flex-wrap gap-2 mb-4">
       {#each periodPresets as preset}
         <button
           type="button"

--- a/src/pages/Download.svelte
+++ b/src/pages/Download.svelte
@@ -428,7 +428,7 @@
                 <div class="flex items-center text-sm">
                   <span>Progress: {(file.progress || 0).toFixed(2)}%</span>
                 </div>
-                <Progress value={file.progress || 0} max={100} />
+                <Progress value={file.progress || 0} max={100} class="bg-gray-200" />
               </div>
             {/if}
             
@@ -463,8 +463,7 @@
             {/if}
             
             {#if file.status === 'completed'}
-              <div class="flex items-center gap-2 mt-3">
-                <span>Download complete!</span>
+              <div class="flex flex-wrap gap-2 mt-3">
                 <Button
                         size="sm"
                         variant="outline"

--- a/src/pages/Upload.svelte
+++ b/src/pages/Upload.svelte
@@ -147,14 +147,14 @@
         <div class="space-y-2">
           {#each $files.filter(f => f.status === 'seeding' || f.status === 'uploaded') as file}
             <div class="flex flex-wrap items-center justify-between gap-2 p-3 bg-secondary rounded-lg hover:bg-secondary/80 transition-colors">
-              <div class="flex items-center gap-3">
+              <div class="flex items-center gap-3 min-w-0">
                 <File class="h-4 w-4 text-muted-foreground" />
-                <div class="flex-1">
+                <div class="flex-1 min-w-0">
                   <p class="text-sm font-medium truncate">{file.name}</p>
-                  <div class="flex flex-wrap items-center gap-3 mt-1">
+                  <div class="flex flex-wrap items-center gap-x-3 gap-y-1 mt-1">
                     <p class="text-xs text-muted-foreground truncate">Hash: {file.hash}</p>
                     <span class="text-xs text-muted-foreground">•</span>
-                    <p class="text-xs text-muted-foreground">{formatFileSize(file.size)}</p>
+                    <p class="text-xs text-muted-foreground truncate">{formatFileSize(file.size)}</p>
                     {#if file.seeders !== undefined}
                       <span class="text-xs text-muted-foreground">•</span>
                       <p class="text-xs text-green-600">{file.seeders || 1} seeder{(file.seeders || 1) !== 1 ? 's' : ''}</p>


### PR DESCRIPTION
Download Page
- Deleted "Download Complete!" text to avoid redundancy and better UI on Mobile.
<img width="389" height="789" alt="Download page pre" src="https://github.com/user-attachments/assets/711e0b64-28e3-4eef-b3ec-fe42939e8da8" />

<img width="368" height="803" alt="Download page post" src="https://github.com/user-attachments/assets/256154c3-d05e-4c14-a311-1b04114b7481" />



Upload Page
- Fixed the file title and size, exceeding the container on Mobile. 
<img width="390" height="794" alt="Upload page pre" src="https://github.com/user-attachments/assets/76510779-99a8-4206-a4e0-4ae7a7fcdea2" />

<img width="365" height="803" alt="Upload page post" src="https://github.com/user-attachments/assets/60a712e9-ff6b-4c3a-92d1-0d4e014a2bbe" />



Analytic page
- Fixed the Earning History buttons exceeding the container on Mobile.
<img width="385" height="798" alt="Analytic page pre" src="https://github.com/user-attachments/assets/e5eb227c-bc84-45fa-b761-555e0269dd16" />

<img width="367" height="790" alt="Analytic page post" src="https://github.com/user-attachments/assets/6c4273f4-c730-4be3-9fd4-a2f7f85e4998" />
