### PR TITLE
fix(login) keystore account list render issue fix

### DIFF
--- a/src/pages/Account.svelte
+++ b/src/pages/Account.svelte
@@ -854,6 +854,7 @@
 
   function logout() {
     // Clear the account details from memory, effectively logging out
+    loadKeystoreAccountsList()
     etcAccount.set(null);
 
     // Reset wallet state to defaults


### PR DESCRIPTION
After saving your key to the keystore with a password, there was a minor issue. After locking your wallet, the keystore account list would not update immediately without a page switch/account creation/application restart. Now the list is updated immediately with a minor change.

<img width="1000" height="435" alt="image" src="https://github.com/user-attachments/assets/f3bcef6a-3650-4265-8ffb-3c68538b2207" />
