### PR TITLE
fix(ui): reset DHT retry label after successful connect

### DIFF
--- a/src/lib/dhtHelpers.d.ts
+++ b/src/lib/dhtHelpers.d.ts
@@ -1,0 +1,1 @@
+export declare function resetConnectionAttempts(attempts: number, connectionSuccessful: boolean): number;

--- a/src/lib/dhtHelpers.js
+++ b/src/lib/dhtHelpers.js
@@ -1,0 +1,10 @@
+/**
+ * Reset the tracked number of DHT connection attempts when a connection succeeds.
+ * Keeps the prior attempt count when we stay disconnected so the UI can show retries.
+ * @param {number} attempts
+ * @param {boolean} connectionSuccessful
+ * @returns {number}
+ */
+export function resetConnectionAttempts(attempts, connectionSuccessful) {
+  return connectionSuccessful ? 0 : attempts;
+}

--- a/src/pages/Network.svelte
+++ b/src/pages/Network.svelte
@@ -11,6 +11,7 @@
   import { invoke } from '@tauri-apps/api/core'
   import { listen } from '@tauri-apps/api/event'
   import { dhtService, DEFAULT_BOOTSTRAP_NODES } from '$lib/dht'
+  import { resetConnectionAttempts } from '$lib/dhtHelpers.js'
   import type { DhtHealth } from '$lib/dht'
   import { Clipboard } from "lucide-svelte"
   import { t } from 'svelte-i18n';
@@ -259,6 +260,7 @@
       
       // Set status based on connection result
       dhtStatus = connectionSuccessful ? 'connected' : 'disconnected'
+      connectionAttempts = resetConnectionAttempts(connectionAttempts, connectionSuccessful)
       
       // Start polling for DHT events and peer count
       const snapshot = await dhtService.getHealth()

--- a/tests/dhtHelpers.test.mjs
+++ b/tests/dhtHelpers.test.mjs
@@ -1,0 +1,13 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { resetConnectionAttempts } from '../src/lib/dhtHelpers.js';
+
+test('resetConnectionAttempts returns zero on success', () => {
+  const result = resetConnectionAttempts(5, true);
+  assert.equal(result, 0);
+});
+
+test('resetConnectionAttempts keeps attempts on failure', () => {
+  const result = resetConnectionAttempts(3, false);
+  assert.equal(result, 3);
+});


### PR DESCRIPTION
## Summary
Prevents the Network page from continuing to show a “Retry” state after a successful DHT connect by resetting the attempts counter.

## How to test (manual)
1) Start the desktop app, go to Network → DHT.
2) Connect once; after success the button label should revert to “Connect to DHT Network” and attempts reset to 0.
3) Disconnect and reconnect to confirm the behavior is consistent.

## Quick local test (optional)
- `node --test tests/dhtHelpers.test.mjs`

## Acceptance checklist
- [ ] UI no longer shows “Retry” after a successful connection.
- [ ] No regression in DHT health polling or status display.
- [ ] i18n unaffected (no new strings introduced here).
- [ ] No unrelated file changes.
