### PR TITLE
feat(upload): surface disk space indicator

### DIFF
--- a/src/lib/services/fileService.ts
+++ b/src/lib/services/fileService.ts
@@ -86,6 +86,20 @@ export class FileService {
   async showInFolder(path: string): Promise<void> {
     await invoke('show_in_folder', { path });
   }
+
+  /**
+   * Queries the backend for the amount of free disk space (in GB) the node can use.
+   * Returns null when the call fails so the UI can surface a retry affordance.
+   */
+  async getAvailableStorage(): Promise<number | null> {
+    try {
+      const storage = await invoke<number>('get_available_storage');
+      return Number.isFinite(storage) ? storage : null;
+    } catch (error) {
+      console.error('Failed to load available storage:', error);
+      return null;
+    }
+  }
 }
 
 // It's often useful to export a singleton instance of the service.

--- a/src/lib/uploadHelpers.d.ts
+++ b/src/lib/uploadHelpers.d.ts
@@ -3,3 +3,4 @@ export interface HashedFileLike {
 }
 
 export declare function isDuplicateHash(files: HashedFileLike[] | undefined | null, hash: string): boolean;
+export declare function getStorageStatus(freeGb: number | null | undefined, thresholdGb?: number): "unknown" | "ok" | "low";

--- a/src/lib/uploadHelpers.js
+++ b/src/lib/uploadHelpers.js
@@ -11,3 +11,21 @@ export function isDuplicateHash(files, hash) {
   }
   return files.some((file) => file && typeof file.hash === 'string' && file.hash === hash);
 }
+
+/**
+ * Returns a status string describing whether free storage is healthy.
+ * @param {number|null|undefined} freeGb
+ * @param {number} [thresholdGb=5]
+ * @returns {"unknown"|"ok"|"low"}
+ */
+export function getStorageStatus(freeGb, thresholdGb = 5) {
+  if (typeof thresholdGb !== 'number' || !Number.isFinite(thresholdGb) || thresholdGb <= 0) {
+    thresholdGb = 5;
+  }
+
+  if (typeof freeGb !== 'number' || !Number.isFinite(freeGb) || freeGb < 0) {
+    return 'unknown';
+  }
+
+  return freeGb < thresholdGb ? 'low' : 'ok';
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -629,6 +629,19 @@
     "addFilesHint2": "Add files to start sharing on the network",
     "duplicateSkipped": "{count, plural, one {1 duplicate file was skipped.} other {{count} duplicate files were skipped.}}",
     "filesAdded": "{count, plural, one {Added 1 file to the share list.} other {Added {count} files to the share list.}}",
-    "fileFailed": "Failed to share '{name}': {error}"
+    "fileFailed": "Failed to share '{name}': {error}",
+    "storage": {
+      "title": "Local Storage",
+      "available": "{space} GB free",
+      "unknown": "Space unavailable",
+      "lowBadge": "Low space",
+      "okBadge": "Healthy",
+      "unknownBadge": "Unknown",
+      "refresh": "Refresh",
+      "lastChecked": "Updated {time}",
+      "error": "Unable to check disk space",
+      "checking": "Checking...",
+      "lowDescription": "Low free space may prevent new uploads."
+    }
   }
 }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -586,7 +586,21 @@
     "noFilesShared": "Aún no hay archivos compartidos",
     "addFilesHint2": "Agrega archivos para empezar a compartir en la red",
     "duplicateSkipped": "{count, plural, one {Este archivo ya se está compartiendo. Duplicado omitido.} other {Se omitieron {count} archivos duplicados.}}",
-    "filesAdded": "{count, plural, one {Se agregó 1 archivo a la lista de compartidos.} other {Se agregaron {count} archivos a la lista de compartidos.}}"
+    "filesAdded": "{count, plural, one {Se agregó 1 archivo a la lista de compartidos.} other {Se agregaron {count} archivos a la lista de compartidos.}}",
+    "fileFailed": "No se pudo compartir '{name}': {error}",
+    "storage": {
+      "title": "Almacenamiento local",
+      "available": "{space} GB libres",
+      "unknown": "Espacio no disponible",
+      "lowBadge": "Espacio bajo",
+      "okBadge": "Saludable",
+      "unknownBadge": "Desconocido",
+      "refresh": "Actualizar",
+      "lastChecked": "Actualizado {time}",
+      "error": "No se pudo comprobar el espacio en disco",
+      "checking": "Comprobando...",
+      "lowDescription": "El espacio libre bajo puede impedir compartir archivos nuevos."
+    }
   },
   "download": {
     "title": "Descargar archivos",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -601,7 +601,21 @@
     "noFilesShared": "아직 공유된 파일이 없습니다",
     "addFilesHint2": "네트워크에서 공유를 시작하려면 파일을 추가하세요",
     "duplicateSkipped": "{count, plural, one {이미 공유 중인 파일입니다. 중복 항목을 건너뛰었습니다.} other {중복 파일 {count}개를 건너뛰었습니다.}}",
-    "filesAdded": "{count, plural, one {공유 목록에 파일 1개를 추가했습니다.} other {공유 목록에 파일 {count}개를 추가했습니다.}}"
+    "filesAdded": "{count, plural, one {공유 목록에 파일 1개를 추가했습니다.} other {공유 목록에 파일 {count}개를 추가했습니다.}}",
+    "fileFailed": "'{name}' 파일을 공유하지 못했습니다: {error}",
+    "storage": {
+      "title": "로컬 저장 공간",
+      "available": "여유 {space} GB",
+      "unknown": "여유 공간을 알 수 없음",
+      "lowBadge": "공간 부족",
+      "okBadge": "정상",
+      "unknownBadge": "알 수 없음",
+      "refresh": "새로고침",
+      "lastChecked": "{time} 업데이트",
+      "error": "디스크 공간을 확인할 수 없습니다",
+      "checking": "확인 중...",
+      "lowDescription": "여유 공간이 부족하면 새 파일을 공유할 수 없습니다."
+    }
   },
   "download": {
     "title": "파일 다운로드",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -593,7 +593,21 @@
     "noFilesShared": "尚无已分享文件",
     "addFilesHint2": "添加文件以开始在网络中分享",
     "duplicateSkipped": "{count, plural, one {该文件已在分享列表中，已跳过重复项。} other {已跳过 {count} 个重复文件。}}",
-    "filesAdded": "{count, plural, one {已将 1 个文件添加到分享列表。} other {已将 {count} 个文件添加到分享列表。}}"
+    "filesAdded": "{count, plural, one {已将 1 个文件添加到分享列表。} other {已将 {count} 个文件添加到分享列表。}}",
+    "fileFailed": "无法分享“{name}”：{error}",
+    "storage": {
+      "title": "本地存储",
+      "available": "可用 {space} GB",
+      "unknown": "无法获取可用空间",
+      "lowBadge": "空间不足",
+      "okBadge": "状态良好",
+      "unknownBadge": "未知",
+      "refresh": "刷新",
+      "lastChecked": "更新于 {time}",
+      "error": "无法检查磁盘空间",
+      "checking": "正在检查...",
+      "lowDescription": "可用空间过低可能导致无法继续分享文件。"
+    }
   },
   "download": {
     "title": "下载文件",

--- a/tests/uploadHelpers.test.mjs
+++ b/tests/uploadHelpers.test.mjs
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { isDuplicateHash } from '../src/lib/uploadHelpers.js';
+import { getStorageStatus, isDuplicateHash } from '../src/lib/uploadHelpers.js';
 
 test('isDuplicateHash returns false when list empty', () => {
   assert.equal(isDuplicateHash([], 'abc'), false);
@@ -20,4 +20,20 @@ test('isDuplicateHash ignores non-array inputs', () => {
 test('isDuplicateHash ignores empty hash', () => {
   const files = [{ hash: 'value' }];
   assert.equal(isDuplicateHash(files, ''), false);
+});
+
+test('getStorageStatus returns unknown for invalid input', () => {
+  assert.equal(getStorageStatus(undefined), 'unknown');
+  assert.equal(getStorageStatus(NaN), 'unknown');
+  assert.equal(getStorageStatus(-1), 'unknown');
+});
+
+test('getStorageStatus flags low storage when below threshold', () => {
+  assert.equal(getStorageStatus(4.9, 5), 'low');
+  assert.equal(getStorageStatus(10, 11), 'low');
+});
+
+test('getStorageStatus reports ok when sufficient space', () => {
+  assert.equal(getStorageStatus(10, 5), 'ok');
+  assert.equal(getStorageStatus(5, 5), 'ok');
 });


### PR DESCRIPTION
## Summary
  - add a “Local Storage” status card to the Upload view that calls the existing `get_available_storage` Tauri command
  - highlight low-space conditions with a warning badge and helper text, plus a manual refresh action
  - surface storage status logic in a shared helper with node-based tests and localized strings (en/es/ko/zh)

  ## Testing
  1. `node --test`
  2. `mkdir -p dist`
  3. `(cd src-tauri && cargo check)`

  ## Screenshots
First screenshot is for web and the other 2 are for desktop 

<img width="1497" height="825" alt="Screenshot 2025-09-21 at 4 09 40 PM" src="https://github.com/user-attachments/assets/1b9d4fac-71ee-4b2e-98f7-58ec1d24d88d" />
<img width="1268" height="763" alt="Screenshot 2025-09-21 at 4 10 10 PM" src="https://github.com/user-attachments/assets/0ae6da64-ea46-4511-bff2-cc55fbed678d" />
<img width="1006" height="126" alt="Screenshot 2025-09-21 at 4 10 30 PM" src="https://github.com/user-attachments/assets/869aa859-957b-4aed-832e-1707ab6fc9e4" />
