### PR TITLE
feat: chunk encryption with the recipient's public key

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,6 +26,8 @@ hex = "0.4"
 sha3 = "0.10"
 sha2 = "0.10"
 aes-gcm = "0.10"
+x25519-dalek = { version = "2.0", features = ["serde"] }
+hkdf = "0.12"
 pbkdf2 = "0.12"
 aes = "0.8"
 ctr = "0.9"

--- a/src-tauri/crypto.rs
+++ b/src-tauri/crypto.rs
@@ -1,0 +1,103 @@
+use aes_gcm::{
+    aead::{Aead, OsRng},
+    Aes256Gcm, KeyInit, Nonce,
+};
+use hkdf::Hkdf;
+use serde::{Deserialize, Serialize};
+use sha2::Sha256;
+use x25519_dalek::{EphemeralSecret, PublicKey};
+
+/// A bundle containing the encrypted AES key and the necessary data for decryption.
+/// This struct is designed to be serialized (e.g., to JSON) and stored as file metadata.
+#[derive(Serialize, Deserialize, Debug)]
+pub struct EncryptedAesKeyBundle {
+    /// The sender's temporary public key (32 bytes), hex-encoded.
+    pub ephemeral_public_key: String,
+    /// The AES key, encrypted and then hex-encoded.
+    pub encrypted_key: String,
+    /// The nonce used for AES-GCM encryption (12 bytes), hex-encoded.
+    pub nonce: String,
+}
+
+/// Encrypts a 32-byte AES key using the recipient's public key (ECIES pattern).
+///
+/// # Arguments
+/// * `aes_key_to_encrypt` - The 32-byte AES key for file chunks (the DEK).
+/// * `recipient_public_key` - The recipient's X25519 public key.
+///
+/// # Returns
+/// An `EncryptedAesKeyBundle` struct containing the data needed for decryption.
+pub fn encrypt_aes_key(
+    aes_key_to_encrypt: &[u8; 32],
+    recipient_public_key: &PublicKey,
+) -> Result<EncryptedAesKeyBundle, String> {
+    // 1. Generate a temporary (ephemeral) X25519 key pair for the sender.
+    let ephemeral_secret = EphemeralSecret::random_from_rng(OsRng);
+    let ephemeral_public_key = PublicKey::from(&ephemeral_secret);
+
+    // 2. Compute the shared secret.
+    let shared_secret = ephemeral_secret.diffie_hellman(recipient_public_key);
+
+    // 3. Use HKDF to derive a Key Encryption Key (KEK) from the shared secret.
+    let hk = Hkdf::<Sha256>::new(Some(ephemeral_public_key.as_bytes()), shared_secret.as_bytes());
+    let mut kek = [0u8; 32]; // 32 bytes for an AES-256 key
+    hk.expand(b"chiral-network-kek", &mut kek)
+        .map_err(|e| format!("HKDF expansion failed: {}", e))?;
+
+    // 4. Encrypt the AES key (DEK) with the derived KEK.
+    let kek_cipher = Aes256Gcm::new_from_slice(&kek).map_err(|e| e.to_string())?;
+    let nonce = Aes256Gcm::generate_nonce(&mut OsRng); // Generate a random nonce
+    let encrypted_key = kek_cipher
+        .encrypt(&nonce, aes_key_to_encrypt.as_ref())
+        .map_err(|e| format!("AES key encryption failed: {}", e))?;
+
+    // 5. Return the bundle with hex-encoded data for easy serialization.
+    Ok(EncryptedAesKeyBundle {
+        ephemeral_public_key: hex::encode(ephemeral_public_key.as_bytes()),
+        encrypted_key: hex::encode(encrypted_key),
+        nonce: hex::encode(nonce.as_slice()),
+    })
+}
+
+/// Decrypts an AES key using the recipient's private key.
+///
+/// # Arguments
+/// * `encrypted_bundle` - The `EncryptedAesKeyBundle` received from the sender.
+/// * `recipient_secret_key` - The recipient's X25519 private key.
+///
+/// # Returns
+/// The decrypted 32-byte AES key.
+pub fn decrypt_aes_key(
+    encrypted_bundle: &EncryptedAesKeyBundle,
+    recipient_secret_key: &EphemeralSecret,
+) -> Result<[u8; 32], String> {
+    // 1. Decode hex-encoded data from the bundle.
+    let ephemeral_public_key_bytes: [u8; 32] = hex::decode(&encrypted_bundle.ephemeral_public_key)
+        .map_err(|e| e.to_string())?
+        .try_into()
+        .map_err(|_| "Invalid ephemeral public key length".to_string())?;
+    let ephemeral_public_key = PublicKey::from(ephemeral_public_key_bytes);
+
+    let encrypted_key = hex::decode(&encrypted_bundle.encrypted_key).map_err(|e| e.to_string())?;
+    let nonce_bytes = hex::decode(&encrypted_bundle.nonce).map_err(|e| e.to_string())?;
+
+    // 2. Compute the same shared secret.
+    let shared_secret = recipient_secret_key.diffie_hellman(&ephemeral_public_key);
+
+    // 3. Derive the same KEK using the same HKDF parameters.
+    let hk = Hkdf::<Sha256>::new(Some(ephemeral_public_key.as_bytes()), shared_secret.as_bytes());
+    let mut kek = [0u8; 32];
+    hk.expand(b"chiral-network-kek", &mut kek)
+        .map_err(|e| format!("HKDF expansion failed: {}", e))?;
+
+    // 4. Decrypt the AES key (DEK) with the derived KEK.
+    let kek_cipher = Aes256Gcm::new_from_slice(&kek).map_err(|e| e.to_string())?;
+    let nonce = Nonce::from_slice(&nonce_bytes);
+    let decrypted_key_vec = kek_cipher
+        .decrypt(nonce, encrypted_key.as_ref())
+        .map_err(|e| format!("AES key decryption failed: {}", e))?;
+
+    decrypted_key_vec
+        .try_into()
+        .map_err(|_| "Decrypted key is not 32 bytes".to_string())
+}

--- a/src-tauri/src/manager.rs
+++ b/src-tauri/src/manager.rs
@@ -1,15 +1,18 @@
 use sha2::{Sha256, Digest};
 use aes_gcm::{Aes256Gcm, Key, Nonce, KeyInit};
-use aes_gcm::aead::{Aead};
-use std::fs::File;
+use aes_gcm::aead::{Aead, OsRng};
+use std::fs::{File, self};
 use std::io::{Read, Error, Write};
 use std::path::{Path, PathBuf};
-use rand::{RngCore, rngs::OsRng};
+use x25519_dalek::PublicKey;
 
+// Import the new crypto functions and the bundle struct
+use crate::crypto::{encrypt_aes_key, EncryptedAesKeyBundle};
+
+#[derive(serde::Serialize, serde::Deserialize, Debug)]
 pub struct ChunkInfo {
     pub index: u32,
-    pub hash: String,
-    pub nonce: Vec<u8>,
+    pub hash: String
     pub size: usize,
     pub encrypted_size: usize,
 }
@@ -27,49 +30,57 @@ impl ChunkManager {
         }
     }
 
-    pub fn chunk_file(&self, file_path: &Path) -> Result<(Vec<ChunkInfo>, Vec<u8>), Error> {
+    // The function now takes the recipient's public key and returns the encrypted key bundle
+    pub fn chunk_and_encrypt_file(
+        &self,
+        file_path: &Path,
+        recipient_public_key: &PublicKey,
+    ) -> Result<(Vec<ChunkInfo>, EncryptedAesKeyBundle), String> {
         let mut key_bytes = [0u8; 32];
         OsRng.fill_bytes(&mut key_bytes);
         let key = Key::<Aes256Gcm>::from_slice(&key_bytes);
 
-        let mut file = File::open(file_path)?;
+        let mut file = File::open(file_path).map_err(|e| e.to_string())?;
         let mut chunks = Vec::new();
         let mut buffer = vec![0u8; self.chunk_size];
         let mut index = 0;
 
         loop {
-            let bytes_read = file.read(&mut buffer)?;
+            let bytes_read = file.read(&mut buffer).map_err(|e| e.to_string())?;
             if bytes_read == 0 { break; }
 
             let chunk_data = &buffer[..bytes_read];
             let chunk_hash = self.hash_chunk(chunk_data);
             
-            let (encrypted_data, nonce) = self.encrypt_chunk(chunk_data, &key).map_err(|e| Error::new(std::io::ErrorKind::Other, e.to_string()))?;
+            // The nonce is now prepended to the ciphertext by `encrypt_chunk`
+            let encrypted_data_with_nonce = self.encrypt_chunk(chunk_data, &key)?;
 
             chunks.push(ChunkInfo {
                 index,
                 hash: chunk_hash.clone(),
-                nonce: nonce.clone(),
                 size: bytes_read,
-                encrypted_size: encrypted_data.len(),
+                encrypted_size: encrypted_data_with_nonce.len(),
             });
 
-            self.save_chunk(&chunk_hash, &nonce, &encrypted_data)?;
+            self.save_chunk(&chunk_hash, &encrypted_data_with_nonce).map_err(|e| e.to_string())?;
             index += 1;
         }
 
-        Ok((chunks, key_bytes.to_vec()))
+        // Instead of returning the raw key, encrypt it with the recipient's public key
+        let encrypted_key_bundle = encrypt_aes_key(&key_bytes, recipient_public_key)?;
+
+        Ok((chunks, encrypted_key_bundle))
     }
 
-    fn encrypt_chunk(&self, data: &[u8], key: &Key<Aes256Gcm>) -> Result<(Vec<u8>, Vec<u8>), aes_gcm::Error> {
+    // This function now returns the nonce and ciphertext combined for easier storage
+    fn encrypt_chunk(&self, data: &[u8], key: &Key<Aes256Gcm>) -> Result<Vec<u8>, String> {
         let cipher = Aes256Gcm::new(key);
-        
-        let mut nonce_bytes = [0u8; 12]; // Using 12-byte IV
-        OsRng.fill_bytes(&mut nonce_bytes);
-        let nonce = Nonce::from_slice(&nonce_bytes);
+        let nonce = Aes256Gcm::generate_nonce(&mut OsRng); // Generate a unique nonce for each chunk
 
-        let ciphertext = cipher.encrypt(nonce, data)?;
-        Ok((ciphertext, nonce_bytes.to_vec()))
+        let ciphertext = cipher.encrypt(&nonce, data).map_err(|e| e.to_string())?;
+        let mut result = nonce.to_vec();
+        result.extend_from_slice(&ciphertext);
+        Ok(result)
     }
 
     fn hash_chunk(&self, data: &[u8]) -> String {
@@ -78,13 +89,10 @@ impl ChunkManager {
         format!("{:x}", hasher.finalize())
     }
 
-    fn save_chunk(&self, hash: &str, nonce: &[u8], data: &[u8]) -> Result<(), Error> {
-        let mut path = self.storage_path.clone();
-        path.push(hash);
-        let mut file = File::create(path)?;
-        
-        file.write_all(nonce)?;
-        file.write_all(data)?;
+    // This function now saves the combined [nonce][ciphertext] blob
+    fn save_chunk(&self, hash: &str, data_with_nonce: &[u8]) -> Result<(), Error> {
+        fs::create_dir_all(&self.storage_path)?;
+        fs::write(self.storage_path.join(hash), data_with_nonce)?;
         Ok(())
     }
 
@@ -100,7 +108,6 @@ impl ChunkManager {
             }
             hasher.update(&buffer[..bytes_read]);
         }
-
         Ok(format!("{:x}", hasher.finalize()))
     }
 }


### PR DESCRIPTION
- crypto.rs implements a hybrid encryption scheme to securely encrypt a file's symmetric AES key using the recipient's X25519 public key. 
- Bundles the encrypted key with the necessary data for the recipient to decrypt it with their private key, ensuring end-to-end security for file transfers.
