### PR TITLE
fix (account): popup message for clearing all blacklisted messages

### DIFF
--- a/src/pages/Account.svelte
+++ b/src/pages/Account.svelte
@@ -661,9 +661,10 @@
   }
 
   function clearAllBlacklist() {
-    if (confirm(tr('blacklist.confirm.removeAll', { count: $blacklist.length }))) {
-      blacklist.set([]);
-      blacklistSearch = '';
+    const count = $blacklist.length;
+    if (window.confirm(`Remove all ${count} blacklisted addresses?`)) {
+        blacklist.set([]);
+        blacklistSearch = '';
     }
   }
 


### PR DESCRIPTION
I fixed the pop message for clearing all of the blacklisted addresses. 

Before: 
<img width="425" height="124" alt="image" src="https://github.com/user-attachments/assets/3e1f992d-9962-41a2-acb3-216633b6905a" />

After: 
<img width="441" height="133" alt="image" src="https://github.com/user-attachments/assets/2420537c-feb6-4890-bb2f-7f433e1ae3a8" />

