### PR TITLE
fix (Download): Added a cancel section and keeping cancelled tasks

### DIFF
--- a/src/pages/Download.svelte
+++ b/src/pages/Download.svelte
@@ -29,9 +29,11 @@
       'completed': 2,
       'queued': 3,
       'failed': 4,
-      'uploaded': 5,
-      'seeding': 6
+      'canceled': 5,
+      'uploaded': 6,
+      'seeding': 7
     }
+
 
     return combined.sort((a, b) => {
       const statusA = statusOrder[a.status] ?? 999
@@ -62,19 +64,22 @@
 
     // Then apply status filter
     switch (filterStatus) {
-      case 'active':
-        return filtered.filter(f => f.status === 'downloading')
-      case 'paused':
-        return filtered.filter(f => f.status === 'paused')
-      case 'queued':
-        return filtered.filter(f => f.status === 'queued')
-      case 'completed':
-        return filtered.filter(f => f.status === 'completed')
-      case 'failed':
-        return filtered.filter(f => f.status === 'failed')
-      default:
-        return filtered
-    }
+  case 'active':
+    return filtered.filter(f => f.status === 'downloading')
+  case 'paused':
+    return filtered.filter(f => f.status === 'paused')
+  case 'queued':
+    return filtered.filter(f => f.status === 'queued')
+  case 'completed':
+    return filtered.filter(f => f.status === 'completed')
+  case 'failed':
+    return filtered.filter(f => f.status === 'failed')
+  case 'canceled':
+    return filtered.filter(f => f.status === 'canceled')
+  default:
+    return filtered
+}
+
   })()
   
   // Calculate counts from the filtered set (excluding uploaded/seeding)
@@ -183,11 +188,15 @@ function clearSearch() {
   }
   
   function cancelDownload(fileId: string) {
-    files.update(f => f.filter(file => file.id !== fileId))
-    downloadQueue.update(q => q.filter(file => file.id !== fileId))
-    // Clean up simulation tracking
-    activeSimulations.delete(fileId)
-  }
+  files.update(f => f.map(file => 
+    file.id === fileId 
+      ? { ...file, status: 'canceled' }
+      : file
+  ))
+  downloadQueue.update(q => q.filter(file => file.id !== fileId))
+  activeSimulations.delete(fileId)
+}
+
   
   function startQueuedDownload(fileId: string) {
     downloadQueue.update(queue => {
@@ -364,6 +373,16 @@ function clearSearch() {
           >
             Queued ({queuedCount})
           </Button>
+
+          <Button
+            size="sm"
+            variant={filterStatus === 'canceled' ? 'default' : 'outline'}
+            on:click={() => filterStatus = 'canceled'}
+            >
+            Canceled ({allFilteredDownloads.filter(f => f.status === 'canceled').length})
+          </Button>
+
+
           <Button
             size="sm"
             variant={filterStatus === 'failed' ? 'default' : 'outline'}
@@ -474,7 +493,9 @@ function clearSearch() {
                   file.status === 'downloading' ? 'bg-green-500 text-white border-green-500' :
                   file.status === 'completed' ? 'bg-blue-500 text-white border-blue-500' :
                   file.status === 'paused' ? 'bg-yellow-500 text-black border-yellow-500' :
-                  file.status === 'queued' ? 'bg-gray-500 text-white border-gray-500' : 'bg-red-500 text-white border-red-500'
+                  file.status === 'queued' ? 'bg-gray-500 text-white border-gray-500' :
+                  file.status === 'canceled' ? 'bg-gray-700 text-white border-gray-700' :
+                  'bg-red-500 text-white border-red-500'
                 }>
                   {file.status === 'queued' ? `Queued #${$downloadQueue.indexOf(file) + 1}` : file.status}
                 </Badge>


### PR DESCRIPTION
Added a Cancelled section to see previously cancelled tasks, and keeping them in the All section (previous code discarded it).

before:
<img width="1547" height="808" alt="Screenshot 2025-09-12 222149" src="https://github.com/user-attachments/assets/d191d30b-424c-4cc9-8bdc-07f900ba9738" />

after:
<img width="1523" height="680" alt="Screenshot 2025-09-12 222230" src="https://github.com/user-attachments/assets/73a103c0-b7a7-423b-8cc3-798a8bafeb32" />
