### PR TITLE
feat: implement human-friendly sorting labels in Network page

### DIFF
--- a/src/pages/Network.svelte
+++ b/src/pages/Network.svelte
@@ -18,6 +18,21 @@
   let sortBy: 'reputation' | 'sharedFiles' | 'totalSize' | 'nickname' | 'location' | 'joinDate' | 'lastSeen' | 'status' = 'reputation'
   let sortDirection: 'asc' | 'desc' = 'desc'
   
+  // Update sort direction when category changes to match the default
+  $: if (sortBy) {
+    const defaults: Record<typeof sortBy, 'asc' | 'desc'> = {
+      reputation: 'desc',     // Highest first
+      sharedFiles: 'desc',    // Most first
+      totalSize: 'desc',      // Largest first
+      joinDate: 'desc',       // Newest first
+      lastSeen: 'desc',       // Most Recent first
+      location: 'asc',        // Closest first
+      status: 'asc',          // Online first
+      nickname: 'asc'         // A → Z first
+    }
+    sortDirection = defaults[sortBy]
+  }
+  
   // Chiral Network Node variables
   let isGethRunning = false
   let isGethInstalled = false
@@ -477,8 +492,31 @@
                       bind:value={sortDirection}
                       class="border rounded px-2 py-1 text-sm"
               >
-                  <option value="asc">↑ Ascending</option>
-                  <option value="desc">↓ Descending</option>
+                  {#if sortBy === 'reputation'}
+                      <option value="desc">Highest</option>
+                      <option value="asc">Lowest</option>
+                  {:else if sortBy === 'sharedFiles'}
+                      <option value="desc">Most</option>
+                      <option value="asc">Least</option>
+                  {:else if sortBy === 'totalSize'}
+                      <option value="desc">Largest</option>
+                      <option value="asc">Smallest</option>
+                  {:else if sortBy === 'joinDate'}
+                      <option value="desc">Newest</option>
+                      <option value="asc">Oldest</option>
+                  {:else if sortBy === 'lastSeen'}
+                      <option value="desc">Most Recent</option>
+                      <option value="asc">Least Recent</option>
+                  {:else if sortBy === 'location'}
+                      <option value="asc">Closest</option>
+                      <option value="desc">Farthest</option>
+                  {:else if sortBy === 'status'}
+                      <option value="asc">Online</option>
+                      <option value="desc">Offline</option>
+                  {:else if sortBy === 'nickname'}
+                      <option value="asc">A → Z</option>
+                      <option value="desc">Z → A</option>
+                  {/if}
               </select>
           </div>
       </div>


### PR DESCRIPTION
**Summary**
- Replace abstract "ascending/descending" dropdown labels with contextual, human-friendly terms
- Implement automatic default sort direction selection when category changes

**Changes Made**

Human-Friendly Sort Labels:
- Reputation: Highest / Lowest (default: Highest)
- Shared Files: Most / Least (default: Most)
- Total Size: Largest / Smallest (default: Largest)
- Join Date: Newest / Oldest (default: Newest)
- Last Seen: Most Recent / Least Recent (default: Most Recent)
- Location: Closest / Farthest (default: Closest)
- Status: Online / Offline (default: Online)
- Name: A → Z / Z → A (default: A → Z)

This enhancement makes the sorting interface more intuitive by replacing technical terms with language that directly relates to what users are trying to accomplish.

**Before:** "ascending/descending" dropdown labels
<img width="548" height="560" alt="Screenshot 2025-09-09 at 10 42 23 PM" src="https://github.com/user-attachments/assets/8882d356-50dc-42ed-a769-84e139c282be" />

**After:** human-friendly labels
<img width="529" height="533" alt="Screenshot 2025-09-10 at 6 12 46 AM" src="https://github.com/user-attachments/assets/cb302b50-3e68-4beb-a641-379465f5097c" />
