### PR TITLE
fix(network): correct windows download

### DIFF
--- a/src-tauri/src/geth_downloader.rs
+++ b/src-tauri/src/geth_downloader.rs
@@ -48,7 +48,7 @@ impl GethDownloader {
             ("macos", "x86_64") => "https://github.com/etclabscore/core-geth/releases/download/v1.12.20/core-geth-darwin-amd64-v1.12.20.tar.gz",
             ("linux", "x86_64") => "https://github.com/etclabscore/core-geth/releases/download/v1.12.20/core-geth-linux-amd64-v1.12.20.tar.gz",
             ("linux", "aarch64") => "https://github.com/etclabscore/core-geth/releases/download/v1.12.20/core-geth-linux-arm64-v1.12.20.tar.gz",
-            ("windows", "x86_64") => "https://github.com/etclabscore/core-geth/releases/download/v1.12.20/core-geth-windows-amd64-v1.12.20.zip",
+            ("windows", "x86_64") => "https://github.com/etclabscore/core-geth/releases/download/v1.12.20/core-geth-win64-v1.12.20.zip",
             _ => return Err(format!("Unsupported platform: {} {}", std::env::consts::OS, std::env::consts::ARCH)),
         };
         


### PR DESCRIPTION
- Corrected core-geth download link for Windows in `get_download_url` function
- Binary now downloads for Windows

Before:
<img width="2447" height="1167" alt="Screenshot 2025-09-10 190053" src="https://github.com/user-attachments/assets/54c1c19f-c343-4dba-ab10-75c7e91fa130" />

<img width="2470" height="1057" alt="Screenshot 2025-09-10 190109" src="https://github.com/user-attachments/assets/2b43d5d6-a5a5-440c-aa2b-9abb37e96218" />

After:
<img width="2460" height="1270" alt="Screenshot 2025-09-10 190148" src="https://github.com/user-attachments/assets/68a5ea42-d289-48ca-a308-e4c71c4fa803" />

<img width="2435" height="1105" alt="Screenshot 2025-09-10 190200" src="https://github.com/user-attachments/assets/47fa7877-9df8-4998-8707-5aa4c8cc7362" />

<img width="2450" height="867" alt="Screenshot 2025-09-10 190210" src="https://github.com/user-attachments/assets/391be06d-b70d-4c62-8da1-030a618b7318" />


