### PR TITLE
Feat/dht kademlia events

### DIFF
--- a/src-tauri/src/bin/dht_smoke.rs
+++ b/src-tauri/src/bin/dht_smoke.rs
@@ -1,0 +1,82 @@
+//AI built test file for DHT smoke test
+
+
+#[path = "../dht.rs"]
+mod dht;
+use dht::{DhtService, FileMetadata, DhtEvent};
+use std::time::Duration;
+use tokio::time::sleep;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Simple logger
+    tracing_subscriber::fmt()
+        .with_env_filter("info")
+        .init();
+
+    // Use high ports unlikely to be occupied
+    let port_a: u16 = 4101;
+    let port_b: u16 = 4102;
+
+    // Start node A without bootstrap
+    let a = DhtService::new(port_a, vec![]).await?;
+    let a_peer = a.get_peer_id().await;
+    a.run().await;
+
+    // Start node B with A as bootstrap
+    let bootstrap = format!("/ip4/127.0.0.1/tcp/{}/p2p/{}", port_a, a_peer);
+    let b = DhtService::new(port_b, vec![bootstrap.clone()]).await?;
+    b.run().await;
+
+    // Give time for listeners to bind
+    sleep(Duration::from_millis(500)).await;
+
+    // Explicitly connect B to A
+    b.connect_peer(bootstrap.clone()).await?;
+    sleep(Duration::from_secs(1)).await;
+
+    // Publish a record on A
+    let file_hash = "QmSmokeTest123".to_string();
+    let meta = FileMetadata {
+        file_hash: file_hash.clone(),
+        file_name: "smoke.txt".to_string(),
+        file_size: 1234,
+        seeders: vec![a_peer.clone()],
+        created_at: std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)?
+            .as_secs(),
+        mime_type: Some("text/plain".to_string()),
+    };
+    a.publish_file(meta).await?;
+
+    // Search from B
+    b.search_file(file_hash.clone()).await?;
+
+    // Await discovery event on B for up to ~8 seconds
+    let mut found = false;
+    for _ in 0..40 { // 40 * 200ms = 8s
+        let events = b.drain_events(100).await;
+        for ev in events {
+            match ev {
+                DhtEvent::FileDiscovered(m) if m.file_hash == file_hash => {
+                    println!("OK: discovered {} ({} bytes)", m.file_name, m.file_size);
+                    found = true;
+                    break;
+                }
+                DhtEvent::Error(e) => {
+                    eprintln!("WARN: {}", e);
+                }
+                _ => {}
+            }
+        }
+        if found { break; }
+        sleep(Duration::from_millis(200)).await;
+    }
+
+    if !found {
+        eprintln!("FAIL: did not discover file via DHT in time");
+        std::process::exit(1);
+    }
+
+    Ok(())
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -17,7 +17,7 @@ use ethereum::{
 };
 use keystore::Keystore;
 use geth_downloader::GethDownloader;
-use dht::{DhtService, FileMetadata};
+use dht::{DhtService, FileMetadata, DhtEvent};
 use sysinfo::{Components, System, MINIMUM_CPU_UPDATE_INTERVAL};
 use systemstat::{Platform, System as SystemStat};
 use std::{sync::{Arc, Mutex}, time::Instant};
@@ -386,9 +386,32 @@ async fn get_dht_peer_id(state: State<'_, AppState>) -> Result<Option<String>, S
 }
 
 #[tauri::command]
-async fn get_dht_events(_state: State<'_, AppState>) -> Result<Vec<String>, String> {
-    // Simplified version returns empty events for now
-    Ok(vec![])
+async fn get_dht_events(state: State<'_, AppState>) -> Result<Vec<String>, String> {
+    let dht = {
+        let dht_guard = state.dht.lock().map_err(|e| e.to_string())?;
+        dht_guard.as_ref().cloned()
+    };
+
+    if let Some(dht) = dht {
+        let events = dht.drain_events(100).await;
+        // Convert events to concise human-readable strings for the UI
+        let mapped: Vec<String> = events.into_iter().map(|e| match e {
+            DhtEvent::PeerDiscovered(p) => format!("peer_discovered:{}", p),
+            DhtEvent::PeerConnected(p) => format!("peer_connected:{}", p),
+            DhtEvent::PeerDisconnected(p) => format!("peer_disconnected:{}", p),
+            DhtEvent::FileDiscovered(meta) => format!(
+                "file_discovered:{}:{}:{}",
+                meta.file_hash,
+                meta.file_name,
+                meta.file_size
+            ),
+            DhtEvent::FileNotFound(hash) => format!("file_not_found:{}", hash),
+            DhtEvent::Error(err) => format!("error:{}", err),
+        }).collect();
+        Ok(mapped)
+    } else {
+        Ok(vec![])
+    }
 }
 
 #[tauri::command]


### PR DESCRIPTION
Kademlia tuning: Set server mode, 10s query timeout, replication factor 20.
Discovery: Added mDNS and Identify; discovered peers added to Kademlia routing table.
Records: Implemented publish/search of file metadata via Kademlia put/get with JSON serialization.
Events: Handle Get/Put results; emit FileDiscovered/FileNotFound/Error and peer events.
UI bridge: Added non‑blocking event drain and Tauri command get_dht_events returning concise event strings.
Connectivity: Dial bootstrap peers, periodic Kademlia bootstrap, 5‑minute idle keepalive retained.