### PR TITLE
fix: Account page: Add immediate Recipient address validation with inline error messages 

### DIFF
--- a/src/pages/Account.svelte
+++ b/src/pages/Account.svelte
@@ -80,24 +80,34 @@
       return sortDescending ? dateB.getTime() - dateA.getTime() : dateA.getTime() - dateB.getTime();
     });
 
-  // Validation logic
+  // Enhanced address validation with immediate feedback
   $: {
-    // Address validation
-    if (!recipientAddress) {
+    if (recipientAddress === '') {
       addressWarning = '';
       isAddressValid = false;
     } else if (!recipientAddress.startsWith('0x')) {
-      addressWarning = 'Address must start with 0x.';
+      addressWarning = 'Address must start with 0x';
       isAddressValid = false;
-    } else if (recipientAddress.length !== 42) {
-      addressWarning = 'Address must be exactly 42 characters long.';
+    } else if (recipientAddress.length > 42) {
+      addressWarning = 'Address is too long (max 42 characters)';
       isAddressValid = false;
-    } else {
+    }
+    else if (!isValidHexAddress(recipientAddress)) {
+      addressWarning = 'Address must contain valid hexadecimal characters (0-9, a-f, A-F)';
+      isAddressValid = false;
+    }
+    else if (recipientAddress.length < 42) {
+      addressWarning = 'Address must be exactly 42 characters long';
+      isAddressValid = false;
+    }
+    else {
       addressWarning = '';
       isAddressValid = true;
     }
+  }
 
-    // Amount validation
+  // Amount validation
+  $: {
     if (rawAmountInput === '') {
       validationWarning = '';
       isAmountValid = false;
@@ -110,11 +120,11 @@
         isAmountValid = false;
         sendAmount = 0;
       } else if (inputValue < 0.01) {
-        validationWarning = `Amount must be at least 0.01 Chiral.`;
+        validationWarning = `Amount must be at least 0.01 CN.`;
         isAmountValid = false;
         sendAmount = 0;
       } else if (inputValue > $wallet.balance) {
-        validationWarning = `Insufficient balance - Need ${(inputValue - $wallet.balance).toFixed(2)} more Chiral.`;
+        validationWarning = `Insufficient balance - Need ${(inputValue - $wallet.balance).toFixed(2)} more CN.`;
         isAmountValid = false;
         sendAmount = 0;
       } else {
@@ -126,26 +136,12 @@
     }
   }
 
-  // Enhanced address validation with user feedback
-  $: {
-    if (recipientAddress.trim() === '') {
-      addressWarning = '';
-      isAddressValid = true;
-    } else if (!isValidAddress(recipientAddress)) {
-      addressWarning = 'Address must contain valid hexadecimal characters (0-9, a-f, A-F)';
-      isAddressValid = false;
-    } else {
-      addressWarning = '';
-      isAddressValid = true;
-    }
-  }
-  
   // Enhanced address validation function
-  function isValidAddress(address: string): boolean {
+  function isValidHexAddress(address: string): boolean {
     // Check that everything after 0x is hexadecimal
     const hexPart = address.slice(2);
     if (hexPart.length === 0) return false;
-    
+
     const hexRegex = /^[a-fA-F0-9]+$/;
     return hexRegex.test(hexPart);
   }


### PR DESCRIPTION
- Show validation errors immediately as user types instead of waiting until later (the error message for 0x happens at the end and if you add it and delete it, it'll let the transaction pass even without 0x)
- Add error message when address exceeds 42 characters
- Add error message when address doesn't start with 0x
- Properly disable send button when address/amount requirements not met

Before: 
<img width="413" height="445" alt="Screenshot 2025-09-10 at 9 58 38 PM" src="https://github.com/user-attachments/assets/a124e469-32fc-412c-bf1f-e08f982ba285" />

After: 
<img width="418" height="408" alt="Screenshot 2025-09-10 at 9 47 55 PM" src="https://github.com/user-attachments/assets/b199fbef-3f52-42a8-bf19-8693f84226c6" />
<img width="417" height="411" alt="Screenshot 2025-09-10 at 9 48 34 PM" src="https://github.com/user-attachments/assets/9eefd1b4-4358-4a34-9979-bf2fcc1af04d" />
<img width="416" height="431" alt="Screenshot 2025-09-10 at 9 49 44 PM" src="https://github.com/user-attachments/assets/06f47af6-9b42-4029-8bdd-faee44ee3629" />
<img width="412" height="432" alt="Screenshot 2025-09-10 at 9 50 22 PM" src="https://github.com/user-attachments/assets/c8c1615c-936e-46bd-931e-b61a8bc47f2d" />
<img width="418" height="445" alt="Screenshot 2025-09-10 at 10 09 23 PM" src="https://github.com/user-attachments/assets/b47e5d98-3854-486e-b791-c9366685393c" />



