### PR TITLE
feat(account): update UI of HD wallet for better UX

### DIFF
--- a/src/lib/components/wallet/AccountList.svelte
+++ b/src/lib/components/wallet/AccountList.svelte
@@ -2,6 +2,7 @@
   import Card from '$lib/components/ui/card.svelte'
   import Button from '$lib/components/ui/button.svelte'
   import Input from '$lib/components/ui/input.svelte'
+  import Dropdown from '$lib/components/ui/dropDown.svelte'
   import { deriveNext } from '$lib/wallet/hd'
   import { showToast } from '$lib/toast'
   import { wallet, etcAccount } from '$lib/stores'
@@ -15,6 +16,19 @@
 
   let renameIndex: number | null = null
   let renameValue = ''
+
+  let selectedAccountIndex: number = 0;
+  $: dropdownOptions = accounts.map((acc, i) => ({
+    value: String(i),
+    label: `${acc.label || 'Account ' + acc.index} - ${short(acc.address, 4, 4)}`
+  }));
+  $: selectedAccount = accounts[selectedAccountIndex] ?? null;
+
+  function handleDropdownChange(event: CustomEvent<{ value: string }>) {
+    selectedAccountIndex = Number(event.detail.value);
+    renameIndex = null;
+    renameValue = '';
+  }
 
   function short(addr: string, prefix = 10, suffix = 8): string {
     if (!addr) return ''
@@ -34,6 +48,9 @@
       const item: AccountItem = { index: derived.index, change: 0, address: derived.address, privateKeyHex: derived.privateKeyHex }
       const updated = [...accounts, item]
       onAccountsChange(updated)
+      if (updated.length > 3) {
+        selectedAccountIndex = updated.length - 1;
+      }
       showToast('Derived account #' + item.index, 'success')
     } catch (e) {
       showToast('Derivation failed: ' + String(e), 'error')
@@ -72,8 +89,18 @@
       <Button class="w-full sm:w-auto" on:click={addNext}>Derive Next</Button>
     </div>
   </div>
-  <div class="space-y-2">
-    {#each accounts as acc}
+
+  {#if accounts.length > 3}
+    <div class="space-y-2">
+      <Dropdown
+        options={dropdownOptions}
+        value={String(selectedAccountIndex)}
+        on:change={handleDropdownChange}
+      />
+    </div>
+
+    {#if selectedAccount}
+      {@const acc = selectedAccount}
       <div class="border rounded-md p-3 space-y-3">
         <!-- Top: name + address -->
         <div class="min-w-0">
@@ -104,12 +131,50 @@
             <span class="hidden md:inline lg:hidden">Save Key</span>
             <span class="md:hidden">Save</span>
           </Button>
-          <Button class="w-full xs:w-auto whitespace-nowrap text-xs h-8 px-2" size="sm" on:click={() => selectAccount(acc)}>Select</Button>
+          <Button class="w-full xs:w-auto whitespace-nowrap text-xs h-8 px-2" size="sm" on:click={() => selectAccount(acc)} disabled={acc.address === $wallet.address}>Select</Button>
         </div>
       </div>
-    {/each}
-    {#if accounts.length === 0}
-      <p class="text-sm text-muted-foreground">No derived accounts yet.</p>
     {/if}
-  </div>
+  {:else}
+    <div class="space-y-2">
+      {#each accounts as acc}
+        <div class="border rounded-md p-3 space-y-3">
+          <!-- Top: name + address -->
+          <div class="min-w-0">
+            <div class="flex items-center gap-2">
+              <span class="text-sm text-muted-foreground">#{acc.index}</span>
+              {#if renameIndex === acc.index}
+                <Input class="h-8 text-sm w-full sm:w-48" bind:value={renameValue} on:keydown={(e) => { const ev = (e as unknown as KeyboardEvent); if (ev.key === 'Enter') commitRename(acc) }} />
+              {:else}
+                <span class="font-medium truncate">{acc.label || 'Account ' + acc.index}</span>
+              {/if}
+            </div>
+            <div class="mt-1 text-xs text-muted-foreground font-mono min-w-0" title={acc.address}>
+              <!-- Responsive middle truncation to keep hash readable without overflow -->
+              <span class="sm:hidden">{short(acc.address, 6, 4)}</span>
+              <span class="hidden sm:inline md:hidden">{short(acc.address, 8, 6)}</span>
+              <span class="hidden md:inline">{short(acc.address, 10, 8)}</span>
+            </div>
+          </div>
+          <!-- Bottom: buttons -->
+          <div class="flex flex-wrap gap-2 w-full">
+            {#if renameIndex === acc.index}
+              <Button class="w-full xs:w-auto whitespace-nowrap text-xs h-8 px-2" size="sm" variant="outline" on:click={() => commitRename(acc)}>Save</Button>
+            {:else}
+              <Button class="w-full xs:w-auto whitespace-nowrap text-xs h-8 px-2" size="sm" variant="outline" on:click={() => startRename(acc)}>Rename</Button>
+            {/if}
+            <Button class="w-full xs:w-auto whitespace-nowrap text-xs h-8 px-2" size="sm" variant="outline" on:click={() => saveToKeystore(acc)}>
+              <span class="hidden lg:inline">Save to Keystore</span>
+              <span class="hidden md:inline lg:hidden">Save Key</span>
+              <span class="md:hidden">Save</span>
+            </Button>
+            <Button class="w-full xs:w-auto whitespace-nowrap text-xs h-8 px-2" size="sm" on:click={() => selectAccount(acc)} disabled={acc.address === $wallet.address}>Select</Button>
+          </div>
+        </div>
+      {/each}
+      {#if accounts.length === 0}
+        <p class="text-sm text-muted-foreground">No derived accounts yet.</p>
+      {/if}
+    </div>
+  {/if}
 </Card>

--- a/src/pages/Account.svelte
+++ b/src/pages/Account.svelte
@@ -1337,25 +1337,6 @@
          {/if}
       </div>
     </Card>
-
-    {#if hdMnemonic}
-      <Card class="p-6">
-        <div class="flex items-center justify-between mb-4">
-          <h2 class="text-lg font-semibold">HD Wallet</h2>
-          <div class="flex gap-2">
-            <Button variant="outline" on:click={openCreateMnemonic}>New</Button>
-            <Button variant="outline" on:click={openImportMnemonic}>Import</Button>
-          </div>
-        </div>
-        <p class="text-sm text-muted-foreground mb-4">Path m/44'/{98765}'/0'/0/*</p>
-        <AccountList
-          mnemonic={hdMnemonic}
-          passphrase={hdPassphrase}
-          accounts={hdAccounts}
-          onAccountsChange={onHDAccountsChange}
-        />
-      </Card>
-    {/if}
     
     {#if $etcAccount}
     <Card class="p-6">
@@ -1510,6 +1491,24 @@
   </div>
 
   {#if $etcAccount}
+    {#if hdMnemonic}
+        <Card class="p-6">
+          <div class="flex items-center justify-between mb-4">
+            <h2 class="text-lg font-semibold">HD Wallet</h2>
+            <div class="flex gap-2">
+              <Button variant="outline" on:click={openCreateMnemonic}>New</Button>
+              <Button variant="outline" on:click={openImportMnemonic}>Import</Button>
+            </div>
+          </div>
+          <p class="text-sm text-muted-foreground mb-4">Path m/44'/{98765}'/0'/0/*</p>
+          <AccountList
+            mnemonic={hdMnemonic}
+            passphrase={hdPassphrase}
+            accounts={hdAccounts}
+            onAccountsChange={onHDAccountsChange}
+          />
+        </Card>
+    {/if}
   <!-- Transaction History Section - Full Width -->
   <Card class="p-6 mt-4">
     <div class="flex items-center justify-between mb-4">


### PR DESCRIPTION

Before, the HD wallet would appear to the right of the "Chiral Network Wallet" card, but this created some UX experiences:
- There was unnecessary empty blank space under the wallet info card
- The user could keep deriving keys from the recovery phrase, create a long list that extends downwards and requires a lot fo scrolling.

<img width="1530" height="833" alt="Screenshot 2025-09-22 125411" src="https://github.com/user-attachments/assets/13ff7185-93d6-4569-b59a-80b3bc8878a7" />

After:
- The HD wallet is now located under the wallet info and send coins cards, allowing for better UX. 
- The HD wallet also transforms into a dropdown if there are more than 3 accounts. 
- The select button also greys out if a certain account is currently selected.

<img width="1212" height="867" alt="image" src="https://github.com/user-attachments/assets/a2b7f941-8a18-40b8-807e-a148126d00ea" />
