### PR TITLE
Recent blocks found will show when mining

### DIFF
--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -252,6 +252,15 @@ export const userLocation = writable<string>("US-East");
 export const etcAccount = writable<ETCAccount | null>(null);
 export const blacklist = writable<BlacklistEntry[]>(blacklistedPeers);
 
+interface RecentBlock {
+  id: string;
+  hash: string;
+  reward: number;
+  timestamp: Date;
+  difficulty: number;
+  nonce: number;
+}
+
 // Mining state
 export interface MiningState {
   isMining: boolean;
@@ -262,6 +271,7 @@ export interface MiningState {
   minerIntensity: number;
   selectedPool: string;
   sessionStartTime?: number; // Track mining session start time for persistence
+  recentBlocks?: RecentBlock[]; // Store recent blocks found
 }
 
 export const miningState = writable<MiningState>({
@@ -273,4 +283,5 @@ export const miningState = writable<MiningState>({
   minerIntensity: 50,
   selectedPool: "solo",
   sessionStartTime: undefined,
+  recentBlocks: [],
 });

--- a/src/pages/Mining.svelte
+++ b/src/pages/Mining.svelte
@@ -18,14 +18,14 @@
     power: number
   }
   
-  interface RecentBlock {
-    id: string
-    hash: string
-    reward: number
-    timestamp: Date
-    difficulty: number
-    nonce: number
-  }
+  // interface RecentBlock {
+  //   id: string
+  //   hash: string
+  //   reward: number
+  //   timestamp: Date
+  //   difficulty: number
+  //   nonce: number
+  // }
   
   // Local UI state only
   let isTauri = false
@@ -62,7 +62,7 @@
   
   // Mining history
   let miningHistory: MiningHistoryPoint[] = []
-  let recentBlocks: RecentBlock[] = []
+  // let recentBlocks: RecentBlock[] = []
   
   // Mock mining intervals  
   let statsInterval: number | null = null
@@ -408,14 +408,14 @@
     const reward = 5 + Math.random() * 2
     $miningState.totalRewards += reward
     
-    recentBlocks = [{
+    $miningState.recentBlocks = [{
       id: `block-${Date.now()}`,
       hash: `0x${Math.random().toString(16).substring(2, 10)}...${Math.random().toString(16).substring(2, 6)}`,
       reward: reward,
       timestamp: new Date(),
       difficulty: currentDifficulty,
       nonce: Math.floor(Math.random() * 1000000)
-    }, ...recentBlocks.slice(0, 4)]
+    }, ...($miningState.recentBlocks ?? []).slice(0, 4)]
   }
   
   function formatUptime(now: number = Date.now()) {
@@ -808,13 +808,13 @@
   <!-- Recent Blocks -->
   <Card class="p-6">
     <h2 class="text-lg font-semibold mb-4">Recent Blocks Found</h2>
-    {#if recentBlocks.length === 0}
+    {#if (!$miningState.recentBlocks || $miningState.recentBlocks.length === 0)}
       <p class="text-sm text-muted-foreground text-center py-8">
         No blocks found yet. Start mining to earn rewards!
       </p>
     {:else}
       <div class="space-y-2">
-        {#each recentBlocks as block}
+        {#each $miningState.recentBlocks ?? [] as block}
           <div class="flex items-center justify-between p-3 bg-secondary rounded-lg">
             <div class="flex items-center gap-3">
               <Award class="h-4 w-4 text-yellow-500" />

--- a/src/pages/Mining.svelte
+++ b/src/pages/Mining.svelte
@@ -189,11 +189,14 @@
             // Use actual hash rate from logs
             $miningState.hashRate = formatHashRate(hashRateFromLogs)
             if (blocksFound > $miningState.blocksFound) {
-              // Calculate rewards for new blocks found
-              const newBlocks = blocksFound - $miningState.blocksFound
-              const rewardPerBlock = 5.0 // Standard block reward for private network
-              $miningState.totalRewards += newBlocks * rewardPerBlock
-              $miningState.blocksFound = blocksFound
+              const newBlocks = blocksFound - $miningState.blocksFound;
+              const rewardPerBlock = 5.0;
+              $miningState.totalRewards += newBlocks * rewardPerBlock;
+              $miningState.blocksFound = blocksFound;
+              // Add each new block to recentBlocks
+              for (let i = 0; i < newBlocks; i++) {
+                findBlock();
+              }
             }
           } else if ($miningState.activeThreads > 0) {
             // Fall back to simulation if no log data yet
@@ -293,9 +296,13 @@
         
         // Update blocks mined from blockchain query
         if (results[4] !== undefined) {
-          const blocksMined = results[4] as number
+          const blocksMined = results[4] as number;
           if (blocksMined > $miningState.blocksFound) {
-            $miningState.blocksFound = blocksMined
+            const newBlocks = blocksMined - $miningState.blocksFound;
+            $miningState.blocksFound = blocksMined;
+            for (let i = 0; i < newBlocks; i++) {
+              findBlock();
+            }
           }
         }
       }


### PR DESCRIPTION
When mining, the blocks found wouldn't show up in the recent block history. 
BEFORE:
<img width="1242" height="812" alt="Screenshot 2025-09-12 at 6 56 30 PM" src="https://github.com/user-attachments/assets/da46f14c-dd28-47fa-a42c-bcb94b4e3e39" />
AFTER:
<img width="1433" height="818" alt="Screenshot 2025-09-12 at 7 00 28 PM" src="https://github.com/user-attachments/assets/b39c78a6-8fb1-4ed2-bd23-dede80462f3b" />
