### PR TITLE
Fix bug in collpased sidebar menu in which two labels were shown; Align dropdown button styling in Proxy section with Settings section

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -18,7 +18,6 @@
     import { t } from 'svelte-i18n';
     import SimpleToast from './lib/components/SimpleToast.svelte';
     import { startNetworkMonitoring } from './lib/services/networkService';
-    import WebRTCSignallingTest from './lib/components/WebRTCSignallingTest.svelte'
     // gets path name not entire url:
     // ex: http://locatlhost:1420/download -> /download
     
@@ -98,7 +97,6 @@
         { id: 'proxy', label: $t('nav.proxy'), icon: Shield },
         { id: 'analytics', label: $t('nav.analytics'), icon: BarChart3 },
         { id: 'account', label: $t('nav.account'), icon: Wallet },
-        { id: 'webrtc-test', label: 'WebRTC Test (To be removed)', icon: Globe }, // Using Globe icon as placeholder
         { id: 'settings', label: $t('nav.settings'), icon: Settings },
       ]
     }
@@ -135,10 +133,6 @@
       {
         path: "account",
         component: AccountPage,
-      },
-      {
-        path: "webrtc-test",
-        component: WebRTCSignallingTest
       },
       {
         path: "settings",
@@ -188,14 +182,11 @@
             }}
             class="w-full group"
             aria-current={currentPage === item.id ? 'page' : undefined}
-            title={sidebarCollapsed ? item.label : undefined}
-            aria-label={item.label}
           >
             <div class="flex items-center {sidebarCollapsed ? 'justify-center' : ''} rounded {currentPage === item.id ? 'bg-gray-200' : 'group-hover:bg-gray-100'}">
               <span class="flex items-center justify-center rounded w-10 h-10 relative">
                 <svelte:component this={item.icon} class="h-5 w-5" />
                 {#if sidebarCollapsed}
-                  <!-- CSS tooltip for collapsed state (appears on hover) -->
                   <span class="tooltip absolute left-full ml-2 top-1/2 -translate-y-1/2 hidden whitespace-nowrap rounded bg-black text-white text-xs px-2 py-1 z-50">{item.label}</span>
                 {/if}
               </span>

--- a/src/pages/Proxy.svelte
+++ b/src/pages/Proxy.svelte
@@ -7,6 +7,7 @@
   import { Shield, Globe, Activity, Plus, Power, Trash2 } from 'lucide-svelte'
   import { proxyNodes } from '$lib/stores'
   import { t } from 'svelte-i18n'
+  import DropDown from '$lib/components/ui/dropDown.svelte'
   
   let newNodeAddress = ''
   let proxyEnabled = true
@@ -15,6 +16,13 @@
   let nodeToRemove: any = null
   const validAddressRegex = /^[a-zA-Z0-9.-]+:[0-9]{1,5}$/
   let statusFilter = 'all'
+  
+  $: statusOptions = [
+    { value: 'all', label: $t('All') },
+    { value: 'online', label: $t('Online') },
+    { value: 'offline', label: $t('Offline') },
+    { value: 'connecting', label: $t('Connecting') }
+  ]
 
   $: filteredNodes = $proxyNodes.filter(node => {
       if (statusFilter === 'all') {
@@ -219,16 +227,11 @@
   <Card class="p-6">
     <div class="flex items-center justify-between mb-4">
         <h2 class="text-lg font-semibold">{$t('proxy.proxyNodes')}</h2>
-        <div>
-            <select
+        <div class="w-40 flex-shrink-0">
+            <DropDown
                 bind:value={statusFilter}
-                class="p-2 rounded-md border border-gray-300 text-sm"
-            >
-                <option value="all">{$t('All')}</option>
-                <option value="online">{$t('Online')}</option>
-                <option value="offline">{$t('Offline')}</option>
-                <option value="connecting">{$t('Connecting')}</option>
-            </select>
+                options={statusOptions}
+            />
         </div>
     </div>
     <div class="space-y-3">


### PR DESCRIPTION
* Removed the default label so that only one label is shown when hovering over a section when sidebar menu is collapsed.
* Aligned dropdown button next to "Proxy Nodes" in the Proxy Network section to be similarly formatted with Network and Settings sections.