### PR TITLE
fix(language): title error (translation keys unmatched the path) on d…

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -821,6 +821,7 @@ dependencies = [
  "fs2",
  "futures-util",
  "hex",
+ "hkdf",
  "hmac",
  "libp2p",
  "pbkdf2 0.12.2",
@@ -845,6 +846,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "x25519-dalek",
  "zip",
 ]
 
@@ -1150,6 +1152,7 @@ dependencies = [
  "digest",
  "fiat-crypto",
  "rustc_version",
+ "serde",
  "subtle",
  "zeroize",
 ]

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -108,7 +108,65 @@
         "downloadOnlyTauri": "Chiral Node download is only available in the desktop app. Please download and run the Tauri desktop version."
     }
   },
-
+  "download": {
+    "title": "Download Files",
+    "subtitle": "Download files from the Chiral Network",
+    "addNew": "Add New Download",
+    "addNewSubtitle": "Enter a file hash (e.g., Qm... or a magnet link) to start a new download.",
+    "placeholder": "Enter file hash or magnet link",
+    "clearInput": "Clear input",
+    "searchAndDownload": "Search & Download",
+    "downloads": "Downloads",
+    "searchPlaceholder": "Search your downloads...",
+    "clearSearch": "Clear search",
+    "filters": {
+      "all": "All",
+      "active": "Active",
+      "paused": "Paused",
+      "queued": "Queued",
+      "completed": "Completed",
+      "canceled": "Canceled",
+      "failed": "Failed"
+    },
+    "settings": {
+      "maxConcurrent": "Max Concurrent",
+      "autoStart": "Auto-start",
+      "toggleAutoStart": "Toggle auto-start {status}"
+    },
+    "status": {
+      "noDownloads": "You haven't started any downloads yet.",
+      "noActive": "No active downloads.",
+      "noPaused": "No paused downloads.",
+      "noQueued": "No downloads in the queue.",
+      "noCompleted": "No completed downloads.",
+      "noFailed": "No failed downloads."
+    },
+    "file": {
+      "hash": "Hash",
+      "queue": "Queue",
+      "progress": "Progress"
+    },
+    "priority": {
+      "low": "Low",
+      "normal": "Normal",
+      "high": "High"
+    },
+    "actions": {
+      "start": "Start",
+      "pause": "Pause",
+      "resume": "Resume",
+      "remove": "Remove",
+      "cancel": "Cancel"
+    },
+    "notifications": {
+      "enterHash": "Please enter a file hash to start downloading.",
+      "searching": "Searching for file metadata in the DHT...",
+      "addedToQueue": "File added to the download queue.",
+      "autostart": "Download automatically started.",
+      "searchFailed": "Search failed: {error}",
+      "downloadFailed": "Download failed for {name}."
+    }
+  },
   "regions.usEast": "US East",
   "regions.usWest": "US West",
   "regions.euWest": "Europe West",


### PR DESCRIPTION
The translation keys in the Download.svelte file didn't match their paths in the en.json language file.
I corrected this by moving download-related translations to a top level, so now the paths match the structure of the translation file.

Before
<img width="1267" height="772" alt="Screenshot 2025-09-20 at 3 51 45 PM" src="https://github.com/user-attachments/assets/4cd56a73-b726-48c1-ad1c-cf5a25d5e813" />

After
<img width="1274" height="771" alt="스크린샷 2025-09-20 오후 4 18 49" src="https://github.com/user-attachments/assets/9b5ff726-453c-46c3-a39b-68cec949dd75" />
