### PR TITLE
feat(p2p): Scaffold real P2P file download logic

### DIFF
--- a/src-tauri/src/file_transfer.rs
+++ b/src-tauri/src/file_transfer.rs
@@ -208,7 +208,7 @@ impl FileTransferService {
         // Note: This requires `dht_service` to have a method that returns the metadata.
         let metadata: FileMetadata = dht_service
             .get_file_metadata(file_hash.to_string())
-            .await? // This function needs to be implemented in DhtService
+            .await?
             .ok_or_else(|| "File metadata not found on the network".to_string())?;
 
         if metadata.seeders.is_empty() {
@@ -238,16 +238,20 @@ impl FileTransferService {
 
         // 4. Reassemble and decrypt the file
         // This requires the user's private key to decrypt the file's AES key.
-        // For now, we'll assume we have it. This is a major piece of future work.
-        // let recipient_secret_key = ... get from keystore ...
-        // chunk_manager.reassemble_and_decrypt_file(
-        //     &metadata.chunks,
-        //     &PathBuf::from(output_path),
-        //     &metadata.encrypted_key_bundle,
-        //     &recipient_secret_key,
-        // )?;
+        // This is a major piece of future work that will require UI interaction to get the password.
+        info!(
+            "All chunks for {} downloaded. Reassembly and decryption is the next step.",
+            file_hash
+        );
 
-        info!("All chunks downloaded for {}. Reassembly/decryption is the next step.", file_hash);
+        // Example of the final step:
+        // let keystore = crate::keystore::Keystore::load()?;
+        // let private_key = keystore.get_account("USER_ADDRESS", "USER_PASSWORD")?;
+        // let secret_key = EphemeralSecret::new(&mut OsRng, &private_key); // This part needs correct crypto implementation
+        // chunk_manager.reassemble_and_decrypt_file(
+        //     &metadata.chunks, &PathBuf::from(output_path), &metadata.encrypted_key_bundle, &secret_key
+        // )?;
+        // info!("File reassembled and decrypted successfully!");
 
         info!("P2P file downloaded: {} -> {}", file_hash, output_path);
         Ok(())

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -610,24 +610,10 @@ async fn download_file_from_network(
     };
 
     if let Some(ft) = ft {
-        // First try to download from local storage
-        match ft
+        // This now attempts a real P2P download via the service
+        ft
             .download_file(file_hash.clone(), output_path.clone())
             .await
-        {
-            Ok(()) => {
-                info!("File downloaded successfully from local storage");
-                return Ok(());
-            }
-            Err(_) => {
-                // File not found locally, would need to implement P2P download here
-                // For now, return an error
-                return Err(
-                    "File not found in local storage. P2P download not yet implemented."
-                        .to_string(),
-                );
-            }
-        }
     } else {
         Err("File transfer service is not running".to_string())
     }


### PR DESCRIPTION

- This Refactors the `FileTransferService` from a local, in-memory mock into a network-aware client that integrates with the `DhtService`.
- Before, it only stored and retrieved files from a local `HashMap`, simulating transfers without any actual network interaction. This was useful for UI development but did not provide real P2P capabilities.

for a real P2P download flow:
- The `FileTransferService` now holds a reference to the `DhtService`.
- The download command now triggers `handle_p2p_download_file`.
- This new function queries the DHT to find file metadata and a list of seeders.
- It then lays the groundwork for requesting the file data directly from a seeder peer.