### PR TITLE
feat: implement geographic-based peer sorting in Network page

### DIFF
--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -195,4 +195,5 @@ export const peers = writable<PeerInfo[]>(dummyPeers);
 export const chatMessages = writable<ChatMessage[]>([]);
 export const networkStats = writable<NetworkStats>(dummyNetworkStats);
 export const downloadQueue = writable<FileItem[]>([]);
+export const userLocation = writable<string>("US-East");
 export const etcAccount = writable<ETCAccount | null>(null);

--- a/src/pages/Network.svelte
+++ b/src/pages/Network.svelte
@@ -5,7 +5,7 @@
   import Input from '$lib/components/ui/input.svelte'
   import Label from '$lib/components/ui/label.svelte'
   import { Users, HardDrive, Activity, RefreshCw, UserPlus, Signal, Server, Play, Square, Download, AlertCircle } from 'lucide-svelte'
-  import { peers, networkStats, networkStatus } from '$lib/stores'
+  import { peers, networkStats, networkStatus, userLocation } from '$lib/stores'
   import { onMount, onDestroy } from 'svelte'
   import { invoke } from '@tauri-apps/api/core'
   import { listen } from '@tauri-apps/api/event'
@@ -461,6 +461,23 @@
                 case 'location':
                     aVal = (a.location || 'zzzzz').toLowerCase() // Put empty locations at the end
                     bVal = (b.location || 'zzzzz').toLowerCase()
+                    // Distance-based sorting: closer peers first
+                    const getLocationDistance = (peerLocation: string | undefined) => {
+                        if (!peerLocation) return 999; // Unknown locations go to the end
+                        
+                        // Distance map from user's location to other regions
+                        const distanceMap: Record<string, Record<string, number>> = {
+                            'US-East': { 'US-East': 0, 'US-West': 1, 'EU-West': 2, 'Asia-Pacific': 3 },
+                            'US-West': { 'US-West': 0, 'US-East': 1, 'EU-West': 3, 'Asia-Pacific': 2 },
+                            'EU-West': { 'EU-West': 0, 'US-East': 1, 'US-West': 3, 'Asia-Pacific': 2 },
+                            'Asia-Pacific': { 'Asia-Pacific': 0, 'US-West': 1, 'EU-West': 2, 'US-East': 3 }
+                        };
+                        
+                        return distanceMap[$userLocation]?.[peerLocation] ?? 999;
+                    };
+                    
+                    aVal = getLocationDistance(a.location);
+                    bVal = getLocationDistance(b.location);
                     break
                 case 'joinDate':
                     aVal = new Date(a.joinDate).getTime()

--- a/src/pages/Settings.svelte
+++ b/src/pages/Settings.svelte
@@ -19,6 +19,7 @@
   import { open } from "@tauri-apps/plugin-dialog";
   import { homeDir } from "@tauri-apps/api/path";
   import { getVersion } from "@tauri-apps/api/app";
+  import { userLocation } from "$lib/stores";
 
   // Settings state
   let settings = {
@@ -35,6 +36,7 @@
     port: 30303,
     enableUPnP: true,
     enableNAT: true,
+    userLocation: "US-East", // Geographic region for peer sorting
 
     // Privacy settings
     enableProxy: true,
@@ -69,6 +71,9 @@
     localStorage.setItem("chiralSettings", JSON.stringify(settings));
     savedSettings = { ...settings };
     hasChanges = false;
+    
+    // Sync user location with the global store
+    userLocation.set(settings.userLocation);
   }
 
   function resetSettings() {
@@ -83,6 +88,7 @@
       port: 30303,
       enableUPnP: true,
       enableNAT: true,
+      userLocation: "US-East",
       enableProxy: true,
       enableEncryption: true,
       anonymousMode: false,
@@ -366,6 +372,24 @@
             <p class="mt-1 text-sm text-red-500">{errors.downloadBandwidth}</p>
           {/if}
         </div>
+      </div>
+
+      <!-- User Location -->
+      <div>
+        <Label for="user-location">Your Location</Label>
+        <select
+          id="user-location"
+          bind:value={settings.userLocation}
+          class="w-full px-3 py-2 mt-2 border rounded-md bg-white"
+        >
+          <option value="US-East">US East</option>
+          <option value="US-West">US West</option>
+          <option value="EU-West">Europe West</option>
+          <option value="Asia-Pacific">Asia Pacific</option>
+        </select>
+        <p class="text-xs text-muted-foreground mt-1">
+          Used to prioritize geographically closer peers for better performance
+        </p>
       </div>
 
       <div class="space-y-2">


### PR DESCRIPTION
**Overview**
Replaced alphabetical region sorting in the Network page with distance-based sorting that prioritizes geographically closer peers. The goal is to provide users with a more intuitive ordering of peers and improve network performance by leveraging real-world proximity.

**Changes**
- Added userLocation store with default "US-East" setting
- Introduced location dropdown in Settings with 4 regions (US-East, US-West, EU-West, Asia-Pacific)
- Replaced alphabetical sorting with a geographic distance matrix
- Calculate peer distances based on actual regional proximity
- Unknown locations are pushed to the end of the list

**Benefits:**
- More intuitive peer ordering for users
- Better network performance by prioritizing closer peers
- User-configurable location setting for accurate results

**Before:** Peers sorted alphabetically by region name (Asia-Pacific, EU-West, US-East)

<img width="549" height="534" alt="Screenshot 2025-09-09 at 9 58 07 PM" src="https://github.com/user-attachments/assets/a7af4cad-625e-4429-a15f-51809882ec3d" />

**After:** Peers sorted by distance from user location (same region → nearby regions → distant regions)

<img width="548" height="560" alt="Screenshot 2025-09-09 at 10 42 23 PM" src="https://github.com/user-attachments/assets/d10b7239-0717-4403-9b4a-ff73f88cc167" />
