### PR TITLE
fix: auto-start toggle was ignored when off

### DIFF
--- a/src/pages/Download.svelte
+++ b/src/pages/Download.svelte
@@ -162,7 +162,9 @@
     }
     
     downloadQueue.update(q => [...q, newFile])
-    processQueue()
+    if (autoStartQueue) {
+      processQueue()
+    }
   }
 
   // Function to clear search
@@ -487,7 +489,17 @@ function clearSearch() {
             
             {#if file.status === 'downloading' || file.status === 'paused' || file.status === 'queued'}
               <div class="flex flex-wrap gap-2 mt-3">
-                {#if file.status !== 'queued'}
+                {#if file.status === 'queued'}
+                  <Button
+                    size="sm"
+                    variant="default"
+                    on:click={() => startQueuedDownload(file.id)}
+                    class="flex-1 min-w-[100px] sm:flex-none"
+                  >
+                    <Play class="h-3 w-3 mr-1" />
+                    Start Download
+                  </Button>
+                {:else}
                   <Button
                     size="sm"
                     variant="outline"


### PR DESCRIPTION
  - Downloads now respect the auto-start OFF setting instead of ignoring it
  - Add manual "Start Download" button for queued files when auto-start disabled
  - Users can control downloads individually instead of everything starting automatically

  **Before:** Auto-start OFF was ignored, files started downloading anyway

https://github.com/user-attachments/assets/0c17c34d-2133-4bb4-9189-d58fcbf4243f

  **After:** Auto-start OFF works correctly, shows manual "Start Download" button

https://github.com/user-attachments/assets/481ca0e8-08da-4973-83a3-7b3e4a1319fe


