### PR TITLE
feat(dht): add health telemetry API + UI;  grace shutdown; default bootstraps; settings validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,8 @@ debug/
 # Package manager locks (keep package-lock.json for npm)
 yarn.lock
 pnpm-lock.yaml
+# Local Python venv
+.venv-pdf/
+
+# Local Python venv
+.venv-pdf/

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-  tauri_build::build()
+    tauri_build::build()
 }

--- a/src-tauri/src/dht.rs
+++ b/src-tauri/src/dht.rs
@@ -1,25 +1,24 @@
 // Real DHT implementation with channel-based communication for thread safety
-use libp2p::{
-    identity,
-    kad::{self, store::MemoryStore, Record, Mode},
-    swarm::{NetworkBehaviour, SwarmEvent},
-    identify,
-    PeerId, Swarm, Multiaddr, SwarmBuilder, StreamProtocol,
-};
+use futures_util::StreamExt;
+use libp2p::identify::Event as IdentifyEvent;
 use libp2p::kad::Behaviour as Kademlia;
 use libp2p::kad::Event as KademliaEvent;
-use libp2p::kad::{Config as KademliaConfig, QueryResult, GetRecordOk, PutRecordOk};
+use libp2p::kad::{Config as KademliaConfig, GetRecordOk, PutRecordOk, QueryResult};
 use libp2p::mdns::{tokio::Behaviour as Mdns, Event as MdnsEvent};
-use libp2p::identify::Event as IdentifyEvent;
-use futures_util::StreamExt;
+use libp2p::{
+    identify, identity,
+    kad::{self, store::MemoryStore, Mode, Record},
+    swarm::{NetworkBehaviour, SwarmEvent},
+    Multiaddr, PeerId, StreamProtocol, Swarm, SwarmBuilder,
+};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::HashSet,
     sync::Arc,
-    time::Duration,
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
-use tokio::sync::{mpsc, Mutex, oneshot};
-use tracing::{info, warn, debug, error};
+use tokio::sync::{mpsc, oneshot, Mutex};
+use tracing::{debug, error, info, warn};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FileMetadata {
@@ -44,6 +43,7 @@ pub enum DhtCommand {
     SearchFile(String),
     ConnectPeer(String),
     GetPeerCount(oneshot::Sender<usize>),
+    Shutdown(oneshot::Sender<()>),
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -56,27 +56,74 @@ pub enum DhtEvent {
     Error(String),
 }
 
+#[derive(Debug, Clone, Default)]
+struct DhtMetrics {
+    last_bootstrap: Option<SystemTime>,
+    last_success: Option<SystemTime>,
+    last_error_at: Option<SystemTime>,
+    last_error: Option<String>,
+    bootstrap_failures: u64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DhtMetricsSnapshot {
+    pub peer_count: usize,
+    pub last_bootstrap: Option<u64>,
+    pub last_peer_event: Option<u64>,
+    pub last_error: Option<String>,
+    pub last_error_at: Option<u64>,
+    pub bootstrap_failures: u64,
+}
+
+impl DhtMetricsSnapshot {
+    fn from(metrics: DhtMetrics, peer_count: usize) -> Self {
+        fn to_secs(ts: SystemTime) -> Option<u64> {
+            ts.duration_since(UNIX_EPOCH).ok().map(|d| d.as_secs())
+        }
+
+        DhtMetricsSnapshot {
+            peer_count,
+            last_bootstrap: metrics.last_bootstrap.and_then(to_secs),
+            last_peer_event: metrics.last_success.and_then(to_secs),
+            last_error: metrics.last_error,
+            last_error_at: metrics.last_error_at.and_then(to_secs),
+            bootstrap_failures: metrics.bootstrap_failures,
+        }
+    }
+}
+
 async fn run_dht_node(
     mut swarm: Swarm<DhtBehaviour>,
     peer_id: PeerId,
     mut cmd_rx: mpsc::Receiver<DhtCommand>,
     event_tx: mpsc::Sender<DhtEvent>,
     connected_peers: Arc<Mutex<HashSet<PeerId>>>,
+    metrics: Arc<Mutex<DhtMetrics>>,
 ) {
     // Periodic bootstrap interval
     let mut bootstrap_interval = tokio::time::interval(Duration::from_secs(30));
-    
-    loop {
+    let mut shutdown_ack: Option<oneshot::Sender<()>> = None;
+
+    'outer: loop {
         tokio::select! {
             _ = bootstrap_interval.tick() => {
                 // Periodically bootstrap to maintain connections
                 let _ = swarm.behaviour_mut().kademlia.bootstrap();
+                if let Ok(mut m) = metrics.try_lock() {
+                    m.last_bootstrap = Some(SystemTime::now());
+                }
                 debug!("Performing periodic Kademlia bootstrap");
             }
-            
-            Some(cmd) = cmd_rx.recv() => {
+
+            cmd = cmd_rx.recv() => {
                 match cmd {
-                    DhtCommand::PublishFile(metadata) => {
+                    Some(DhtCommand::Shutdown(ack)) => {
+                        info!("Received shutdown signal for DHT node");
+                        shutdown_ack = Some(ack);
+                        break 'outer;
+                    }
+                    Some(DhtCommand::PublishFile(metadata)) => {
                         let key = kad::RecordKey::new(&metadata.file_hash.as_bytes());
                         match serde_json::to_vec(&metadata) {
                             Ok(value) => {
@@ -86,7 +133,7 @@ async fn run_dht_node(
                                     publisher: Some(peer_id),
                                     expires: None,
                                 };
-                                
+
                                 match swarm.behaviour_mut().kademlia.put_record(record, kad::Quorum::One) {
                                     Ok(_) => {
                                         info!("Published file metadata: {}", metadata.file_hash);
@@ -103,12 +150,12 @@ async fn run_dht_node(
                             }
                         }
                     }
-                    DhtCommand::SearchFile(file_hash) => {
+                    Some(DhtCommand::SearchFile(file_hash)) => {
                         let key = kad::RecordKey::new(&file_hash.as_bytes());
                         let _query_id = swarm.behaviour_mut().kademlia.get_record(key);
                         info!("Searching for file: {}", file_hash);
                     }
-                    DhtCommand::ConnectPeer(addr) => {
+                    Some(DhtCommand::ConnectPeer(addr)) => {
                         info!("Attempting to connect to: {}", addr);
                         if let Ok(multiaddr) = addr.parse::<Multiaddr>() {
                             match swarm.dial(multiaddr.clone()) {
@@ -127,13 +174,17 @@ async fn run_dht_node(
                             let _ = event_tx.send(DhtEvent::Error(format!("Invalid address: {}", addr))).await;
                         }
                     }
-                    DhtCommand::GetPeerCount(tx) => {
+                    Some(DhtCommand::GetPeerCount(tx)) => {
                         let count = connected_peers.lock().await.len();
                         let _ = tx.send(count);
                     }
+                    None => {
+                        info!("DHT command channel closed; shutting down node task");
+                        break 'outer;
+                    }
                 }
             }
-            
+
             event = swarm.next() => if let Some(event) = event {
                 match event {
                     SwarmEvent::Behaviour(DhtBehaviourEvent::Kademlia(kad_event)) => {
@@ -148,15 +199,18 @@ async fn run_dht_node(
                     SwarmEvent::ConnectionEstablished { peer_id, endpoint, .. } => {
                         info!("✅ CONNECTION ESTABLISHED with peer: {}", peer_id);
                         info!("   Endpoint: {:?}", endpoint);
-                        
+
                         // Add peer to Kademlia routing table
                         swarm.behaviour_mut().kademlia.add_address(&peer_id, endpoint.get_remote_address().clone());
-                        
+
                         let peers_count = {
                             let mut peers = connected_peers.lock().await;
                             peers.insert(peer_id);
                             peers.len()
                         };
+                        if let Ok(mut m) = metrics.try_lock() {
+                            m.last_success = Some(SystemTime::now());
+                        }
                         info!("   Total connected peers: {}", peers_count);
                         let _ = event_tx.send(DhtEvent::PeerConnected(peer_id.to_string())).await;
                     }
@@ -175,6 +229,11 @@ async fn run_dht_node(
                         info!("📡 Now listening on: {}", address);
                     }
                     SwarmEvent::OutgoingConnectionError { peer_id, error, .. } => {
+                        if let Ok(mut m) = metrics.try_lock() {
+                            m.last_error = Some(error.to_string());
+                            m.last_error_at = Some(SystemTime::now());
+                            m.bootstrap_failures = m.bootstrap_failures.saturating_add(1);
+                        }
                         if let Some(peer_id) = peer_id {
                             error!("❌ Outgoing connection error to {}: {}", peer_id, error);
                             // Check if this is a bootstrap connection error
@@ -193,12 +252,26 @@ async fn run_dht_node(
                         let _ = event_tx.send(DhtEvent::Error(format!("Connection failed: {}", error))).await;
                     }
                     SwarmEvent::IncomingConnectionError { error, .. } => {
+                        if let Ok(mut m) = metrics.try_lock() {
+                            m.last_error = Some(error.to_string());
+                            m.last_error_at = Some(SystemTime::now());
+                            m.bootstrap_failures = m.bootstrap_failures.saturating_add(1);
+                        }
                         error!("❌ Incoming connection error: {}", error);
                     }
                     _ => {}
                 }
+            } else {
+                info!("DHT swarm stream ended; shutting down node task");
+                break 'outer;
             }
         }
+    }
+
+    connected_peers.lock().await.clear();
+    info!("DHT node task exiting");
+    if let Some(ack) = shutdown_ack {
+        let _ = ack.send(());
     }
 }
 
@@ -218,7 +291,9 @@ async fn handle_kademlia_event(event: KademliaEvent, event_tx: &mpsc::Sender<Dht
                 QueryResult::GetRecord(Ok(ok)) => match ok {
                     GetRecordOk::FoundRecord(peer_record) => {
                         // Try to parse file metadata from record value
-                        if let Ok(metadata) = serde_json::from_slice::<FileMetadata>(&peer_record.record.value) {
+                        if let Ok(metadata) =
+                            serde_json::from_slice::<FileMetadata>(&peer_record.record.value)
+                        {
                             let _ = event_tx.send(DhtEvent::FileDiscovered(metadata)).await;
                         } else {
                             debug!("Received non-file metadata record");
@@ -241,7 +316,9 @@ async fn handle_kademlia_event(event: KademliaEvent, event_tx: &mpsc::Sender<Dht
                 }
                 QueryResult::PutRecord(Err(err)) => {
                     warn!("PutRecord error: {:?}", err);
-                    let _ = event_tx.send(DhtEvent::Error(format!("PutRecord failed: {:?}", err))).await;
+                    let _ = event_tx
+                        .send(DhtEvent::Error(format!("PutRecord failed: {:?}", err)))
+                        .await;
                 }
                 _ => {}
             }
@@ -250,7 +327,11 @@ async fn handle_kademlia_event(event: KademliaEvent, event_tx: &mpsc::Sender<Dht
     }
 }
 
-async fn handle_identify_event(event: IdentifyEvent, swarm: &mut Swarm<DhtBehaviour>, _event_tx: &mpsc::Sender<DhtEvent>) {
+async fn handle_identify_event(
+    event: IdentifyEvent,
+    swarm: &mut Swarm<DhtBehaviour>,
+    _event_tx: &mpsc::Sender<DhtEvent>,
+) {
     match event {
         IdentifyEvent::Received { peer_id, info, .. } => {
             info!("Identified peer {}: {:?}", peer_id, info.protocol_version);
@@ -266,19 +347,31 @@ async fn handle_identify_event(event: IdentifyEvent, swarm: &mut Swarm<DhtBehavi
     }
 }
 
-async fn handle_mdns_event(event: MdnsEvent, swarm: &mut Swarm<DhtBehaviour>, event_tx: &mpsc::Sender<DhtEvent>) {
+async fn handle_mdns_event(
+    event: MdnsEvent,
+    swarm: &mut Swarm<DhtBehaviour>,
+    event_tx: &mpsc::Sender<DhtEvent>,
+) {
     match event {
         MdnsEvent::Discovered(list) => {
             for (peer_id, multiaddr) in list {
                 debug!("mDNS discovered peer {} at {}", peer_id, multiaddr);
-                swarm.behaviour_mut().kademlia.add_address(&peer_id, multiaddr);
-                let _ = event_tx.send(DhtEvent::PeerDiscovered(peer_id.to_string())).await;
+                swarm
+                    .behaviour_mut()
+                    .kademlia
+                    .add_address(&peer_id, multiaddr);
+                let _ = event_tx
+                    .send(DhtEvent::PeerDiscovered(peer_id.to_string()))
+                    .await;
             }
         }
         MdnsEvent::Expired(list) => {
             for (peer_id, multiaddr) in list {
                 debug!("mDNS expired peer {} at {}", peer_id, multiaddr);
-                swarm.behaviour_mut().kademlia.remove_address(&peer_id, &multiaddr);
+                swarm
+                    .behaviour_mut()
+                    .kademlia
+                    .remove_address(&peer_id, &multiaddr);
             }
         }
     }
@@ -289,17 +382,22 @@ pub struct DhtService {
     cmd_tx: mpsc::Sender<DhtCommand>,
     event_rx: Arc<Mutex<mpsc::Receiver<DhtEvent>>>,
     peer_id: String,
+    connected_peers: Arc<Mutex<HashSet<PeerId>>>,
+    metrics: Arc<Mutex<DhtMetrics>>,
 }
 
 impl DhtService {
-    pub async fn new(port: u16, bootstrap_nodes: Vec<String>) -> Result<Self, Box<dyn std::error::Error>> {
+    pub async fn new(
+        port: u16,
+        bootstrap_nodes: Vec<String>,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
         // Generate a new keypair for this node
         let local_key = identity::Keypair::generate_ed25519();
         let local_peer_id = PeerId::from(local_key.public());
         let peer_id_str = local_peer_id.to_string();
-        
+
         info!("Local peer id: {}", local_peer_id);
-        
+
         // Create a Kademlia behaviour with tuned configuration
         let store = MemoryStore::new(local_peer_id);
         let mut kad_cfg = KademliaConfig::new(StreamProtocol::new("/chiral/kad/1.0.0"));
@@ -310,21 +408,25 @@ impl DhtService {
             kad_cfg.set_replication_factor(nz);
         }
         let mut kademlia = Kademlia::with_config(local_peer_id, store, kad_cfg);
-        
+
         // Set Kademlia to server mode to accept incoming connections
         kademlia.set_mode(Some(Mode::Server));
-        
+
         // Create identify behaviour
         let identify = identify::Behaviour::new(identify::Config::new(
             "/chiral/1.0.0".to_string(),
             local_key.public(),
         ));
-        
+
         // mDNS for local peer discovery
         let mdns = Mdns::new(Default::default(), local_peer_id)?;
-        
-        let behaviour = DhtBehaviour { kademlia, identify, mdns };
-        
+
+        let behaviour = DhtBehaviour {
+            kademlia,
+            identify,
+            mdns,
+        };
+
         // Create the swarm
         let mut swarm = SwarmBuilder::with_existing_identity(local_key)
             .with_tokio()
@@ -334,16 +436,16 @@ impl DhtService {
                 libp2p::yamux::Config::default,
             )?
             .with_behaviour(|_| behaviour)?
-            .with_swarm_config(|c| c
-                .with_idle_connection_timeout(Duration::from_secs(300)) // 5 minutes
+            .with_swarm_config(
+                |c| c.with_idle_connection_timeout(Duration::from_secs(300)), // 5 minutes
             )
             .build();
-        
+
         // Listen on the specified port
         let listen_addr: Multiaddr = format!("/ip4/0.0.0.0/tcp/{}", port).parse()?;
         swarm.listen_on(listen_addr)?;
         info!("DHT listening on port: {}", port);
-        
+
         // Connect to bootstrap nodes
         info!("Bootstrap nodes to connect: {:?}", bootstrap_nodes);
         let mut successful_connections = 0;
@@ -363,7 +465,10 @@ impl DhtService {
                                 None
                             }
                         }) {
-                            swarm.behaviour_mut().kademlia.add_address(&peer_id, addr.clone());
+                            swarm
+                                .behaviour_mut()
+                                .kademlia
+                                .add_address(&peer_id, addr.clone());
                         }
                     }
                     Err(e) => warn!("✗ Failed to dial bootstrap {}: {}", bootstrap_addr, e),
@@ -372,67 +477,82 @@ impl DhtService {
                 warn!("✗ Invalid bootstrap address format: {}", bootstrap_addr);
             }
         }
-        
+
         // Trigger initial bootstrap if we have any bootstrap nodes (even if connection failed)
         if !bootstrap_nodes.is_empty() {
             let _ = swarm.behaviour_mut().kademlia.bootstrap();
-            info!("Triggered initial Kademlia bootstrap (attempted {}/{} connections)", successful_connections, total_bootstrap_nodes);
+            info!(
+                "Triggered initial Kademlia bootstrap (attempted {}/{} connections)",
+                successful_connections, total_bootstrap_nodes
+            );
             if successful_connections == 0 {
-                warn!("⚠ No bootstrap connections succeeded - node will operate in standalone mode");
+                warn!(
+                    "⚠ No bootstrap connections succeeded - node will operate in standalone mode"
+                );
                 warn!("  Other nodes can still connect to this node directly");
             }
         } else {
             info!("No bootstrap nodes provided - starting in standalone mode");
         }
-        
+
         let (cmd_tx, cmd_rx) = mpsc::channel(100);
         let (event_tx, event_rx) = mpsc::channel(100);
         let connected_peers = Arc::new(Mutex::new(HashSet::new()));
-        
+        let metrics = Arc::new(Mutex::new(DhtMetrics::default()));
+
         // Spawn the DHT node task
         tokio::spawn(run_dht_node(
             swarm,
             local_peer_id,
             cmd_rx,
             event_tx,
-            connected_peers,
+            connected_peers.clone(),
+            metrics.clone(),
         ));
-        
+
         Ok(DhtService {
             cmd_tx,
             event_rx: Arc::new(Mutex::new(event_rx)),
             peer_id: peer_id_str,
+            connected_peers,
+            metrics,
         })
     }
-    
+
     pub async fn run(&self) {
         // The node is already running in a spawned task
         info!("DHT node is running");
     }
-    
+
     pub async fn publish_file(&self, metadata: FileMetadata) -> Result<(), String> {
-        self.cmd_tx.send(DhtCommand::PublishFile(metadata)).await
+        self.cmd_tx
+            .send(DhtCommand::PublishFile(metadata))
+            .await
             .map_err(|e| e.to_string())
     }
-    
+
     pub async fn search_file(&self, file_hash: String) -> Result<(), String> {
-        self.cmd_tx.send(DhtCommand::SearchFile(file_hash)).await
+        self.cmd_tx
+            .send(DhtCommand::SearchFile(file_hash))
+            .await
             .map_err(|e| e.to_string())
     }
-    
+
     pub async fn get_file(&self, file_hash: String) -> Result<(), String> {
         self.search_file(file_hash).await
     }
-    
+
     pub async fn connect_peer(&self, addr: String) -> Result<(), String> {
-        self.cmd_tx.send(DhtCommand::ConnectPeer(addr)).await
+        self.cmd_tx
+            .send(DhtCommand::ConnectPeer(addr))
+            .await
             .map_err(|e| e.to_string())
     }
-    
+
     pub async fn get_peer_id(&self) -> String {
         self.peer_id.clone()
     }
-    
+
     pub async fn get_peer_count(&self) -> usize {
         let (tx, rx) = oneshot::channel();
         if self.cmd_tx.send(DhtCommand::GetPeerCount(tx)).await.is_ok() {
@@ -441,7 +561,23 @@ impl DhtService {
             0
         }
     }
-    
+
+    pub async fn metrics_snapshot(&self) -> DhtMetricsSnapshot {
+        let metrics = self.metrics.lock().await.clone();
+        let peer_count = self.connected_peers.lock().await.len();
+        DhtMetricsSnapshot::from(metrics, peer_count)
+    }
+
+    pub async fn shutdown(&self) -> Result<(), String> {
+        let (tx, rx) = oneshot::channel();
+        if self.cmd_tx.send(DhtCommand::Shutdown(tx)).await.is_err() {
+            return Ok(());
+        }
+
+        rx.await.map_err(|e| e.to_string())?;
+
+        Ok(())
+    }
 
     // Drain up to `max` pending events without blocking
     pub async fn drain_events(&self, max: usize) -> Vec<DhtEvent> {
@@ -456,5 +592,24 @@ impl DhtService {
             }
         }
         events
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn shutdown_command_stops_dht_service() {
+        let service = DhtService::new(0, Vec::new()).await.expect("start service");
+        service.run().await;
+
+        service.shutdown().await.expect("shutdown");
+
+        // Subsequent calls should gracefully no-op
+        assert_eq!(service.get_peer_count().await, 0);
+
+        let snapshot = service.metrics_snapshot().await;
+        assert_eq!(snapshot.peer_count, 0);
     }
 }

--- a/src-tauri/src/keystore.rs
+++ b/src-tauri/src/keystore.rs
@@ -1,12 +1,12 @@
 use aes::cipher::{KeyIvInit, StreamCipher};
-use ctr::Ctr128BE;
 use aes::Aes256;
+use ctr::Ctr128BE;
+use directories::ProjectDirs;
 use hmac::Hmac;
 use pbkdf2::pbkdf2;
-use rand::{RngCore, thread_rng};
-use sha3::Sha3_256;
-use directories::ProjectDirs;
+use rand::{thread_rng, RngCore};
 use serde::{Deserialize, Serialize};
+use sha3::Sha3_256;
 use std::fs;
 use std::path::PathBuf;
 
@@ -35,39 +35,37 @@ impl Keystore {
     pub fn get_keystore_path() -> Result<PathBuf, String> {
         let proj_dirs = ProjectDirs::from("com", "chiral", "network")
             .ok_or_else(|| "Could not determine project directories".to_string())?;
-        
+
         let data_dir = proj_dirs.data_dir();
-        
+
         // Create directory if it doesn't exist
         fs::create_dir_all(data_dir)
             .map_err(|e| format!("Failed to create data directory: {}", e))?;
-        
+
         Ok(data_dir.join("keystore.json"))
     }
 
     pub fn load() -> Result<Self, String> {
         let path = Self::get_keystore_path()?;
-        
+
         if !path.exists() {
             return Ok(Self::new());
         }
-        
-        let contents = fs::read_to_string(&path)
-            .map_err(|e| format!("Failed to read keystore: {}", e))?;
-        
-        serde_json::from_str(&contents)
-            .map_err(|e| format!("Failed to parse keystore: {}", e))
+
+        let contents =
+            fs::read_to_string(&path).map_err(|e| format!("Failed to read keystore: {}", e))?;
+
+        serde_json::from_str(&contents).map_err(|e| format!("Failed to parse keystore: {}", e))
     }
 
     pub fn save(&self) -> Result<(), String> {
         let path = Self::get_keystore_path()?;
-        
+
         let contents = serde_json::to_string_pretty(self)
             .map_err(|e| format!("Failed to serialize keystore: {}", e))?;
-        
-        fs::write(&path, contents)
-            .map_err(|e| format!("Failed to write keystore: {}", e))?;
-        
+
+        fs::write(&path, contents).map_err(|e| format!("Failed to write keystore: {}", e))?;
+
         Ok(())
     }
 
@@ -78,17 +76,17 @@ impl Keystore {
         password: &str,
     ) -> Result<(), String> {
         let (encrypted, salt, iv) = encrypt_private_key(private_key, password)?;
-        
+
         // Remove existing account with same address
         self.accounts.retain(|a| a.address != address);
-        
+
         self.accounts.push(EncryptedKeystore {
             address,
             encrypted_private_key: encrypted,
             salt,
             iv,
         });
-        
+
         self.save()?;
         Ok(())
     }
@@ -99,7 +97,7 @@ impl Keystore {
             .iter()
             .find(|a| a.address == address)
             .ok_or_else(|| "Account not found".to_string())?;
-        
+
         decrypt_private_key(
             &account.encrypted_private_key,
             &account.salt,
@@ -126,30 +124,29 @@ fn derive_key(password: &str, salt: &[u8]) -> [u8; 32] {
     key
 }
 
-fn encrypt_private_key(private_key: &str, password: &str) -> Result<(String, String, String), String> {
+fn encrypt_private_key(
+    private_key: &str,
+    password: &str,
+) -> Result<(String, String, String), String> {
     let mut rng = thread_rng();
-    
+
     // Generate random salt
     let mut salt = [0u8; 32];
     rng.fill_bytes(&mut salt);
-    
+
     // Generate random IV
     let mut iv = [0u8; 16];
     rng.fill_bytes(&mut iv);
-    
+
     // Derive key from password
     let key = derive_key(password, &salt);
-    
+
     // Encrypt
     let mut data = private_key.as_bytes().to_vec();
     let mut cipher = Aes256Ctr::new(&key.into(), &iv.into());
     cipher.apply_keystream(&mut data);
-    
-    Ok((
-        hex::encode(data),
-        hex::encode(salt),
-        hex::encode(iv),
-    ))
+
+    Ok((hex::encode(data), hex::encode(salt), hex::encode(iv)))
 }
 
 fn decrypt_private_key(
@@ -159,23 +156,22 @@ fn decrypt_private_key(
     password: &str,
 ) -> Result<String, String> {
     // Decode hex
-    let salt_bytes = hex::decode(salt)
-        .map_err(|e| format!("Invalid salt: {}", e))?;
-    let iv_bytes = hex::decode(iv)
-        .map_err(|e| format!("Invalid IV: {}", e))?;
-    let mut ciphertext = hex::decode(encrypted)
-        .map_err(|e| format!("Invalid ciphertext: {}", e))?;
-    
+    let salt_bytes = hex::decode(salt).map_err(|e| format!("Invalid salt: {}", e))?;
+    let iv_bytes = hex::decode(iv).map_err(|e| format!("Invalid IV: {}", e))?;
+    let mut ciphertext =
+        hex::decode(encrypted).map_err(|e| format!("Invalid ciphertext: {}", e))?;
+
     // Derive key from password
     let key = derive_key(password, &salt_bytes);
-    
+
     // Decrypt
-    let iv_array: [u8; 16] = iv_bytes.try_into()
+    let iv_array: [u8; 16] = iv_bytes
+        .try_into()
         .map_err(|_| "Invalid IV length".to_string())?;
-    
+
     let mut cipher = Aes256Ctr::new(&key.into(), &iv_array.into());
     cipher.apply_keystream(&mut ciphertext);
-    
+
     String::from_utf8(ciphertext)
         .map_err(|_| "Decryption failed: incorrect password or corrupted data".to_string())
 }

--- a/src/lib/dht.ts
+++ b/src/lib/dht.ts
@@ -21,6 +21,15 @@ export interface FileMetadata {
   mimeType?: string;
 }
 
+export interface DhtHealth {
+  peerCount: number;
+  lastBootstrap: number | null;
+  lastPeerEvent: number | null;
+  lastError: string | null;
+  lastErrorAt: number | null;
+  bootstrapFailures: number;
+}
+
 export class DhtService {
   private static instance: DhtService | null = null;
   private peerId: string | null = null;
@@ -165,6 +174,16 @@ export class DhtService {
     } catch (error) {
       console.error("Failed to get peer count:", error);
       return 0;
+    }
+  }
+
+  async getHealth(): Promise<DhtHealth | null> {
+    try {
+      const health = await invoke<DhtHealth | null>("get_dht_health");
+      return health;
+    } catch (error) {
+      console.error("Failed to get DHT health:", error);
+      return null;
     }
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -57,7 +57,15 @@
       "peerId": "Peer ID",
       "bootstrapNode": "Bootstrap Node",
       "recentEvents": "Recent Events",
-      "disconnect": "Disconnect from DHT"
+      "disconnect": "Disconnect from DHT",
+      "health": {
+        "lastBootstrap": "Last bootstrap",
+        "lastPeer": "Last peer event",
+        "lastError": "Last error",
+        "failures": "Bootstrap failures",
+        "never": "Never",
+        "none": "None recorded"
+      }
     },
     "networkStatus": "Network Status",
     "dhtPeers": "DHT Peers",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -57,7 +57,15 @@
       "peerId": "ID de par",
       "bootstrapNode": "Nodo bootstrap",
       "recentEvents": "Eventos recientes",
-      "disconnect": "Desconectar del DHT"
+      "disconnect": "Desconectar del DHT",
+      "health": {
+        "lastBootstrap": "Último arranque",
+        "lastPeer": "Último evento de par",
+        "lastError": "Último error",
+        "failures": "Intentos fallidos",
+        "never": "Nunca",
+        "none": "No registrado"
+      }
     },
     "networkStatus": "Estado de la red",
     "dhtPeers": "Pares DHT",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -57,7 +57,15 @@
       "peerId": "피어 ID",
       "bootstrapNode": "부트스트랩 노드",
       "recentEvents": "최근 이벤트",
-      "disconnect": "DHT에서 연결 끊기"
+      "disconnect": "DHT에서 연결 끊기",
+      "health": {
+        "lastBootstrap": "마지막 부트스트랩",
+        "lastPeer": "최근 피어 이벤트",
+        "lastError": "최근 오류",
+        "failures": "부트스트랩 실패 횟수",
+        "never": "없음",
+        "none": "기록 없음"
+      }
     },
     "networkStatus": "네트워크 상태",
     "dhtPeers": "DHT 피어",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -57,7 +57,15 @@
       "peerId": "节点ID",
       "bootstrapNode": "引导节点",
       "recentEvents": "最近事件",
-      "disconnect": "断开DHT"
+      "disconnect": "断开DHT",
+      "health": {
+        "lastBootstrap": "最近一次引导",
+        "lastPeer": "最近一次节点事件",
+        "lastError": "最近错误",
+        "failures": "引导失败次数",
+        "never": "从未",
+        "none": "无记录"
+      }
     },
     "networkStatus": "网络状态",
     "dhtPeers": "DHT节点",

--- a/src/pages/Network.svelte
+++ b/src/pages/Network.svelte
@@ -6,16 +6,19 @@
   import Label from '$lib/components/ui/label.svelte'
   import { Users, HardDrive, Activity, RefreshCw, UserPlus, Signal, Server, Play, Square, Download, AlertCircle, Wifi } from 'lucide-svelte'
   import { peers, networkStats, networkStatus, userLocation, etcAccount } from '$lib/stores'
+  import { get } from 'svelte/store'
   import { onMount, onDestroy } from 'svelte'
   import { invoke } from '@tauri-apps/api/core'
   import { listen } from '@tauri-apps/api/event'
   import { dhtService, DEFAULT_BOOTSTRAP_NODES } from '$lib/dht'
+  import type { DhtHealth } from '$lib/dht'
   import { Clipboard } from "lucide-svelte"
   import { t } from 'svelte-i18n';
   import { showToast } from '$lib/toast';
 
   // Check if running in Tauri environment
   const isTauri = typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window
+  const tr = (k: string, params?: Record<string, any>) => get(t)(k, params)
   
   let discoveryRunning = false
   let newPeerAddress = ''
@@ -61,6 +64,7 @@
   let dhtBootstrapNode = DEFAULT_BOOTSTRAP_NODES[0] || 'No bootstrap nodes configured'
   let dhtEvents: string[] = []
   let dhtPeerCount = 0
+  let dhtHealth: DhtHealth | null = null
   let dhtError: string | null = null
   let connectionAttempts = 0
   let dhtPollInterval: number | undefined
@@ -82,6 +86,15 @@
     }
     
     return `${size.toFixed(2)} ${units[unitIndex]}`
+  }
+
+  function formatHealthTimestamp(epoch: number | null): string {
+    if (!epoch) return tr('network.dht.health.never')
+    return new Date(epoch * 1000).toLocaleString()
+  }
+
+  function formatHealthMessage(value: string | null): string {
+    return value ?? tr('network.dht.health.none')
   }
   
   async function startDht() {
@@ -114,13 +127,20 @@
         dhtEvents = [...dhtEvents, `✓ DHT already running with peer ID: ${backendPeerId.slice(0, 16)}...`]
         
         // Check connection status immediately
-        const peerCount = await dhtService.getPeerCount()
-        dhtPeerCount = peerCount
-        
-        if (peerCount > 0) {
+        let currentPeers = 0
+        const health = await dhtService.getHealth()
+        if (health) {
+          dhtHealth = health
+          currentPeers = health.peerCount
+        } else {
+          currentPeers = await dhtService.getPeerCount()
+        }
+        dhtPeerCount = currentPeers
+
+        if (currentPeers > 0) {
           // Set status directly to connected without showing connecting first
           dhtStatus = 'connected'
-          dhtEvents = [...dhtEvents, `✓ Connected to ${peerCount} peer(s)`]
+          dhtEvents = [...dhtEvents, `✓ Connected to ${currentPeers} peer(s)`]
           startDhtPolling() // Start polling for updates
           return // Already connected, no need to continue
         } else {
@@ -240,6 +260,11 @@
       dhtStatus = connectionSuccessful ? 'connected' : 'disconnected'
       
       // Start polling for DHT events and peer count
+      const snapshot = await dhtService.getHealth()
+      if (snapshot) {
+        dhtHealth = snapshot
+        dhtPeerCount = snapshot.peerCount
+      }
       startDhtPolling()
     } catch (error: any) {
       console.error('Failed to start DHT:', error)
@@ -259,9 +284,17 @@
           dhtEvents = [...dhtEvents, ...events].slice(-10)
         }
         
-        const peerCount = await dhtService.getPeerCount()
-        dhtPeerCount = peerCount
-        
+        let peerCount = dhtPeerCount
+        const health = await dhtService.getHealth()
+        if (health) {
+          dhtHealth = health
+          peerCount = health.peerCount
+          dhtPeerCount = peerCount
+        } else {
+          peerCount = await dhtService.getPeerCount()
+          dhtPeerCount = peerCount
+        }
+
         // Update connection status based on peer count
         if (dhtStatus === 'connected' && peerCount === 0) {
           dhtStatus = 'disconnected'
@@ -282,6 +315,7 @@
       dhtPeerId = null
       dhtError = null
       connectionAttempts = 0
+      dhtHealth = null
       return
     }
     
@@ -292,6 +326,7 @@
       dhtError = null
       connectionAttempts = 0
       dhtEvents = [...dhtEvents, `✓ DHT stopped`]
+      dhtHealth = null
     } catch (error) {
       console.error('Failed to stop DHT:', error)
       dhtEvents = [...dhtEvents, `✗ Failed to stop DHT: ${error}`]
@@ -821,6 +856,30 @@
             </div>
             <p class="text-xs font-mono break-all">{dhtBootstrapNode}</p>
           </div>
+
+          {#if dhtHealth}
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-3 pt-3">
+              <div class="bg-muted/40 rounded-lg p-3">
+                <p class="text-xs uppercase text-muted-foreground">{$t('network.dht.health.lastBootstrap')}</p>
+                <p class="text-sm font-medium mt-1">{formatHealthTimestamp(dhtHealth.lastBootstrap)}</p>
+              </div>
+              <div class="bg-muted/40 rounded-lg p-3">
+                <p class="text-xs uppercase text-muted-foreground">{$t('network.dht.health.lastPeer')}</p>
+                <p class="text-sm font-medium mt-1">{formatHealthTimestamp(dhtHealth.lastPeerEvent)}</p>
+              </div>
+              <div class="bg-muted/40 rounded-lg p-3">
+                <p class="text-xs uppercase text-muted-foreground">{$t('network.dht.health.lastError')}</p>
+                <p class="text-sm font-medium mt-1">{formatHealthMessage(dhtHealth.lastError)}</p>
+                {#if dhtHealth.lastErrorAt}
+                  <p class="text-xs text-muted-foreground mt-1">{formatHealthTimestamp(dhtHealth.lastErrorAt)}</p>
+                {/if}
+              </div>
+              <div class="bg-muted/40 rounded-lg p-3">
+                <p class="text-xs uppercase text-muted-foreground">{$t('network.dht.health.failures')}</p>
+                <p class="text-sm font-medium mt-1">{dhtHealth.bootstrapFailures}</p>
+              </div>
+            </div>
+          {/if}
           
           {#if dhtEvents.length > 0}
             <div class="pt-2">

--- a/src/pages/Settings.svelte
+++ b/src/pages/Settings.svelte
@@ -96,6 +96,10 @@
   $: hasChanges = JSON.stringify(settings) !== JSON.stringify(savedSettings);
 
   function saveSettings() {
+    if (!isValid || maxStorageError) {
+      return;
+    }
+
     // Save to local storage
     localStorage.setItem("chiralSettings", JSON.stringify(settings));
     savedSettings = { ...settings };
@@ -283,7 +287,6 @@
       }
       next[key] = null;
     }
-    console.log(next);
     errors = next;
   }
 
@@ -291,6 +294,7 @@
   $: validate(settings);
 
   // Valid when no error messages remain
+  let isValid = true;
   $: isValid = Object.values(errors).every((e) => !e);
 
   let freeSpaceGB: number | null = null;
@@ -798,8 +802,8 @@
       <Button
         size="xs"
         on:click={saveSettings}
-        disabled={!hasChanges || !!maxStorageError}
-        class={`transition-colors duration-200 ${!hasChanges || !!maxStorageError ? "cursor-not-allowed opacity-50" : ""}`}
+        disabled={!hasChanges || !!maxStorageError || !isValid}
+        class={`transition-colors duration-200 ${!hasChanges || !!maxStorageError || !isValid ? "cursor-not-allowed opacity-50" : ""}`}
       >
         <Save class="h-4 w-4 mr-2" />
         {$t("actions.save")}


### PR DESCRIPTION


This PR improves DHT reliability and observability and tightens settings validation:

* **Health telemetry (backend + UI)** – exposes a lightweight snapshot so users can see when the node last bootstrapped, last peer activity, and recent errors/failures.
* **Graceful DHT shutdown** – avoids orphaned tasks and makes start/stop idempotent.
* **Default bootstraps in headless** – new nodes without config can still join.
* **Settings validation guard** – invalid values no longer persist.

These align with IPFS/Swarm good practices (robust bootstrapping; observable peer lifecycle) and the course goal of shipping small, incremental improvements.

---

### Changes

#### Backend (Rust / Tauri)

* **`get_dht_health` Tauri command** returns `DhtMetricsSnapshot` (peer count, timestamps for last bootstrap/peer-event/error, and recent bootstrap failure count).
* **Graceful stop**: `stop_dht_node` now awaits `dht.shutdown()` and clears state.
* **Headless defaults**: when no custom `--bootstrap` are provided, supply a safe default list (and avoid self-connecting on primary).
* Minor logging/formatting cleanups; no breaking API changes to existing commands.

#### Frontend (Svelte)

* **Network page**: new *DHT Health* card showing:

  * Last bootstrap, last peer event, last error (+ timestamp), and bootstrap failure count.
* **Settings page**: save button now disabled when inputs are invalid; early return on invalid state.
* **Locales**: i18n entries for the health labels (en/es/zh/ko).
* `lib/dht.ts`: adds `getHealth()` and `DhtHealth` type.

---

### User-facing behavior

* On connect, the health panel appears and updates during polling (same cadence as events/peer count).
* If the DHT is stopped, the health panel clears.
* Saving settings with invalid values is blocked (button disabled, validation messages remain inline).

---

### Files touched (summary)

* **Backend**: `src-tauri/src/main.rs`, `src-tauri/src/dht.rs` (health metrics plumbing), `src-tauri/src/headless.rs` (bootstrap defaults), small cleanups in `ethereum.rs`, `file_transfer.rs`, `keystore.rs`, `build.rs`.
* **Frontend**: `src/lib/dht.ts`, `src/pages/Network.svelte`, `src/pages/Settings.svelte`, `src/locales/*.json`.
* **Repo hygiene**: `.gitignore` now ignores local `.venv-pdf/`.

---

### How to test (manual steps)

* **DHT health shows up**

  1. Start DHT from Network page; expect health card to render.
  2. Verify *Last bootstrap* and *Last peer event* become non-“Never” after peers connect.
  3. Disconnect and reconnect; error/“failures” counters behave as expected on bad bootstraps.

* **Settings guard**

  1. Enter invalid values (e.g., malformed addresses) → **Save** stays disabled and values are not persisted.
  2. Fix inputs → **Save** enables and persists.

* **Headless defaults**

  1. Run headless without `--bootstrap`.
  2. Expect an info log that default bootstraps are used and the node joins without manual config.

