### PR TITLE
feat(network): Added more user feedback when disconnected from the DHT Node

### DIFF
--- a/src/pages/Network.svelte
+++ b/src/pages/Network.svelte
@@ -12,6 +12,7 @@
   import { dhtService, DEFAULT_BOOTSTRAP_NODE } from '$lib/dht'
   import { Clipboard } from "lucide-svelte"
   import { t } from 'svelte-i18n';
+  import { showToast } from '$lib/toast';
 
   // Check if running in Tauri environment
   const isTauri = typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window
@@ -285,6 +286,10 @@
   }
 
   function runDiscovery() {
+    if (dhtStatus !== 'connected') {
+      showToast($t('network.errors.dhtNotConnected'), 'error');
+      return;
+    }
     discoveryRunning = true
     
     // Simulate discovering new peers

--- a/src/pages/Network.svelte
+++ b/src/pages/Network.svelte
@@ -836,8 +836,8 @@
         </div>
         <div>
           <p class="text-sm text-muted-foreground">{$t('network.bandwidth')}</p>
-          <p class="text-sm font-bold">↓ {$networkStats.avgDownloadSpeed.toFixed(1)} MB/s</p>
-          <p class="text-sm font-bold">↑ {$networkStats.avgUploadSpeed.toFixed(1)} MB/s</p>
+          <p class="text-sm font-bold">↓ {dhtStatus === 'connected' ? $networkStats.avgDownloadSpeed.toFixed(1) : '0.0'} MB/s</p>
+          <p class="text-sm font-bold">↑ {dhtStatus === 'connected' ? $networkStats.avgUploadSpeed.toFixed(1) : '0.0'} MB/s</p>
         </div>
       </div>
     </Card>


### PR DESCRIPTION
Set bandwidth to 0 if disconnected from the DHT Node. Added an error message to Run Discovery if disconnected from the DHT Node.
<img width="999" height="551" alt="Network page before" src="https://github.com/user-attachments/assets/83a0dab9-c2e3-4f87-8cf2-dee5a9639030" />
<img width="992" height="539" alt="Bandwidth 0" src="https://github.com/user-attachments/assets/7278e98e-8dd3-4891-b26c-af4a26130cb3" />
<img width="1009" height="389" alt="Network Error" src="https://github.com/user-attachments/assets/cddf315b-93c3-4de9-a094-6390f5349b3c" />
