### PR TITLE
feat(system-tray): implemented basic background operation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ This implementation synthesizes concepts from multiple design teams, focusing on
 
 - **Tauri 2**: Rust-based desktop runtime for native performance
 - **Native File System**: Direct OS integration for file operations
-- **System Tray**: Background operation support (planned)
+- **System Tray**: Background operation support
 - **Auto-Updates**: Seamless application updates (planned)
 
 ### Data Management

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 tauri-build = { version = "2.0", features = [] }
 
 [dependencies]
-tauri = { version = "2.1", features = ["macos-private-api"] }
+tauri = { version = "2.1", features = ["macos-private-api", "tray-icon"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tauri-plugin-process = "2.0"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -3,7 +3,11 @@
     windows_subsystem = "windows"
 )]
 
-use tauri::Manager;
+use tauri::{
+    menu::{Menu, MenuItem},
+    tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
+    Manager,
+};
 
 fn main() {
     println!("Starting Chiral Network...");
@@ -17,11 +21,70 @@ fn main() {
             println!("App setup complete");
             println!("Window should be visible now!");
 
+            let show_i = MenuItem::with_id(app, "show", "Show", true, None::<&str>)?;
+            let hide_i = MenuItem::with_id(app, "hide", "Hide", true, None::<&str>)?;
+            let quit_i = MenuItem::with_id(app, "quit", "Quit", true, None::<&str>)?;
+            let menu = Menu::with_items(app, &[&show_i, &hide_i, &quit_i])?;
+
+            let _tray = TrayIconBuilder::new()
+                .icon(app.default_window_icon().unwrap().clone())
+                .menu(&menu)
+                .tooltip("Chiral Network")
+                .show_menu_on_left_click(false)
+                .on_tray_icon_event(|tray, event| match event {
+                    TrayIconEvent::Click {
+                        button: MouseButton::Left,
+                        button_state: MouseButtonState::Up,
+                        ..
+                    } => {
+                        println!("Tray icon left-clicked");
+                        let app = tray.app_handle();
+                        if let Some(window) = app.get_webview_window("main") {
+                            let _ = window.unminimize();
+                            let _ = window.show();
+                            let _ = window.set_focus();
+                        }
+                    }
+                    _ => {}
+                })
+                .on_menu_event(|app, event| match event.id.as_ref() {
+                    "show" => {
+                        println!("Show menu item clicked");
+                        if let Some(window) = app.get_webview_window("main") {
+                            let _ = window.show();
+                            let _ = window.set_focus();
+                        }
+                    }
+                    "hide" => {
+                        println!("Hide menu item clicked");
+                        if let Some(window) = app.get_webview_window("main") {
+                            let _ = window.hide();
+                        }
+                    }
+                    "quit" => {
+                        println!("Quit menu item clicked");
+                        app.exit(0);
+                    }
+                    _ => {}
+                })
+                .build(app)?;
+
             // Get the main window and ensure it's visible
             if let Some(window) = app.get_webview_window("main") {
                 window.show().unwrap();
                 window.set_focus().unwrap();
                 println!("Window shown and focused");
+
+                let app_handle = app.handle().clone();
+                window.on_window_event(move |event| {
+                    if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+                        // Prevent the window from closing and hide it instead
+                        api.prevent_close();
+                        if let Some(window) = app_handle.get_webview_window("main") {
+                            let _ = window.hide();
+                        }
+                    }
+                });
             } else {
                 println!("Could not find main window!");
             }


### PR DESCRIPTION
## Summary
Add a system tray icon and behavior so the app minimizes to the system tray when the user closes the main window (X). The tray includes a small menu with Show, Hide, and Exit. This change improves UX by preventing accidental quits and enabling quick restore from the tray. Feel free to request changes to the behavior, but this is what I think makes sense for the background operation support.

## What I changed
* Added a system tray icon and menu (Show / Hide / Exit).
* Implemented CloseRequested handling for the main window to prevent close and hide the window (minimize to tray).
* Added handlers for tray left-click to restore/unminimize the main window.

<img width="250" height="188" alt="image" src="https://github.com/user-attachments/assets/53cf49aa-3543-40eb-9adc-2819b8a7c319" />
