### PR TITLE
 polished confirmation log info

### DIFF
--- a/src/pages/Proxy.svelte
+++ b/src/pages/Proxy.svelte
@@ -95,19 +95,17 @@
 {#if showConfirmDialog && nodeToRemove}
   <div class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
     <div class="bg-white rounded-lg p-6 max-w-md w-full mx-4">
-      <h3 class="text-lg font-semibold mb-4">{$t('proxy.confirmRemove') || 'Confirm Removal'}</h3>
+      <h3 class="text-lg font-semibold mb-4">Confirm Removal</h3>
       <p class="text-muted-foreground mb-6">
-        {$t('proxy.confirmRemoveMessage') || 'Are you sure you want to remove the proxy node'} 
-        <span class="font-medium">{nodeToRemove.address}</span>?
-        {$t('proxy.confirmRemoveWarning') || 'This action cannot be undone.'}
+        Confirm the removal of proxy node <span class="font-medium">{nodeToRemove.address}</span>
       </p>
       <div class="flex gap-3 justify-end">
         <Button variant="outline" on:click={cancelRemoveNode}>
-          {$t('proxy.cancel') || 'Cancel'}
+          Cancel
         </Button>
         <Button variant="destructive" on:click={confirmRemoveNode}>
           <Trash2 class="h-4 w-4 mr-2" />
-          {$t('proxy.remove') || 'Remove'}
+          Remove
         </Button>
       </div>
     </div>


### PR DESCRIPTION
Polished confirmation information
before:
<img width="1154" height="616" alt="Screenshot 2025-09-15 at 4 36 10 PM" src="https://github.com/user-attachments/assets/d33bae91-e45b-480b-b4dc-80e27efce382" />
after:
<img width="1184" height="653" alt="Screenshot 2025-09-15 at 5 44 58 PM" src="https://github.com/user-attachments/assets/60460694-4e5b-42c2-b120-c46ef0798e9f" />
