### PR TITLE
fix(manager): repair chunk struct and rng usage

### DIFF
--- a/src-tauri/src/manager.rs
+++ b/src-tauri/src/manager.rs
@@ -1,6 +1,7 @@
 use sha2::{Sha256, Digest};
 use aes_gcm::{Aes256Gcm, Key, Nonce, KeyInit};
 use aes_gcm::aead::{Aead, OsRng};
+use rand::RngCore;
 use std::fs::{File, self};
 use std::io::{Read, Error, Write};
 use std::path::{Path, PathBuf};
@@ -12,7 +13,7 @@ use crate::crypto::{encrypt_aes_key, EncryptedAesKeyBundle};
 #[derive(serde::Serialize, serde::Deserialize, Debug)]
 pub struct ChunkInfo {
     pub index: u32,
-    pub hash: String
+    pub hash: String,
     pub size: usize,
     pub encrypted_size: usize,
 }


### PR DESCRIPTION
  ## Summary
  - restore the missing comma in `ChunkInfo` so the struct parses correctly
  - import `rand::RngCore` so `OsRng.fill_bytes` links during chunk encryption

  ## Testing
  1. Ensure the frontend dist folder exists so Tauri’s macro resolves: `mkdir -p dist`
  2. Run `cargo check` inside `src-tauri/`
  3. From the repo root, run `node --test`

  _No UI changes—screenshots not required._