### PR TITLE
feat(webrtc): implement basic signaling server and test UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "chiral-network",
       "version": "0.1.0",
+      "license": "ISC",
       "dependencies": {
         "@mateothegreat/svelte5-router": "^2.16.19",
         "@tauri-apps/api": "^2.1.1",
@@ -22,7 +23,8 @@
         "svelte-i18n": "^4.0.1",
         "svelte-sonner": "^0.3.19",
         "tailwind-merge": "^2.5.5",
-        "tailwind-variants": "^0.3.0"
+        "tailwind-variants": "^0.3.0",
+        "ws": "^8.18.3"
       },
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^6.1.3",
@@ -4327,6 +4329,27 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "svelte-i18n": "^4.0.1",
     "svelte-sonner": "^0.3.19",
     "tailwind-merge": "^2.5.5",
-    "tailwind-variants": "^0.3.0"
+    "tailwind-variants": "^0.3.0",
+    "ws": "^8.18.3"
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^6.1.3",
@@ -42,5 +43,21 @@
     "tailwindcss": "^3.4.17",
     "typescript": "^5.7.0",
     "vite": "^7.1.4"
-  }
+  },
+  "description": "Chiral Network is a BitTorrent-like decentralized file sharing application designed for legitimate personal and organizational use. Built with Svelte, TypeScript, and Tauri, it provides a modern desktop experience for peer-to-peer file sharing focused on privacy, security, and efficient data distribution. The platform operates on a continuous seeding model where files are instantly available to the network once added, similar to BitTorrent's architecture.",
+  "main": "postcss.config.js",
+  "directories": {
+    "doc": "docs"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Aery1e/chiral-network.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/Aery1e/chiral-network/issues"
+  },
+  "homepage": "https://github.com/Aery1e/chiral-network#readme"
 }

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -18,6 +18,7 @@
     import { t } from 'svelte-i18n';
     import SimpleToast from './lib/components/SimpleToast.svelte';
     import { startNetworkMonitoring } from './lib/services/networkService';
+    import WebRTCSignallingTest from './lib/components/WebRTCSignallingTest.svelte'
     // gets path name not entire url:
     // ex: http://locatlhost:1420/download -> /download
     
@@ -97,6 +98,7 @@
         { id: 'proxy', label: $t('nav.proxy'), icon: Shield },
         { id: 'analytics', label: $t('nav.analytics'), icon: BarChart3 },
         { id: 'account', label: $t('nav.account'), icon: Wallet },
+        { id: 'webrtc-test', label: 'WebRTC Test (To be removed)', icon: Globe }, // Using Globe icon as placeholder
         { id: 'settings', label: $t('nav.settings'), icon: Settings },
       ]
     }
@@ -133,6 +135,10 @@
       {
         path: "account",
         component: AccountPage,
+      },
+      {
+        path: "webrtc-test",
+        component: WebRTCSignallingTest
       },
       {
         path: "settings",

--- a/src/lib/components/WebRTCSignallingTest.svelte
+++ b/src/lib/components/WebRTCSignallingTest.svelte
@@ -1,0 +1,78 @@
+<script lang="ts">
+    import { onMount, onDestroy } from 'svelte';
+    import { SignalingService } from '$lib/services/signallingService';
+
+    console.log("[WebRTCTest] Component initializing");
+    
+    let signaling: SignalingService;
+    let connected = false;
+    let peers: string[] = [];
+    let messages: string[] = [];
+
+    onMount(async () => {
+        try {
+            console.log("[WebRTCTest] Component mounted");
+            signaling = new SignalingService("ws://localhost:3000");
+            
+            // Subscribe to peers updates before connecting
+            signaling.peers.subscribe(value => {
+                console.log("[WebRTCTest] Peers updated:", value);
+                peers = value;
+            });
+
+            signaling.connected.subscribe(value => {
+                console.log("[WebRTCTest] Connection state:", value);
+                connected = value;
+            });
+            
+            console.log("[WebRTCTest] Connecting to signaling server...");
+            await signaling.connect();
+        } catch (err) {
+            console.error("[WebRTCTest] Connection failed:", err);
+            connected = false;
+        }
+    });
+    
+    onDestroy(() => {
+        console.log("[WebRTCTest] Component destroying");
+        signaling?.disconnect();
+    });
+
+    function connectToPeer(peerId: string) {
+        console.log("[WebRTCTest] Attempting to connect to peer:", peerId);
+        // TODO: Implement peer connection
+    }
+</script>
+
+<div class="p-4">
+    <h1 class="text-xl mb-4">WebRTC Test</h1>
+    
+    <div class="mb-4 p-2 border rounded">
+        Connection Status: {connected ? 'Connected' : 'Disconnected'}
+    </div>
+
+    <div class="mb-4">
+        <h2 class="text-lg mb-2">Connected Peers:</h2>
+        <ul class="list-disc pl-5">
+            {#each peers as peer}
+                <li class="mb-2">
+                    {peer}
+                    <button 
+                        class="ml-2 px-2 py-1 bg-blue-500 text-white rounded"
+                        on:click={() => connectToPeer(peer)}>
+                        Connect
+                    </button>
+                </li>
+            {/each}
+        </ul>
+    </div>
+
+    <div>
+        <h2 class="text-lg mb-2">Messages:</h2>
+        <div class="border p-2 h-40 overflow-y-auto">
+            {#each messages as message}
+                <div class="mb-1">{message}</div>
+            {/each}
+        </div>
+    </div>
+</div>

--- a/src/lib/services/package.json
+++ b/src/lib/services/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "services",
+  "version": "1.0.0",
+  "main": "signallingServer.js",
+  "dependencies": {
+    "ws": "^8.18.3"
+  },
+  "devDependencies": {},
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": ""
+}

--- a/src/lib/services/server/package-lock.json
+++ b/src/lib/services/server/package-lock.json
@@ -1,0 +1,38 @@
+{
+  "name": "server",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "server",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "ws": "^8.18.3"
+      },
+      "devDependencies": {}
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/src/lib/services/server/package.json
+++ b/src/lib/services/server/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "server",
+  "version": "1.0.0",
+  "main": "signallingServer.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "ws": "^8.18.3"
+  },
+  "description": ""
+}

--- a/src/lib/services/server/signalingServer.js
+++ b/src/lib/services/server/signalingServer.js
@@ -1,0 +1,53 @@
+const WebSocket = require('ws');
+
+const wss = new WebSocket.Server({ port: 3000 });
+const clients = new Map();
+
+wss.on('connection', (ws) => {
+  console.log('New client connected');
+
+  ws.on('message', (message) => {
+    const data = JSON.parse(message);
+    console.log('Received:', data);
+    
+    if (data.type === 'register') {
+      clients.set(data.clientId, ws);
+      console.log(`Client registered: ${data.clientId}`);
+      broadcastPeers();
+      return;
+    }
+
+    const targetWs = clients.get(data.to);
+    if (targetWs) {
+      console.log(`Forwarding message to: ${data.to}`);
+      targetWs.send(JSON.stringify(data));
+    }
+  });
+
+  ws.on('close', () => {
+    for (const [clientId, client] of clients.entries()) {
+      if (client === ws) {
+        console.log(`Client disconnected: ${clientId}`);
+        clients.delete(clientId);
+        break;
+      }
+    }
+    broadcastPeers();
+  });
+});
+
+function broadcastPeers() {
+  const peerList = Array.from(clients.keys());
+  console.log('Current peers:', peerList);
+  
+  const message = JSON.stringify({
+    type: 'peers',
+    peers: peerList
+  });
+  
+  for (const client of clients.values()) {
+    client.send(message);
+  }
+}
+
+console.log('Signaling server running on ws://localhost:3000');

--- a/src/lib/services/signallingService.ts
+++ b/src/lib/services/signallingService.ts
@@ -1,0 +1,64 @@
+import { writable, type Writable } from "svelte/store";
+
+export class SignalingService {
+  private ws: WebSocket | null = null;
+  private clientId: string;
+  
+  public connected: Writable<boolean> = writable(false);
+  public peers: Writable<string[]> = writable([]);
+
+  constructor(private url: string = "ws://localhost:3000") {
+    this.clientId = crypto.randomUUID();
+  }
+
+  async connect(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      try {
+        console.log("[SignalingService] Initializing connection to:", this.url);
+        console.log("[SignalingService] Client ID:", this.clientId);
+        
+        this.ws = new WebSocket(this.url);
+        
+        this.ws.onopen = () => {
+          console.log("[SignalingService] WebSocket connection established");
+          this.connected.set(true);
+          const msg = { type: "register", clientId: this.clientId };
+          console.log("[SignalingService] Sending register message:", msg);
+          this.ws?.send(JSON.stringify(msg));
+          resolve();
+        };
+
+        this.ws.onmessage = (event) => {
+          console.log("[SignalingService] Received message:", event.data);
+          const message = JSON.parse(event.data);
+          
+          if (message.type === "peers") {
+            this.peers.set(message.peers);
+          }
+        };
+
+        this.ws.onclose = () => {
+          console.log("[SignalingService] WebSocket connection closed");
+          this.connected.set(false);
+          this.peers.set([]);
+        };
+
+        this.ws.onerror = (error) => {
+          console.error("[SignalingService] WebSocket error:", error);
+          reject(error);
+        };
+
+      } catch (error) {
+        console.error("[SignalingService] Connection failed:", error);
+        reject(error);
+      }
+    });
+  }
+
+  disconnect(): void {
+    this.ws?.close();
+    this.ws = null;
+    this.connected.set(false);
+    this.peers.set([]);
+  }
+}


### PR DESCRIPTION
### Changes
- Add WebRTC signaling server implementation with WebSocket
- Implement WebRTC test UI component with peer list
- Add real-time connection status monitoring
- Integrate signaling service with main application router

### Technical Details
- Implement `SignalingService` class for WebSocket management
- Add `WebRTCSignallingTest` component for testing connections
- Add WebSocket server for peer discovery and signaling
- Update router configuration to include WebRTC test route

### Testing Instructions
1. Start signaling server:
```bash
cd src/lib/services/server
node signalingServer.js
```

2. In a different console: 
```bash 
npm run dev
```

3. Navigate to WebRTC Test Page and open in multiple windows to test peer discovery

Related Issues
Implements first phase of WebRTC P2P functionality
Foundation for future file transfer implementation