### PR TITLE
feat(settings): Add feedback for import/export actions

### DIFF
--- a/src/pages/Settings.svelte
+++ b/src/pages/Settings.svelte
@@ -71,6 +71,7 @@
   let selectedLanguage = 'en';
   let clearingCache = false;
   let cacheCleared = false;
+  let importExportFeedback: { message: string; type: 'success' | 'error' } | null = null;
 
   const locations = [
     { value: 'US-East', label: 'US East' },
@@ -88,6 +89,7 @@
     localStorage.setItem("chiralSettings", JSON.stringify(settings));
     savedSettings = { ...settings };
     userLocation.set(settings.userLocation);
+    importExportFeedback = null;
   }
 
   function handleConfirmReset() {
@@ -165,6 +167,10 @@
     a.download = "chiral-settings.json";
     a.click();
     URL.revokeObjectURL(url);
+    importExportFeedback = {
+      message: $t('advanced.exportSuccess', { default: "Settings exported to your browser's download folder." }),
+      type: 'success'
+    };
   }
 
   function importSettings(event: Event) {
@@ -176,12 +182,18 @@
       try {
         const imported = JSON.parse(e.target?.result as string);
         settings = { ...settings, ...imported };
-        saveSettings();
-        localStorage.setItem("chiralSettings", JSON.stringify(settings));
-        hasChanges = false;
+        saveSettings(); // This saves, updates savedSettings, and clears any old feedback.
+        // Now we set the new feedback for the import action.
+        importExportFeedback = {
+          message: $t('advanced.importSuccess', { default: 'Settings imported successfully.' }),
+          type: 'success'
+        };
       } catch (err) {
         console.error("Failed to import settings:", err);
-        alert("Invalid JSON file. Please select a valid export.");
+        importExportFeedback = {
+          message: $t('advanced.importError', { default: 'Invalid JSON file. Please select a valid export.' }),
+          type: 'error'
+        };
       }
     };
     reader.readAsText(file);
@@ -694,6 +706,12 @@
           />
         </label>
       </div>
+
+      {#if importExportFeedback}
+        <div class="mt-4 p-3 rounded-md text-sm {importExportFeedback.type === 'success' ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'}">
+          {importExportFeedback.message}
+        </div>
+      {/if}
     </div>
   </Card>
 


### PR DESCRIPTION
Implemented a user feedback mechanism for the settings import and export functionality to improve user experience.

- Added a persistent notification message that appears upon successful export or import, or on import failure.
- The message informs the user of the action's outcome (e.g., "Settings exported to your browser's download folder" or "Invalid JSON file").
- This feedback remains visible until the user saves the settings again or navigates away from the page, ensuring they have time to read it.
<img width="2934" height="1227" alt="image" src="https://github.com/user-attachments/assets/b0d56de0-0d38-48e3-8513-f9dc490d3b13" />


