### PR TITLE
fix: fix backend directory issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,12 +39,7 @@ lerna-debug.log*
 # Tauri
 src-tauri/target/
 src-tauri/WixTools/
-src-tauri/bin/
-src-tauri/gen/schemas/
-src-tauri/geth-data/
-
-# Downloaded binaries
-bin/
+src-tauri/gen/
 
 # Tauri executables
 *.exe

--- a/src-tauri/src/geth_downloader.rs
+++ b/src-tauri/src/geth_downloader.rs
@@ -16,24 +16,12 @@ pub struct GethDownloader {
 
 impl GethDownloader {
     pub fn new() -> Self {
-        let base_dir = if cfg!(debug_assertions) {
-            // In development, use the project root directory
-            PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-                .parent()
-                .unwrap()
-                .to_path_buf()
-        } else {
-            // In production, the app bundle structure may differ
-            std::env::current_exe()
-                .unwrap()
-                .parent()
-                .unwrap()
-                .parent()
-                .unwrap()
-                .parent()
-                .unwrap()
-                .to_path_buf()
-        };
+        // Use executable's directory for both dev and prod - bin/ lives next to the exe
+        let base_dir = std::env::current_exe()
+            .unwrap()
+            .parent()
+            .unwrap()
+            .to_path_buf();
 
         GethDownloader { base_dir }
     }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "productName": "Chiral Network",
   "version": "0.1.0",
-  "identifier": "com.chiralnetwork.app",
+  "identifier": "com.chiralnetwork",
   "build": {
     "beforeDevCommand": "npm run dev",
     "beforeBuildCommand": "npm run build",
@@ -27,7 +27,7 @@
   },
   "bundle": {
     "active": true,
-    "category": "Network",
+    "category": "Utilities",
     "copyright": "",
     "linux": {
       "appimage": {

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -53,9 +53,9 @@ if [ -f "src-tauri/tauri.conf.json" ]; then
     cp "src-tauri/tauri.conf.json" "$BACKUP_DIR/"
 fi
 
-if [ -d "bin/geth-data" ]; then
+if [ -d "src-tauri/bin/geth-data" ]; then
     echo "  • Backing up geth data (this may take a moment)..."
-    cp -r "bin/geth-data" "$BACKUP_DIR/" 2>/dev/null || true
+    cp -r "src-tauri/bin/geth-data" "$BACKUP_DIR/" 2>/dev/null || true
 fi
 
 echo -e "${GREEN}Step 3: Cleaning build artifacts...${NC}"


### PR DESCRIPTION
Previously, `bin/` was present in both the root directory as well as `src-tauri/`. The `bin/` directory is now `src-tauri/target/debug/bin/` in dev and `src-tauri/target/release/bin/` in build. The relative `geth-data/` directory location (it should be `bin/geth-data/`) and the `geth` executable location (it should be `bin/geth-exe` or similar for other platforms) are also moved accordingly.