### PR TITLE
feat(Mining): add scrollbar to Recent Blocks Found and make Hash Rate History graph consistent with Analytics page

### DIFF
--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -258,7 +258,7 @@ interface RecentBlock {
   nonce: number;
 }
 
-interface MiningHistoryPoint {
+export interface MiningHistoryPoint {
   timestamp: number;
   hashRate: number;
   power: number;


### PR DESCRIPTION
- Add scrollbar to Recent Blocks Found since previously unlimited blocks will show overfilling the page 
- Add axis labels and blue coloring to the graph of Hash Rate History to look like the graphs on the Analytics page

Before:
<img width="2707" height="1935" alt="Screenshot 2025-09-16 145528" src="https://github.com/user-attachments/assets/af07f3fd-5231-4fd1-98cd-40ef32a370fa" />
<img width="2670" height="775" alt="Screenshot 2025-09-16 145825" src="https://github.com/user-attachments/assets/17c72a36-d900-4953-ae69-10948dc42143" />
<img width="2702" height="745" alt="Screenshot 2025-09-16 145842" src="https://github.com/user-attachments/assets/2f85241d-4a5e-4baa-91da-4f8acb63d704" />


After:
<img width="2692" height="1762" alt="Screenshot 2025-09-16 145301" src="https://github.com/user-attachments/assets/28dde5f3-94b4-4985-ad62-86de39858098" />
<img width="2697" height="977" alt="Screenshot 2025-09-16 151540" src="https://github.com/user-attachments/assets/b292e6d3-463b-4c31-a1aa-52cd77255990" />
<img width="2695" height="987" alt="Screenshot 2025-09-16 151550" src="https://github.com/user-attachments/assets/124dc1a4-9f74-49db-be42-289e1b13bf40" />

