### PR TITLE
fix(analytics): latency graph

### DIFF
--- a/src/pages/Analytics.svelte
+++ b/src/pages/Analytics.svelte
@@ -461,7 +461,7 @@ function computeLatencyStats() {
         <div
           role="button"
           tabindex="0"
-          class="flex-1 relative bg-gradient-to-t from-green-400/30 to-red-500/60 hover:from-green-500/60 hover:to-red-600/90 transition-all rounded-t shadow-sm"
+          class="flex-1 bg-gradient-to-t from-blue-400/40 to-blue-500/80 hover:from-blue-500/60 hover:to-blue-600/90 transition-all rounded-t-md shadow-sm relative"
           style="height: {(Math.min(p.latency, 300) / 300) * 100}%"
           aria-label="{p.date}: {p.latency.toFixed(0)} ms"
           on:mouseenter={() => { hoveredLatency = p; hoveredIndex = i; }}


### PR DESCRIPTION
- Added color, min & max latency summary below the chart for quick insights, and y-axis and gridlines for readability
- Implemented hover tooltip to display detailed latency values

**Before**
<img width="386" height="329" alt="Screenshot 2025-09-11 at 9 41 40 AM" src="https://github.com/user-attachments/assets/496c6faa-9ac1-43b5-ab92-26f0721a1952" />

**After:**
<img width="342" height="306" alt="Screenshot 2025-09-11 at 10 31 56 AM" src="https://github.com/user-attachments/assets/91998426-953b-47ab-98e8-cf8716091811" />
