### PR TITLE
fix(geth): point intel mac download to macos archive

### DIFF
--- a/src-tauri/src/geth_downloader.rs
+++ b/src-tauri/src/geth_downloader.rs
@@ -43,8 +43,8 @@ impl GethDownloader {
     fn get_download_url(&self) -> Result<String, String> {
         // Core-Geth v1.12.20 URLs for different platforms
         let url = match (std::env::consts::OS, std::env::consts::ARCH) {
-            ("macos", "aarch64") => "https://github.com/etclabscore/core-geth/releases/download/v1.12.20/core-geth-osx-v1.12.20.zip",            
-            ("macos", "x86_64") => "https://github.com/etclabscore/core-geth/releases/download/v1.12.20/core-geth-win64-v1.12.20.zip",
+            ("macos", "aarch64") => "https://github.com/etclabscore/core-geth/releases/download/v1.12.20/core-geth-osx-v1.12.20.zip",
+            ("macos", "x86_64") => "https://github.com/etclabscore/core-geth/releases/download/v1.12.20/core-geth-osx-v1.12.20.zip",
             ("linux", "x86_64") => "https://github.com/etclabscore/core-geth/releases/download/v1.12.20/core-geth-linux-v1.12.20.zip",
             ("linux", "aarch64") => "https://github.com/etclabscore/core-geth/releases/download/v1.12.20/core-geth-arm64-v1.12.20.zip",
             ("windows", "x86_64") => "https://github.com/etclabscore/core-geth/releases/download/v1.12.20/core-geth-win64-v1.12.20.zip",


### PR DESCRIPTION
  ## Summary
  - correct the macOS x86_64 download URL to use the `core-geth-osx` archive
  - keep both macOS architectures aligned on the macOS bundle so Intel users receive a valid binary

  ## Testing
  1. Ensure the frontend dist folder exists: `mkdir -p dist`
  2. Run `cargo check` inside `src-tauri/`
  3. (Optional) `curl -I https://github.com/etclabscore/core-geth/releases/download/v1.12.20/core-geth-osx-v1.12.20.zip` to
  confirm the resolved file

  _No UI changes—screenshots not required._