### PR TITLE
 Adding the file hash check for shared files at Download file page an…

### DIFF
--- a/src/pages/Download.svelte
+++ b/src/pages/Download.svelte
@@ -253,12 +253,33 @@
       return
     }
     
-    // Check for duplicates
-    const exists = [...$files, ...$downloadQueue].some(f => f.hash === searchHash)
-    if (exists) {
-      showNotification(tr('download.notifications.alreadyExists'), 'warning')
+    // Check for ALL duplicates (including uploaded files)
+const allFiles = [...$files, ...$downloadQueue]
+const existingFile = allFiles.find(f => f.hash === searchHash)
+
+if (existingFile) {
+  // Handle different scenarios
+  if (existingFile.status === 'seeding' || existingFile.status === 'uploaded') {
+    // User is trying to download a file they're already sharing
+    const shouldContinue = confirm(
+      `You're already sharing a file with this hash (${existingFile.name}). ` +
+      `Do you want to download it anyway? `
+    )
+    
+    if (!shouldContinue) {
+      showNotification('Download canceled by user', 'info')
       return
     }
+    
+    // Show additional info message
+    showNotification('Downloading file that you are already sharing', 'warning', 3000)
+    
+  } else {
+    // File is already in download queue/completed/etc.
+    showNotification('File is already in your download list', 'warning')
+    return
+  }
+}
     
     try {
       // Step 1: Show search start notification


### PR DESCRIPTION
… would allow for a shared file to download in case the user deleted the original copy
before:
When we enter the shared file hash into 'Add New Download', it prompts the file in the download list. However, when we search for it, it's not in the list.
<img width="1174" height="470" alt="Screenshot 2025-09-15 at 5 59 14 PM" src="https://github.com/user-attachments/assets/c8a1a3f8-ceb1-4727-81ca-eccfb1147c8b" />
after: 
Inform the user that this hash corresponds to the file you shared, and confirm whether they want to download it, as they are the ones who uploaded the file.
<img width="1463" height="771" alt="Screenshot 2025-09-15 at 6 19 14 PM" src="https://github.com/user-attachments/assets/d2263a0e-dc0e-4950-b4e9-5f05ee7f8839" />
