### PR TITLE
ui (analytics): made all of the headers consistent

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -400,7 +400,7 @@
     "latencyHint": "0–50 ms (great), 50–150 ms (ok), >150 ms (poor)",
     "nodesReporting": "Nodes Reporting",
     "sampleSize": "Sample Size",
-    "latencyRecent": "Latency (recent)",
+    "latencyRecent": "Latency (Recent)",
     "topEarningFiles": "Top Earning Files",
     "seeders": "seeders",
     "noEarningsYet": "No earnings yet",

--- a/src/pages/Analytics.svelte
+++ b/src/pages/Analytics.svelte
@@ -460,7 +460,7 @@
     </Card>
 
     <Card class="p-6">
-      <h3 class="text-md font-medium mb-4">{$t('analytics.latencyRecent')}</h3>
+      <h3 class="text-lg font-semibold mb-4">{$t('analytics.latencyRecent')}</h3> 
       <div class="flex h-48 gap-2">
         <!-- Y-axis labels -->
         <div class="flex flex-col justify-between text-xs text-muted-foreground pr-2">


### PR DESCRIPTION
I made the "latency (recent)" header consistent with all the other headers. 

Before: 
<img width="2438" height="704" alt="image" src="https://github.com/user-attachments/assets/b892431b-db91-40b5-ba5b-9dd1de47b81d" />

After: 
<img width="996" height="352" alt="image" src="https://github.com/user-attachments/assets/db92b32a-e214-4e37-90d6-b5e9086a5a13" />