### PR TITLE
fix (Mining): fixed broken links for downloading core-geth

### DIFF
--- a/src-tauri/src/geth_downloader.rs
+++ b/src-tauri/src/geth_downloader.rs
@@ -51,9 +51,9 @@ impl GethDownloader {
         // Core-Geth v1.12.20 URLs for different platforms
         let url = match (std::env::consts::OS, std::env::consts::ARCH) {
             ("macos", "aarch64") => "https://github.com/etclabscore/core-geth/releases/download/v1.12.20/core-geth-osx-v1.12.20.zip",            
-            ("macos", "x86_64") => "https://github.com/etclabscore/core-geth/releases/download/v1.12.20/core-geth-darwin-amd64-v1.12.20.tar.gz",
-            ("linux", "x86_64") => "https://github.com/etclabscore/core-geth/releases/download/v1.12.20/core-geth-linux-amd64-v1.12.20.tar.gz",
-            ("linux", "aarch64") => "https://github.com/etclabscore/core-geth/releases/download/v1.12.20/core-geth-linux-arm64-v1.12.20.tar.gz",
+            ("macos", "x86_64") => "https://github.com/etclabscore/core-geth/releases/download/v1.12.20/core-geth-win64-v1.12.20.zip",
+            ("linux", "x86_64") => "https://github.com/etclabscore/core-geth/releases/download/v1.12.20/core-geth-linux-v1.12.20.zip",
+            ("linux", "aarch64") => "https://github.com/etclabscore/core-geth/releases/download/v1.12.20/core-geth-arm64-v1.12.20.zip",
             ("windows", "x86_64") => "https://github.com/etclabscore/core-geth/releases/download/v1.12.20/core-geth-win64-v1.12.20.zip",
             _ => return Err(format!("Unsupported platform: {} {}", std::env::consts::OS, std::env::consts::ARCH)),
         };


### PR DESCRIPTION
Fixed issue where core-geth download wouldn't work because of invalid links for a Linux OS running on x86_64 architecture. I also fixed the links for Linux running on ARM64 architecture and MacOS running on x86_64 architecture.

Before:
<img width="971" height="279" alt="image" src="https://github.com/user-attachments/assets/6e91b69a-4993-4d07-b528-f9677a1ba616" />
After:
<img width="971" height="258" alt="image" src="https://github.com/user-attachments/assets/ea1d141f-30ab-44c1-af82-22f2e8842485" />
