### PR TITLE
feat(upload): skip duplicate shared files

### DIFF
--- a/src/lib/uploadHelpers.d.ts
+++ b/src/lib/uploadHelpers.d.ts
@@ -1,0 +1,5 @@
+export interface HashedFileLike {
+  hash?: string;
+}
+
+export declare function isDuplicateHash(files: HashedFileLike[] | undefined | null, hash: string): boolean;

--- a/src/lib/uploadHelpers.js
+++ b/src/lib/uploadHelpers.js
@@ -1,0 +1,13 @@
+/**
+ * Returns true when the provided hash already exists in the list of files.
+ * The check is hash-based so duplicate filenames with different content are allowed.
+ *
+ * @param {Array<{hash?: string}>} files
+ * @param {string} hash
+ */
+export function isDuplicateHash(files, hash) {
+  if (!Array.isArray(files) || typeof hash !== 'string' || hash.length === 0) {
+    return false;
+  }
+  return files.some((file) => file && typeof file.hash === 'string' && file.hash === hash);
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -590,7 +590,9 @@
     "hashCopied": "Hash copied!",
     "stopSharing": "Stop sharing",
     "noFilesShared": "No files shared yet",
-    "addFilesHint2": "Add files to start sharing on the network"
+    "addFilesHint2": "Add files to start sharing on the network",
+    "duplicateSkipped": "{count, plural, one {Already sharing this file. Skipped duplicate.} other {Skipped {count} duplicate files.}}",
+    "filesAdded": "{count, plural, one {Added 1 file to sharing list.} other {Added {count} files to sharing list.}}"
   },
   "download": {
     "title": "Download Files",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -582,7 +582,9 @@
     "hashCopied": "¡Hash copiado!",
     "stopSharing": "Dejar de compartir",
     "noFilesShared": "Aún no hay archivos compartidos",
-    "addFilesHint2": "Agrega archivos para empezar a compartir en la red"
+    "addFilesHint2": "Agrega archivos para empezar a compartir en la red",
+    "duplicateSkipped": "{count, plural, one {Este archivo ya se está compartiendo. Duplicado omitido.} other {Se omitieron {count} archivos duplicados.}}",
+    "filesAdded": "{count, plural, one {Se agregó 1 archivo a la lista de compartidos.} other {Se agregaron {count} archivos a la lista de compartidos.}}"
   },
   "download": {
     "title": "Descargar archivos",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -597,7 +597,9 @@
     "hashCopied": "해시 복사됨!",
     "stopSharing": "공유 중지",
     "noFilesShared": "아직 공유된 파일이 없습니다",
-    "addFilesHint2": "네트워크에서 공유를 시작하려면 파일을 추가하세요"
+    "addFilesHint2": "네트워크에서 공유를 시작하려면 파일을 추가하세요",
+    "duplicateSkipped": "{count, plural, one {이미 공유 중인 파일입니다. 중복 항목을 건너뛰었습니다.} other {중복 파일 {count}개를 건너뛰었습니다.}}",
+    "filesAdded": "{count, plural, one {공유 목록에 파일 1개를 추가했습니다.} other {공유 목록에 파일 {count}개를 추가했습니다.}}"
   },
   "download": {
     "title": "파일 다운로드",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -589,7 +589,9 @@
     "hashCopied": "哈希已复制！",
     "stopSharing": "停止分享",
     "noFilesShared": "尚无已分享文件",
-    "addFilesHint2": "添加文件以开始在网络中分享"
+    "addFilesHint2": "添加文件以开始在网络中分享",
+    "duplicateSkipped": "{count, plural, one {该文件已在分享列表中，已跳过重复项。} other {已跳过 {count} 个重复文件。}}",
+    "filesAdded": "{count, plural, one {已将 1 个文件添加到分享列表。} other {已将 {count} 个文件添加到分享列表。}}"
   },
   "download": {
     "title": "下载文件",

--- a/tests/uploadHelpers.test.mjs
+++ b/tests/uploadHelpers.test.mjs
@@ -1,0 +1,23 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { isDuplicateHash } from '../src/lib/uploadHelpers.js';
+
+test('isDuplicateHash returns false when list empty', () => {
+  assert.equal(isDuplicateHash([], 'abc'), false);
+});
+
+test('isDuplicateHash handles missing hash values', () => {
+  const files = [{ id: '1' }, { id: '2', hash: 'xyz' }];
+  assert.equal(isDuplicateHash(files, 'xyz'), true);
+  assert.equal(isDuplicateHash(files, 'abc'), false);
+});
+
+test('isDuplicateHash ignores non-array inputs', () => {
+  assert.equal(isDuplicateHash(undefined, 'abc'), false);
+  assert.equal(isDuplicateHash(null, 'abc'), false);
+});
+
+test('isDuplicateHash ignores empty hash', () => {
+  const files = [{ hash: 'value' }];
+  assert.equal(isDuplicateHash(files, ''), false);
+});


### PR DESCRIPTION
## Summary
  - prevent duplicate shared files by hashing each selection and
  skipping hashes that already exist
  - surface localized toasts notifying the user when files are added
  vs. ignored as duplicates
  - add a small helper + node-based tests to keep the dedupe logic
  covered

  ## Testing
  - node --test tests/uploadHelpers.test.mjs

  1. Open the Upload page.
  2. Click “Add Files” and select `file-A.txt`; observe success toast.
  3. Click “Add Files” again, choose the same `file-A.txt`; observe
  the duplicate warning toast and confirm the list still shows one
  entry.
  4. (Optional) Add two different files at once to see the plural
  success message.