### PR TITLE
fix: Add `geth-data` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ src-tauri/target/
 src-tauri/WixTools/
 src-tauri/bin/
 src-tauri/gen/schemas/
+src-tauri/geth-data/
 
 # Tauri executables
 *.exe


### PR DESCRIPTION
Similar to #105 and #106 , `src-tauri/geth-data/` has operational data created when `Geth` runs and should not be added to the repository.