### PR TITLE
feat(account): Add Save Password for keystore login

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -329,7 +329,9 @@
       "empty": "No accounts found in keystore.",
       "success": "Account loaded successfully",
       "successSimulated": "Account loaded (demo mode)",
-      "error": "Failed to load account: {error}"
+      "error": "Failed to load account: {error}",
+      "savePassword": "Save password on this computer",
+      "addressMismatch": "Decryption error: address does not match."
     }
   },
 

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -285,7 +285,9 @@
       "empty": "키스토어에서 계정을 찾을 수 없습니다.",
       "success": "계정을 성공적으로 불러왔습니다!",
       "successSimulated": "시뮬레이션된 계정 불러오기 성공!",
-      "error": "오류: {error}"
+      "error": "오류: {error}",
+      "savePassword": "이 컴퓨터에 비밀번호 저장",
+      "addressMismatch": "복호화 오류: 주소가 일치하지 않습니다."
     }
   },
 
@@ -390,19 +392,6 @@
     "reason": "사유 입력…"
   },
 
-  "password": {
-    "weak": "취약한 비밀번호",
-    "medium": "보통 강도",
-    "strong": "강력한 비밀번호",
-    "requirements": {
-      "length": "최소 8자 이상",
-      "uppercase": "대문자 1개",
-      "lowercase": "소문자 1개",
-      "number": "숫자 1개",
-      "special": "특수문자 1개"
-    }
-  },
-
   "tooltips": {
     "showQr": "QR 코드 보기",
     "clearSearch": "검색 지우기"
@@ -422,8 +411,7 @@
     "address": {
       "mustStartWith0x": "주소는 0x로 시작해야 합니다.",
       "mustBe42": "주소 길이는 정확히 42자여야 합니다.",
-      "mustBeHex": "주소는 16진수 문자(0-9, a-f, A-F)만 포함해야 합니다.",
-      "blacklisted": "이 주소는 블랙리스트에 등록되어 있어 거래를 받을 수 없습니다"
+      "mustBeHex": "주소는 16진수 문자(0-9, a-f, A-F)만 포함해야 합니다."
     },
     "amount": {
       "invalid": "0보다 큰 올바른 금액을 입력하세요.",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -285,7 +285,9 @@
       "empty": "未在存储中找到账户。",
       "success": "账户加载成功",
       "successSimulated": "账户已加载（演示模式）",
-      "error": "加载账户时出错: {error}"
+      "error": "加载账户时出错: {error}",
+      "savePassword": "在这台电脑上保存密码",
+      "addressMismatch": "解密错误：地址不匹配。"
     }
   },
 
@@ -382,19 +384,6 @@
     "reason": "输入原因..."
   },
 
-  "password": {
-    "weak": "密码强度弱",
-    "medium": "密码强度中等",
-    "strong": "密码强度强",
-    "requirements": {
-      "length": "至少8个字符",
-      "uppercase": "一个大写字母",
-      "lowercase": "一个小写字母",
-      "number": "一个数字",
-      "special": "一个特殊字符"
-    }
-  },
-
   "tooltips": {
     "showQr": "显示二维码",
     "clearSearch": "清除搜索"
@@ -414,8 +403,7 @@
     "address": {
       "mustStartWith0x": "地址必须以0x开头。",
       "mustBe42": "地址必须正好是42个字符。",
-      "mustBeHex": "地址必须包含有效的十六进制字符 (0-9, a-f, A-F)",
-      "blacklisted": "该地址已被列入黑名单，无法接收交易"
+      "mustBeHex": "地址必须包含有效的十六进制字符 (0-9, a-f, A-F)"
     },
     "amount": {
       "invalid": "请输入大于0的有效数量。",


### PR DESCRIPTION
This feature is "Save password on this computer" for the "Load from Keystore" functionality on the Account page. This enhances user experience by allowing them to save their decryption password locally for easier access.

When a user checks this box and successfully unlocks their account, the password for that specific address is saved to the browser's `localStorage`. The next time the user selects that account from the dropdown, the password field is automatically populated, streamlining the login process.
<img width="1276" height="766" alt="Screenshot 2025-09-22 at 2 32 41 PM" src="https://github.com/user-attachments/assets/387506ba-85f7-413c-a15c-5b1a69144878" />

