### PR TITLE
Fix: Add default binary to `cargo.toml`

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Chiral Network Team"]
 license = "MIT"
 repository = ""
 edition = "2021"
+default-run = "chiral-network"
 
 [build-dependencies]
 tauri-build = { version = "2.0", features = [] }


### PR DESCRIPTION
Before:
With the new addition of the dht_smoke binary, there are now two binaries that cargo can execute: `chiral-network` and `dht_smoke`, which gives us an error because cargo doesn't know which one to choose. The solution is to define a default binary in `cargo.toml` that cargo can fall back to.
<img width="810" height="499" alt="image" src="https://github.com/user-attachments/assets/57e46b96-9941-49df-9c63-02a1950c78bc" />
After:
Project runs successfully