### PR TITLE
fix(language): broken text (missing translation keys) on Analytics/Se…

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -106,7 +106,16 @@
     },
     "errors": {
         "downloadOnlyTauri": "Chiral Node download is only available in the desktop app. Please download and run the Tauri desktop version."
-    }
+    },
+    "maxConnections": "Max Connections",
+    "port": "Port",
+    "uploadLimit": "Upload Limit (MB/s)",
+    "downloadLimit": "Download Limit (MB/s)",
+    "userLocation": "User Location",
+    "locationHint": "Helps find closer peers for better performance.",
+    "enableUpnp": "Enable UPnP",
+    "enableNat": "Enable NAT Port Mapping",
+    "enableDht": "Enable DHT"
   },
   "download": {
     "title": "Download Files",
@@ -221,6 +230,9 @@
   "advanced.exportSettings": "Export Settings",
   "advanced.importSettings": "Import Settings",
   "advanced.invalidJsonAlert": "Invalid JSON file. Please select a valid export.",
+  "advanced.exportSuccess": "Settings exported to your browser's download folder.",
+  "advanced.importSuccess": "Settings imported successfully.",
+  "advanced.importError": "Invalid JSON file. Please select a valid export.",
 
   "actions.resetDefaults": "Reset to Defaults",
   "actions.cancel": "Cancel",
@@ -490,8 +502,13 @@
       "30d": "Last 30 days",
       "thisMonth": "This Month",
       "lastMonth": "Last Month",
-      "ytd": "Year to Date"
-    }
+      "ytd": "Year to Date",
+      "custom": "Custom"
+    },
+    "from": "From",
+    "to": "To",
+    "suspiciousActivity": "Suspicious Activity",
+    "noSuspiciousActivity": "No suspicious activity detected."
   },
   "proxy": {
     "title": "Proxy Network",


### PR DESCRIPTION
Some texts were broken due to missing translation keys on Analytics and Settings pages. 
I added all the missing keys to fix the error. 

Before:
<img width="1259" height="780" alt="KakaoTalk_Photo_2025-09-20-16-26-33" src="https://github.com/user-attachments/assets/298029fe-50cd-4d2b-8a8e-b14f302133b6" />
<img width="1274" height="764" alt="스크린샷 2025-09-20 오후 4 28 25" src="https://github.com/user-attachments/assets/5d620276-4129-4384-9b0f-f77abdd2dfeb" />

After:
<img width="1273" height="773" alt="스크린샷 2025-09-20 오후 4 26 24" src="https://github.com/user-attachments/assets/b3870d24-addb-4f97-a4c9-345b99b53913" />
<img width="1273" height="767" alt="스크린샷 2025-09-20 오후 4 35 14" src="https://github.com/user-attachments/assets/291df649-72f3-4371-85d9-6b8c5d04dd32" />
