### PR TITLE
fix: consistent file status UI - Download

### DIFF
--- a/src/pages/Download.svelte
+++ b/src/pages/Download.svelte
@@ -470,10 +470,13 @@ function clearSearch() {
                 <Badge class={
                   file.status === 'downloading' ? 'bg-green-500 text-white border-green-500' :
                   file.status === 'completed' ? 'bg-blue-500 text-white border-blue-500' :
-                  file.status === 'paused' ? 'bg-yellow-500 text-black border-yellow-500' :
-                  file.status === 'queued' ? 'bg-gray-500 text-white border-gray-500' : 'bg-red-500 text-white border-red-500'
-                }>
-                  {file.status === 'queued' ? `Queued #${filteredDownloads.filter(f => f.status === 'queued').indexOf(file) + 1}` : file.status}
+                  file.status === 'paused' ? 'bg-yellow-500 text-white border-yellow-500' :
+                  file.status === 'queued' ? 'bg-gray-500 text-white border-gray-500' :
+                  'bg-red-500 text-white border-red-500'
+                            }>
+                      {file.status === 'queued'
+                          ? `Queued #${filteredDownloads.filter(f => f.status === 'queued').indexOf(file) + 1}`
+                              : file.status}
                 </Badge>
               </div>
             </div>


### PR DESCRIPTION
The file status in the download section was looking inconsistent, hence I changed text colors to make it more consistent.
Before:
<img width="440" height="756" alt="image" src="https://github.com/user-attachments/assets/d6ace5c0-6920-4706-8ea7-71a8430fa235" />
After:
<img width="208" height="379" alt="image" src="https://github.com/user-attachments/assets/c8ce533c-fa25-40ae-b33d-42c7320fe857" />
