### PR TITLE
feat(network): surface DHT listen addresses

### DIFF
--- a/src/lib/dht.ts
+++ b/src/lib/dht.ts
@@ -28,6 +28,7 @@ export interface DhtHealth {
   lastError: string | null;
   lastErrorAt: number | null;
   bootstrapFailures: number;
+  listenAddrs: string[];
 }
 
 export class DhtService {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -56,6 +56,8 @@
       "peers": "Connected Peers",
       "peerId": "Peer ID",
       "bootstrapNode": "Bootstrap Node",
+      "listenAddresses": "Listening Addresses",
+      "noListenAddresses": "No listening addresses yet",
       "recentEvents": "Recent Events",
       "disconnect": "Disconnect from DHT",
       "health": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -56,6 +56,8 @@
       "peers": "Pares conectados",
       "peerId": "ID de par",
       "bootstrapNode": "Nodo bootstrap",
+      "listenAddresses": "Direcciones de escucha",
+      "noListenAddresses": "Sin direcciones de escucha aún",
       "recentEvents": "Eventos recientes",
       "disconnect": "Desconectar del DHT",
       "health": {

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -56,6 +56,8 @@
       "peers": "연결된 피어",
       "peerId": "피어 ID",
       "bootstrapNode": "부트스트랩 노드",
+      "listenAddresses": "리스닝 주소",
+      "noListenAddresses": "아직 리스닝 주소가 없습니다",
       "recentEvents": "최근 이벤트",
       "disconnect": "DHT에서 연결 끊기",
       "health": {

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -56,6 +56,8 @@
       "peers": "已连接节点",
       "peerId": "节点ID",
       "bootstrapNode": "引导节点",
+      "listenAddresses": "监听地址",
+      "noListenAddresses": "暂无监听地址",
       "recentEvents": "最近事件",
       "disconnect": "断开DHT",
       "health": {

--- a/src/pages/Network.svelte
+++ b/src/pages/Network.svelte
@@ -75,6 +75,7 @@
   let copiedNodeAddr = false
   let copiedPeerId = false
   let copiedBootstrap = false
+  let copiedListenAddr: string | null = null
 
   function formatSize(bytes: number): string {
     const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB']
@@ -344,6 +345,7 @@
       dhtError = null
       connectionAttempts = 0
       dhtHealth = null
+      copiedListenAddr = null
       return
     }
     
@@ -355,6 +357,7 @@
       connectionAttempts = 0
       dhtEvents = [...dhtEvents, `✓ DHT stopped`]
       dhtHealth = null
+      copiedListenAddr = null
     } catch (error) {
       console.error('Failed to stop DHT:', error)
       dhtEvents = [...dhtEvents, `✗ Failed to stop DHT: ${error}`]
@@ -891,6 +894,36 @@
             </div>
             <p class="text-xs font-mono break-all">{dhtBootstrapNode}</p>
           </div>
+
+          {#if dhtHealth?.listenAddrs && dhtHealth.listenAddrs.length > 0}
+            <div class="pt-2 space-y-2">
+              <p class="text-sm text-muted-foreground">{$t('network.dht.listenAddresses')}</p>
+              {#each dhtHealth.listenAddrs as addr}
+                <div class="bg-muted/40 rounded-lg px-3 py-2">
+                  <div class="flex items-start justify-between gap-2">
+                    <p class="text-xs font-mono break-all flex-1">{addr}</p>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      class="h-7 px-2 flex-shrink-0"
+                      on:click={async () => {
+                        await copy(addr)
+                        copiedListenAddr = addr
+                        setTimeout(() => (copiedListenAddr = null), 1200)
+                      }}
+                    >
+                      <Clipboard class="h-3.5 w-3.5 mr-1" />
+                      {copiedListenAddr === addr ? $t('network.copied') : $t('network.copy')}
+                    </Button>
+                  </div>
+                </div>
+              {/each}
+            </div>
+          {:else if dhtStatus === 'connected'}
+            <div class="pt-2">
+              <p class="text-xs text-muted-foreground">{$t('network.dht.noListenAddresses')}</p>
+            </div>
+          {/if}
 
           {#if dhtHealth}
             <div class="grid grid-cols-1 md:grid-cols-2 gap-3 pt-3">


### PR DESCRIPTION
## Summary
Expose the node’s live listen multiaddrs in DHT health and render them on Network → DHT with copy actions. This helps verify port configuration and advertised endpoints, especially with multi-instance setups and user-configurable `dhtPort`.
