### PR TITLE
fix(UI/Mining): Fixed Recent Block History To Pull From Backend

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -13,7 +13,7 @@ use ethereum::{
     create_new_account, get_account_from_private_key, get_balance, get_peer_count,
     start_mining, stop_mining, get_mining_status, get_hashrate, get_block_number,
     get_network_difficulty, get_network_hashrate, get_mining_logs, get_mining_performance,
-    get_mined_blocks_count, EthAccount, GethProcess
+    get_mined_blocks_count, get_recent_mined_blocks, EthAccount, GethProcess, MinedBlock
 };
 use keystore::Keystore;
 use geth_downloader::GethDownloader;
@@ -267,7 +267,10 @@ async fn get_miner_performance(data_dir: String) -> Result<(u64, f64), String> {
 async fn get_blocks_mined(address: String) -> Result<u64, String> {
     get_mined_blocks_count(&address).await
 }
-
+#[tauri::command] 
+async fn get_recent_mined_blocks_pub(address:String, lookback:u64, limit:usize) -> Result<Vec<MinedBlock>, String> {
+    get_recent_mined_blocks(&address, lookback, limit).await
+}
 #[tauri::command]
 async fn start_dht_node(state: State<'_, AppState>, port: u16, bootstrap_nodes: Vec<String>) -> Result<String, String> {
     {
@@ -529,7 +532,8 @@ fn main() {
             get_network_stats,
             get_miner_logs,
             get_miner_performance,
-            get_blocks_mined,
+            get_blocks_mined, 
+            get_recent_mined_blocks_pub,
             get_cpu_temperature,
             start_dht_node,
             stop_dht_node,

--- a/src/pages/Mining.svelte
+++ b/src/pages/Mining.svelte
@@ -248,14 +248,8 @@
             $miningState.hashRate = formatHashRate(hashRateFromLogs)
             if (blocksFound > $miningState.blocksFound) {
               const newBlocks = blocksFound - $miningState.blocksFound;
-              // const rewardPerBlock = 5.0;
-              // $miningState.totalRewards += newBlocks * rewardPerBlock;
               $miningState.blocksFound = blocksFound; 
               //Visualization Now Handled By Backend
-              // Add each new block to recentBlocks
-              // for (let i = 0; i < newBlocks; i++) {
-              //   findBlock();
-              // }
             }
           } else if ($miningState.activeThreads > 0) {
             // Fall back to simulation if no log data yet
@@ -307,11 +301,6 @@
         const timeDelta = (Date.now() - lastHashUpdate) / 1000 // seconds
         totalHashes += Math.floor(hashRateNum * timeDelta)
         lastHashUpdate = Date.now()
-        
-        // Simulate finding blocks occasionally (very low probability) -> No More Simulating Blocks 
-        // if (Math.random() < 0.001) {
-        //   findBlock()
-        // }
       }
     } catch (e) {
       console.error('Failed to update mining stats:', e)
@@ -357,11 +346,7 @@
         if (results[4] !== undefined) {
           const blocksMined = results[4] as number;
           if (blocksMined > $miningState.blocksFound) {
-            // const newBlocks = blocksMined - $miningState.blocksFound;
             $miningState.blocksFound = blocksMined;
-            // for (let i = 0; i < newBlocks; i++) {
-            //   findBlock();
-            // }
           }
         }
       }
@@ -463,22 +448,7 @@
       console.error('Failed to stop mining:', e)
     }
   }
-  
-  // function findBlock() {
-  //   $miningState.blocksFound++
-  //   const reward = 5 + Math.random() * 2
-  //   $miningState.totalRewards += reward
-    
-  //   $miningState.recentBlocks = [{
-  //     id: `block-${Date.now()}`,
-  //     hash: `0x${Math.random().toString(16).substring(2, 10)}...${Math.random().toString(16).substring(2, 6)}`,
-  //     reward: reward,
-  //     timestamp: new Date(),
-  //     difficulty: currentDifficulty,
-  //     nonce: Math.floor(Math.random() * 1000000)
-  //   }, ...($miningState.recentBlocks ?? []).slice(0, 4)]
-  // } 
-  
+
   // Simulation removed; recent blocks come from backend
 
   // Keep a set of hashes we've already shown to avoid duplicates


### PR DESCRIPTION
In a previous PR #168, I added a function into the backend to get recently mined blocks. 

This PR is a follow up to that where I now added a public tauri command called `get_recently_mined_blocks_pub` that is now called in our frontend under the newly created function `appendNewBlocksFromBackend` to grab this information and appropriately update the UI to reflect this. The way this is done is that a Set is created when the mining page is loaded which contains all these recently mined blocks.  

**Before**: 
<img width="1229" height="302" alt="image" src="https://github.com/user-attachments/assets/bf547089-22f2-4011-9789-1dc7c32223ac" />
<img width="1270" height="288" alt="image" src="https://github.com/user-attachments/assets/25dcfb75-56ba-447c-bfb0-a3c0c8344579" />

**After:** 
<img width="1919" height="1018" alt="image" src="https://github.com/user-attachments/assets/ef935bab-6ee8-47f6-8768-efdc65e42a39" />
<img width="1526" height="598" alt="image" src="https://github.com/user-attachments/assets/78ba1ba4-38f4-448a-84be-d275d2707f86" /> 

As you can see from the images above, the issue has been fixed. We may need to consider paginating or changing the way these recent blocks are displayed, but that can be a future PR. 
