### PR TITLE
fix(language): internationalize missing contents in the settings page

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -433,7 +433,13 @@
     "min": "Min:",
     "max": "Max:",
     "suspiciousActivity": "Suspicious Activity Alerts",
-    "noSuspiciousActivity": "No suspicious activity detected"
+    "noSuspiciousActivity": "No suspicious activity detected",
+    "unusualUpload": "Unusual Upload",
+    "unusualUploadDesc": "File > 1GB uploaded unusually fast",
+    "multipleLogins": "Multiple Logins",
+    "multipleLoginsDesc": "User logged in from different countries in 5 mins",
+    "failedDownloads": "Failed Downloads",
+    "failedDownloadsDesc": "Several failed download attempts detected"
   },
   "proxy": {
     "title": "Proxy Network",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -441,7 +441,13 @@
     "min": "최소:",
     "max": "최대:",
     "suspiciousActivity": "의심스러운 활동 알림",
-    "noSuspiciousActivity": "의심스러운 활동이 감지되지 않았습니다"
+    "noSuspiciousActivity": "의심스러운 활동이 감지되지 않았습니다",
+    "unusualUpload": "비정상적인 업로드",
+    "unusualUploadDesc": "1GB 이상의 파일이 비정상적으로 빠르게 업로드되었습니다",
+    "multipleLogins": "다중 로그인",
+    "multipleLoginsDesc": "5분 이내에 다른 국가에서 로그인했습니다",
+    "failedDownloads": "실패한 다운로드",
+    "failedDownloadsDesc": "여러 번의 실패한 다운로드 시도가 감지되었습니다"
   },
   "proxy": {
     "title": "프록시 네트워크",

--- a/src/pages/Analytics.svelte
+++ b/src/pages/Analytics.svelte
@@ -781,7 +781,7 @@
   </Card>
 
   <Card class="p-6">
-  <h2 class="text-lg font-semibold mb-4">Suspicious Activity Alerts</h2>
+  <h2 class="text-lg font-semibold mb-4">{$t('analytics.suspiciousActivity')}</h2>
   {#if $suspiciousActivity.length > 0}
     <div class="space-y-2">
       {#each $suspiciousActivity as alert}
@@ -804,7 +804,7 @@
       {/each}
     </div>
   {:else}
-    <p class="text-sm text-muted-foreground text-center py-4">No suspicious activity detected</p>
+    <p class="text-sm text-muted-foreground text-center py-4">{$t('analytics.noSuspiciousActivity')}</p>
   {/if}
 </Card>
 


### PR DESCRIPTION
Internationalized missing contents in the settings page
**Before**
<img width="500" height="500" alt="before" src="https://github.com/user-attachments/assets/0aed15dc-d6d6-4dd4-ba75-c5c273995036" />
**After**
<img width="500" height="500" alt="after" src="https://github.com/user-attachments/assets/251511c3-25d8-4e05-8be3-1e332cc38358" />
