### PR TITLE
fix(account): Fix form validation UX issues in Account page

### DIFF
--- a/src/pages/Account.svelte
+++ b/src/pages/Account.svelte
@@ -763,10 +763,9 @@
       <BadgeX class="h-5 w-5 text-muted-foreground" />
     </div>
 
-
     <div class="space-y-4">
       <div>
-        <Label for="blacklist-address">Chrial Address to Blacklist</Label>
+        <Label for="blacklist-address">Chiral Address to Blacklist</Label>
         <Input
           id="blacklist-address"
           bind:value={newBlacklistEntry.chiral_address}
@@ -786,7 +785,6 @@
       <Button type="button" class="w-full" disabled={!isBlacklistFormValid} on:click={addBlacklistEntry}>
         Add to Blacklist
       </Button>
-
 
       <h3 class="text-md font-semibold mt-6 mb-3">Blacklisted Addresses</h3>
       {#if $blacklist.length === 0}
@@ -808,7 +806,5 @@
       {/if}
     </div>
   </Card>
-
   {/if}
-
 </div>


### PR DESCRIPTION
Fixed amount validation warnings showing incorrectly when input field is empty, even when the user hasn't entered anything. It previously only did this for the recipient address.

Before:
<img width="1085" height="208" alt="image" src="https://github.com/user-attachments/assets/62e96f1e-fd56-4db5-8ed8-5ece42b00d7a" />

After:
<img width="1121" height="207" alt="image" src="https://github.com/user-attachments/assets/74bd128f-5937-4462-aba2-1b38d36dad16" />

Improved address character counter to show "X over" instead of negative numbers. Users now see clear feedback when exceeding the 42 character limit.

Before:
<img width="1143" height="345" alt="image" src="https://github.com/user-attachments/assets/1c3a80c6-3084-4220-ad79-8079562c8751" />

After:
<img width="1141" height="369" alt="image" src="https://github.com/user-attachments/assets/52a43d11-acae-4e0f-82ef-4b564c555458" />