### PR TITLE
feat: Enhance DHT Bootstrap Configuration and Terminology

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -220,6 +220,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "asn1_der"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "155a5a185e42c6b77ac7b88a15143d930a9e9727a5b7b77eed417404ab15c247"
+
+[[package]]
 name = "async-attributes"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3152,12 +3158,14 @@ version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3104e13b51e4711ff5738caa1fb54467c8604c2e94d607e27745bcf709068774"
 dependencies = [
+ "asn1_der",
  "bs58",
  "ed25519-dalek",
  "hkdf",
  "multihash",
  "quick-protobuf",
  "rand 0.8.5",
+ "ring 0.17.14",
  "sha2",
  "thiserror 2.0.16",
  "tracing",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -40,7 +40,7 @@ futures-util = "0.3"
 systemstat = "0.2.5"
 sysinfo = "0.31"
 sys-locale = "0.3"
-libp2p = { version = "0.54", features = ["kad", "mdns", "noise", "tcp", "yamux", "identify", "gossipsub", "macros", "tokio"] }
+libp2p = { version = "0.54", features = ["kad", "mdns", "noise", "tcp", "yamux", "identify", "gossipsub", "macros", "tokio", "rsa"] }
 async-std = { version = "1.12", features = ["attributes"] }
 async-trait = "0.1"
 tracing = "0.1"

--- a/src-tauri/src/dht.rs
+++ b/src-tauri/src/dht.rs
@@ -181,9 +181,9 @@ async fn run_dht_node(
                             if error.to_string().contains("rsa") {
                                 error!("   ℹ Hint: This node uses RSA keys. Enable 'rsa' feature if needed.");
                             } else if error.to_string().contains("Timeout") {
-                                warn!("   ℹ Hint: Bootstrap node may be unreachable or overloaded.");
+                                warn!("   ℹ Hint: Bootstrap nodes may be unreachable or overloaded.");
                             } else if error.to_string().contains("Connection refused") {
-                                warn!("   ℹ Hint: Bootstrap node is not accepting connections.");
+                                warn!("   ℹ Hint: Bootstrap nodes are not accepting connections.");
                             } else if error.to_string().contains("Transport") {
                                 warn!("   ℹ Hint: Transport protocol negotiation failed.");
                             }
@@ -355,7 +355,7 @@ impl DhtService {
                     Ok(_) => {
                         info!("✓ Initiated connection to bootstrap: {}", bootstrap_addr);
                         successful_connections += 1;
-                        // Add bootstrap node to Kademlia routing table if it has a peer ID
+                        // Add bootstrap nodes to Kademlia routing table if it has a peer ID
                         if let Some(peer_id) = addr.iter().find_map(|p| {
                             if let libp2p::multiaddr::Protocol::P2p(peer) = p {
                                 Some(peer)

--- a/src-tauri/src/dht.rs
+++ b/src-tauri/src/dht.rs
@@ -175,7 +175,21 @@ async fn run_dht_node(
                         info!("📡 Now listening on: {}", address);
                     }
                     SwarmEvent::OutgoingConnectionError { peer_id, error, .. } => {
-                        error!("❌ Outgoing connection error to {:?}: {}", peer_id, error);
+                        if let Some(peer_id) = peer_id {
+                            error!("❌ Outgoing connection error to {}: {}", peer_id, error);
+                            // Check if this is a bootstrap connection error
+                            if error.to_string().contains("rsa") {
+                                error!("   ℹ Hint: This node uses RSA keys. Enable 'rsa' feature if needed.");
+                            } else if error.to_string().contains("Timeout") {
+                                warn!("   ℹ Hint: Bootstrap node may be unreachable or overloaded.");
+                            } else if error.to_string().contains("Connection refused") {
+                                warn!("   ℹ Hint: Bootstrap node is not accepting connections.");
+                            } else if error.to_string().contains("Transport") {
+                                warn!("   ℹ Hint: Transport protocol negotiation failed.");
+                            }
+                        } else {
+                            error!("❌ Outgoing connection error to unknown peer: {}", error);
+                        }
                         let _ = event_tx.send(DhtEvent::Error(format!("Connection failed: {}", error))).await;
                     }
                     SwarmEvent::IncomingConnectionError { error, .. } => {
@@ -332,12 +346,15 @@ impl DhtService {
         
         // Connect to bootstrap nodes
         info!("Bootstrap nodes to connect: {:?}", bootstrap_nodes);
+        let mut successful_connections = 0;
+        let total_bootstrap_nodes = bootstrap_nodes.len();
         for bootstrap_addr in &bootstrap_nodes {
             info!("Attempting to connect to bootstrap: {}", bootstrap_addr);
             if let Ok(addr) = bootstrap_addr.parse::<Multiaddr>() {
                 match swarm.dial(addr.clone()) {
                     Ok(_) => {
                         info!("✓ Initiated connection to bootstrap: {}", bootstrap_addr);
+                        successful_connections += 1;
                         // Add bootstrap node to Kademlia routing table if it has a peer ID
                         if let Some(peer_id) = addr.iter().find_map(|p| {
                             if let libp2p::multiaddr::Protocol::P2p(peer) = p {
@@ -356,10 +373,16 @@ impl DhtService {
             }
         }
         
-        // Trigger initial bootstrap if we have bootstrap nodes
+        // Trigger initial bootstrap if we have any bootstrap nodes (even if connection failed)
         if !bootstrap_nodes.is_empty() {
             let _ = swarm.behaviour_mut().kademlia.bootstrap();
-            info!("Triggered initial Kademlia bootstrap");
+            info!("Triggered initial Kademlia bootstrap (attempted {}/{} connections)", successful_connections, total_bootstrap_nodes);
+            if successful_connections == 0 {
+                warn!("⚠ No bootstrap connections succeeded - node will operate in standalone mode");
+                warn!("  Other nodes can still connect to this node directly");
+            }
+        } else {
+            info!("No bootstrap nodes provided - starting in standalone mode");
         }
         
         let (cmd_tx, cmd_rx) = mpsc::channel(100);

--- a/src-tauri/src/headless.rs
+++ b/src-tauri/src/headless.rs
@@ -17,7 +17,7 @@ pub struct CliArgs {
     #[arg(long, default_value = "4001")]
     pub dht_port: u16,
 
-    /// Bootstrap node to connect to (can be specified multiple times)
+    /// Bootstrap nodes to connect to (can be specified multiple times)
     #[arg(long)]
     pub bootstrap: Vec<String>,
 
@@ -51,15 +51,15 @@ pub async fn run_headless(args: CliArgs) -> Result<(), Box<dyn std::error::Error
     info!("Starting Chiral Network in headless mode");
     info!("DHT Port: {}", args.dht_port);
     
-    // Add default bootstrap node if no custom ones specified
+    // Add default bootstrap nodes if no custom ones specified
     let mut bootstrap_nodes = args.bootstrap.clone();
     if bootstrap_nodes.is_empty() && args.dht_port != 4001 {
         // Don't connect to self if we're running on port 4001
-        // Use reliable IP-based bootstrap node
+        // Use reliable IP-based bootstrap nodes
         bootstrap_nodes.extend([
             "/ip4/104.131.131.82/tcp/4001/p2p/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ".to_string(),
         ]);
-        info!("Using default bootstrap node: {:?}", bootstrap_nodes);
+        info!("Using default bootstrap nodes: {:?}", bootstrap_nodes);
     }
     
     // Start DHT node
@@ -116,7 +116,7 @@ pub async fn run_headless(args: CliArgs) -> Result<(), Box<dyn std::error::Error
             match dht_service.connect_peer(bootstrap_addr.clone()).await {
                 Ok(_) => {
                     info!("Connected to bootstrap: {}", bootstrap_addr);
-                    // In a real implementation, the bootstrap node would add us as a peer
+                    // In a real implementation, the bootstrap nodes would add us as a peer
                     // For now, simulate this by adding the bootstrap as a connected peer
                 }
                 Err(e) => error!("Failed to connect to {}: {}", bootstrap_addr, e),

--- a/src-tauri/src/headless.rs
+++ b/src-tauri/src/headless.rs
@@ -17,7 +17,7 @@ pub struct CliArgs {
     #[arg(long, default_value = "4001")]
     pub dht_port: u16,
 
-    /// Bootstrap nodes to connect to (can be specified multiple times)
+    /// Bootstrap node to connect to (can be specified multiple times)
     #[arg(long)]
     pub bootstrap: Vec<String>,
 
@@ -55,8 +55,11 @@ pub async fn run_headless(args: CliArgs) -> Result<(), Box<dyn std::error::Error
     let mut bootstrap_nodes = args.bootstrap.clone();
     if bootstrap_nodes.is_empty() && args.dht_port != 4001 {
         // Don't connect to self if we're running on port 4001
-        bootstrap_nodes.push("/ip4/130.245.173.105/tcp/4001".to_string());
-        info!("Using default bootstrap node: 130.245.173.105:4001");
+        // Use reliable IP-based bootstrap node
+        bootstrap_nodes.extend([
+            "/ip4/104.131.131.82/tcp/4001/p2p/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ".to_string(),
+        ]);
+        info!("Using default bootstrap node: {:?}", bootstrap_nodes);
     }
     
     // Start DHT node

--- a/src/lib/dht.ts
+++ b/src/lib/dht.ts
@@ -1,9 +1,10 @@
 // DHT configuration and utilities
 import { invoke } from "@tauri-apps/api/core";
 
-// Default bootstrap node
-export const DEFAULT_BOOTSTRAP_NODE =
-  "/ip4/104.131.131.82/tcp/4001/p2p/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ";
+// Default bootstrap nodes for network connectivity
+export const DEFAULT_BOOTSTRAP_NODES = [
+  "/ip4/104.131.131.82/tcp/4001/p2p/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ",
+];
 
 export interface DhtConfig {
   port: number;
@@ -42,10 +43,10 @@ export class DhtService {
     const port = config?.port || 4001;
     let bootstrapNodes = config?.bootstrapNodes || [];
 
-    // Use default bootstrap node if none provided
+    // Use default bootstrap nodes if none provided
     if (bootstrapNodes.length === 0) {
-      bootstrapNodes = [DEFAULT_BOOTSTRAP_NODE];
-      console.log("Using default bootstrap node for network connectivity");
+      bootstrapNodes = DEFAULT_BOOTSTRAP_NODES;
+      console.log("Using default bootstrap nodes for network connectivity");
     } else {
       console.log(`Using ${bootstrapNodes.length} custom bootstrap nodes`);
     }

--- a/src/pages/Account.svelte
+++ b/src/pages/Account.svelte
@@ -1189,7 +1189,6 @@
               type="text"
               inputmode="decimal"
               bind:value={rawAmountInput}
-              placeholder={$t('transfer.amount.placeholder')}
               class="mt-2"
               data-form-type="other"
               data-lpignore="true"

--- a/src/pages/Network.svelte
+++ b/src/pages/Network.svelte
@@ -926,7 +926,7 @@
           <Input
             id="peer-address"
             bind:value={newPeerAddress}
-            placeholder="/ip4/192.168.1.100/tcp/4001/p2p/12D3Koo..."
+            placeholder={$t('network.peerDiscovery.placeholder')}
             class="flex-1 min-w-0 break-all"
           />
           <Button on:click={connectToPeer} disabled={!newPeerAddress}>


### PR DESCRIPTION
- Added RSA support to `libp2p`
- Enhanced error handling with specific hints for RSA, timeout, and transport failures
- Added connection tracking showing successful/total bootstrap attempts
- Updated default bootstrap node to include full peer ID for reliability
- Improved UI feedback with better error parsing and standalone mode handling
- Changed all instances of "bootstrap node" to "bootstrap nodes" because we may have more than 1 bootstrap node in the future
- Also fix a tiny error in `Account.svelte` where the Amount (Chiral) placeholder literally said "transfer.amount.placeholder"