### PR TITLE
feature(UI): Added Mining Session Payouts To Transaction History

### DIFF
--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -93,6 +93,17 @@ export interface NetworkStats {
   totalTransactions: number;
 }
 
+export interface Transaction {
+    id: number;
+    type: 'sent' | 'received';
+    amount: number;
+    to?: string;
+    from?: string;
+    date: Date;
+    description: string;
+    status: 'pending' | 'completed';
+}
+
 export interface BlacklistEntry {
   chiral_address: string;
   reason: string;
@@ -231,11 +242,51 @@ const dummyNetworkStats: NetworkStats = {
   totalTransactions: 98765,
 };
 
+const dummyTransactions: Transaction[] = [
+  {
+    id: 1,
+    type: 'received',
+    amount: 50.5,
+    from: '0x8765...4321',
+    date: new Date('2024-03-15'),
+    description: 'File purchase',
+    status: 'completed'
+  },
+  {
+    id: 2,
+    type: 'sent',
+    amount: 10.25,
+    to: '0x1234...5678',
+    date: new Date('2024-03-14'),
+    description: 'Proxy service',
+    status: 'completed'
+  },
+  {
+    id: 3,
+    type: 'received',
+    amount: 100,
+    from: '0xabcd...ef12',
+    date: new Date('2024-03-13'),
+    description: 'Upload reward',
+    status: 'completed'
+  },
+  {
+    id: 4,
+    type: 'sent',
+    amount: 5.5,
+    to: '0x9876...5432',
+    date: new Date('2024-03-12'),
+    description: 'File download',
+    status: 'completed'
+  }
+];
+
 // Stores
 export const files = writable<FileItem[]>(dummyFiles);
 export const proxyNodes = writable<ProxyNode[]>(dummyProxyNodes);
 export const wallet = writable<WalletInfo>(dummyWallet);
 export const activeDownloads = writable<number>(1);
+export const transactions = writable<Transaction[]>(dummyTransactions);
 
 // Import real network status
 import { networkStatus } from "./services/networkService";

--- a/src/pages/Account.svelte
+++ b/src/pages/Account.svelte
@@ -5,7 +5,8 @@
   import Label from '$lib/components/ui/label.svelte'
   import { Wallet, Copy, ArrowUpRight, ArrowDownLeft, History, Coins, Plus, Import, BadgeX, KeyRound, FileText } from 'lucide-svelte'
   import DropDown from "$lib/components/ui/dropDown.svelte";
-  import { wallet, etcAccount, blacklist } from '$lib/stores'
+  import { wallet, etcAccount, blacklist} from '$lib/stores' 
+  import { transactions, type Transaction } from '$lib/stores';
   import { writable, derived } from 'svelte/store'
   import { invoke } from '@tauri-apps/api/core'
   import QRCode from 'qrcode'
@@ -30,16 +31,18 @@
   // Check if running in Tauri environment
   const isTauri = typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window
 
-  interface Transaction {
-    id: number;
-    type: 'sent' | 'received';
-    amount: number;
-    to?: string;
-    from?: string;
-    date: Date;
-    description: string;
-    status: 'pending' | 'completed';
-  }
+  // Interfaces - Transaction is now defined in stores.ts
+
+  // interface Transaction {
+  //   id: number;
+  //   type: 'sent' | 'received';
+  //   amount: number;
+  //   to?: string;
+  //   from?: string;
+  //   date: Date;
+  //   description: string;
+  //   status: 'pending' | 'completed';
+  // }
 
   interface BlacklistEntry {
     chiral_address: string;
@@ -85,12 +88,12 @@
   let Html5QrcodeScanner: InstanceType<typeof Html5QrcodeScannerClass> | null = null;
   
   // Demo transactions - in real app these will be fetched from blockchain
-  const transactions = writable<Transaction[]>([
-    { id: 1, type: 'received', amount: 50.5, from: '0x8765...4321', to: undefined, date: new Date('2024-03-15'), description: 'File purchase', status: 'completed' },
-    { id: 2, type: 'sent', amount: 10.25, to: '0x1234...5678', from: undefined, date: new Date('2024-03-14'), description: 'Proxy service', status: 'completed' },
-    { id: 3, type: 'received', amount: 100, from: '0xabcd...ef12', to: undefined, date: new Date('2024-03-13'), description: 'Upload reward', status: 'completed' },
-    { id: 4, type: 'sent', amount: 5.5, to: '0x9876...5432', from: undefined, date: new Date('2024-03-12'), description: 'File download', status: 'completed' },
-  ]);
+  // const transactions = writable<Transaction[]>([
+  //   { id: 1, type: 'received', amount: 50.5, from: '0x8765...4321', to: undefined, date: new Date('2024-03-15'), description: 'File purchase', status: 'completed' },
+  //   { id: 2, type: 'sent', amount: 10.25, to: '0x1234...5678', from: undefined, date: new Date('2024-03-14'), description: 'Proxy service', status: 'completed' },
+  //   { id: 3, type: 'received', amount: 100, from: '0xabcd...ef12', to: undefined, date: new Date('2024-03-13'), description: 'Upload reward', status: 'completed' },
+  //   { id: 4, type: 'sent', amount: 5.5, to: '0x9876...5432', from: undefined, date: new Date('2024-03-12'), description: 'File download', status: 'completed' },
+  // ]);
 
   // Enhanced validation states
   let validationWarning = '';


### PR DESCRIPTION
Previously while mining had properly updated the wallet with the Chiral earned, there was no clear way to identify how much Chiral you were earning/earned from the mining. To resolve this, we decided to add the results of a mining session to the transaction history with how many blocks were mined. 

This can be seen in this screenshot here: 
<img width="1256" height="324" alt="image" src="https://github.com/user-attachments/assets/6bfc0b01-eb16-4f0a-9ad6-5dab7e0f42c8" />

Not entirely sure how the card/receipt itself should look for this kind of recorded transaction and whether the mining page should be showing total blocks mined, or if it should showcase the blocks only from the ongoing mining session. That could be worth looking into for future PRs.  

To accomplish this we moved the Transaction Interface out of account and into stores.ts as we're expanding the use of transactions to record payouts from mining sessions in the user's transaction history. 