### PR TITLE
Fix (Mining): Fixed dropdown component import

### DIFF
--- a/src/pages/Mining.svelte
+++ b/src/pages/Mining.svelte
@@ -5,7 +5,7 @@
   import Progress from '$lib/components/ui/progress.svelte'
   import Input from '$lib/components/ui/input.svelte'
   import Label from '$lib/components/ui/label.svelte'
-  import DropDown from "$lib/components/ui/Dropdown.svelte";
+  import DropDown from "$lib/components/ui/dropDown.svelte";
   import { Cpu, Zap, TrendingUp, Award, Play, Pause, Coins, Thermometer, AlertCircle, Terminal, X, RefreshCw } from 'lucide-svelte'
   import { onDestroy, onMount } from 'svelte'
   import { invoke } from '@tauri-apps/api/core'


### PR DESCRIPTION
The dropdown component import has a typo in the file name.

Before:
<img width="1062" height="587" alt="image" src="https://github.com/user-attachments/assets/77b62236-25dd-4c76-8cd4-065f11c4a1d7" />
After:
<img width="1250" height="778" alt="image" src="https://github.com/user-attachments/assets/30d397bf-b6dd-4485-a6a3-283c45db956b" />
