### PR TITLE
fix: update `.gitignore` to not include Tauri executables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,15 @@ lerna-debug.log*
 # Tauri
 src-tauri/target/
 src-tauri/WixTools/
+src-tauri/bin/
+
+# Tauri executables
+*.exe
+*.app
+*.dmg
+*.deb
+*.rpm
+*.AppImage
 
 # Testing
 coverage/


### PR DESCRIPTION
Build artifacts should be excluded from the repository, as they can be large files and we don't want students from different platforms each adding their platform-specific executables to the repository. In other words, this repository should contain everything needed to create the application, but not the final application itself.

Exclude:
- `src-tauri/bin/`
- Windows: `*.exe`
- macOS: `*.app`, `*.dmg`  
- Linux: `*.deb`, `*.rpm`, `*.AppImage`