### PR TITLE
Fix (Network): Fix automatic rebuild error on network page

### DIFF
--- a/src-tauri/.taurignore
+++ b/src-tauri/.taurignore
@@ -1,0 +1,4 @@
+icons/**
+gen/**
+geth-data/**
+capabilities/**


### PR DESCRIPTION
Before:
When running the project in desktop developer mode with an existing geth-data folder, the project would rebuild itself everytime a user clicked on the network page and started the node. This is because the backend watcher (Tauri) doesn't know to ignore any generated files in the `src/tauri` directory and rebuilds on any change in the directory.

https://github.com/user-attachments/assets/b3324f54-2d94-440f-8241-e869034ad437

After:
By adding a `.taurignore` file, the backend watcher knows which files to ignore, and the rebuild is avoided when clicking on the network page.