### PR TITLE
fix (settings): changed the save changes and reset to defaults button

### DIFF
--- a/src/pages/Settings.svelte
+++ b/src/pages/Settings.svelte
@@ -679,25 +679,45 @@
 
   <!-- Action Buttons -->
   <div class="flex flex-wrap items-center justify-between gap-2">
-    <Button variant="outline" size="xs" on:click={openResetConfirm}>
-      Reset to Defaults
+  <Button 
+    variant="destructive" 
+    size="xs" 
+    on:click={openResetConfirm}
+  >
+    Reset to Defaults
+  </Button>
+
+  <div class="flex gap-2">
+    <Button
+      variant="outline"
+      size="xs"
+      on:click={() => (settings = { ...savedSettings })}
+      disabled={!hasChanges}
+      class={`transition-colors duration-200 ${
+        !hasChanges 
+          ? 'cursor-not-allowed opacity-50' 
+          : 'hover:bg-gray-200'
+      }`}
+    >
+      Cancel
     </Button>
 
-    <div class="flex gap-2">
-      <Button
-        variant="outline"
-        size="xs"
-        on:click={() => (settings = { ...savedSettings })}
-        disabled={!hasChanges}
-      >
-        Cancel
-      </Button>
-      <Button size="xs" on:click={saveSettings} disabled={!hasChanges || !isValid}>
-        <Save class="h-4 w-4 mr-2" />
-        Save Settings
-      </Button>
-    </div>
+    <Button
+      size="xs"
+      on:click={saveSettings}
+      disabled={!hasChanges || !isValid}
+      class={`transition-colors duration-200 ${
+        !hasChanges || !isValid
+          ? 'cursor-not-allowed opacity-50 pointer-events-none'
+          : 'bg-green-500 text-white hover:bg-green-600'
+      }`}
+    >
+      <Save class="h-4 w-4 mr-2" />
+      Save Settings
+    </Button>
   </div>
+</div>
+
 </div>
 {#if showResetConfirmModal}
   <div


### PR DESCRIPTION
Fix so that Save Changes button is only enabled/ green when the settings are truly changed, and made the Reset to Defaults button red

before:
<img width="1559" height="86" alt="Screenshot 2025-09-12 210639" src="https://github.com/user-attachments/assets/e362214e-c1e7-4077-bc89-f8a11471e0a7" />

after:
<img width="1573" height="79" alt="Screenshot 2025-09-12 210710" src="https://github.com/user-attachments/assets/bd8b2a98-c1a6-4e97-9ba9-9e0789e92669" />
