### PR TITLE
fix(dht): headless and bootstrap node

### DIFF
--- a/src-tauri/src/dht.rs
+++ b/src-tauri/src/dht.rs
@@ -390,9 +390,21 @@ impl DhtService {
     pub async fn new(
         port: u16,
         bootstrap_nodes: Vec<String>,
+        secret: Option<String>,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         // Generate a new keypair for this node
-        let local_key = identity::Keypair::generate_ed25519();
+        // Generate a keypair either from the secret or randomly
+        let local_key = match secret {
+            Some(secret_str) => {
+                let secret_bytes = secret_str.as_bytes();
+                let mut seed = [0u8; 32];
+                for (i, &b) in secret_bytes.iter().take(32).enumerate() {
+                    seed[i] = b;
+                }
+                identity::Keypair::ed25519_from_bytes(seed)?
+            }
+            None => identity::Keypair::generate_ed25519(),
+        };
         let local_peer_id = PeerId::from(local_key.public());
         let peer_id_str = local_peer_id.to_string();
 

--- a/src-tauri/src/headless.rs
+++ b/src-tauri/src/headless.rs
@@ -40,14 +40,13 @@ pub struct CliArgs {
     /// Generate multiaddr for this node (shows the address others can connect to)
     #[arg(long)]
     pub show_multiaddr: bool,
+
+    // Generate consistent peerid
+    #[arg(long)]
+    pub secret: Option<String>,
 }
 
 pub async fn run_headless(args: CliArgs) -> Result<(), Box<dyn std::error::Error>> {
-    // Initialize logging
-    tracing_subscriber::fmt()
-        .with_env_filter(args.log_level)
-        .init();
-
     info!("Starting Chiral Network in headless mode");
     info!("DHT Port: {}", args.dht_port);
 
@@ -57,14 +56,14 @@ pub async fn run_headless(args: CliArgs) -> Result<(), Box<dyn std::error::Error
     if !provided_bootstrap {
         // Use reliable IP-based bootstrap nodes so fresh nodes can join the mesh
         bootstrap_nodes.extend([
-            "/ip4/104.131.131.82/tcp/4001/p2p/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ"
+            "/ip4/54.198.145.146/tcp/4001/p2p/12D3KooWNHdYWRTe98KMF1cDXXqGXvNjd1SAchDaeP5o4MsoJLu2"
                 .to_string(),
         ]);
         info!("Using default bootstrap nodes: {:?}", bootstrap_nodes);
     }
 
     // Start DHT node
-    let dht_service = DhtService::new(args.dht_port, bootstrap_nodes.clone()).await?;
+    let dht_service = DhtService::new(args.dht_port, bootstrap_nodes.clone(), args.secret).await?;
     let peer_id = dht_service.get_peer_id().await;
 
     // Start the DHT running in background

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -317,7 +317,7 @@ async fn start_dht_node(
         }
     }
 
-    let dht_service = DhtService::new(port, bootstrap_nodes)
+    let dht_service = DhtService::new(port, bootstrap_nodes, None)
         .await
         .map_err(|e| format!("Failed to start DHT: {}", e))?;
 

--- a/src/lib/dht.ts
+++ b/src/lib/dht.ts
@@ -3,7 +3,7 @@ import { invoke } from "@tauri-apps/api/core";
 
 // Default bootstrap nodes for network connectivity
 export const DEFAULT_BOOTSTRAP_NODES = [
-  "/ip4/104.131.131.82/tcp/4001/p2p/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ",
+  "/ip4/54.198.145.146/tcp/4001/p2p/12D3KooWNHdYWRTe98KMF1cDXXqGXvNjd1SAchDaeP5o4MsoJLu2",
 ];
 
 export interface DhtConfig {


### PR DESCRIPTION
- fixed bootstrap not really working by adding a bootstrap node that understands chiral/1.0.0 protocol hosted on AWS
- fixed headless mode not able to start by removing duplicate logging initialization
- added `secret` cli argument to derive consistent ed25519 key  from secret so bootstrap server has consistent peer_id

(on 3 devices, 2 on stony network and 1 not on stony network,  with the new bootstrap node)
<img width="564" height="637" alt="image" src="https://github.com/user-attachments/assets/8a2b6937-f311-4f55-814c-7523f79e5567" />
