### PR TITLE
fix(mining): auto-update transaction history while mining

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -299,7 +299,7 @@
     "pending": {
       "title": "Pending Transactions",
       "noDetails": "No pending transaction details available.",
-      "count": "{count} Pending Transaction{count !== 1 ? 's' : ''}",
+      "count": "{count, plural, one {# Pending Transaction} other {# Pending Transactions}}",
       "none": "Pending Transactions"
     }
   },

--- a/src/pages/Account.svelte
+++ b/src/pages/Account.svelte
@@ -1461,11 +1461,7 @@
               <circle cx="12" cy="10" r="8" />
               <polyline points="12,6 12,10 16,14" />
             </svg>
-            {#if $pendingCount > 0}
-              {$t('transfer.pending.count', { values: { count: $pendingCount } })}
-            {:else}
-              {$t('transfer.pending.none')}
-            {/if}
+            {$t('transfer.pending.count', { values: { count: $pendingCount } })}
           </span>
         </Button>
         {#if showPending}

--- a/src/pages/Mining.svelte
+++ b/src/pages/Mining.svelte
@@ -345,13 +345,22 @@
         
         // Update total rewards from actual balance
         if (results[3] !== undefined) {
-          const balance = parseFloat(results[3])
-          if (!isNaN(balance) && balance > 0) {
-            // Use actual balance as total rewards
-            $miningState.totalRewards = balance
+          const balance = parseFloat(results[3]);
+          if (!isNaN(balance)) {
+            // Only update if backend balance is higher
+            if (balance > ($miningState.totalRewards ?? 0)) {
+              $miningState.totalRewards = balance;
+
+              // Mark all "pending" mining reward txs as completed
+              transactions.update(list =>
+                list.map(tx =>
+                  tx.status === 'pending' ? { ...tx, status: 'completed' } : tx
+                )
+              );
+            }
           }
         }
-        
+                
         // Update blocks mined from blockchain query
         if (results[4] !== undefined) {
           const blocksMined = results[4] as number;
@@ -448,24 +457,7 @@
       $miningState.hashRate = '0 H/s'
       $miningState.activeThreads = 0 
 
-      const endRewards = $miningState.totalRewards ?? 0 
-      const endBlocks  = $miningState.blocksFound ?? 0
-      const sessionReward = Math.max(0, endRewards - sessionStartRewards)  
-      const sessionBlocks = Math.max(0, endBlocks - sessionStartBlocks)
-
-      const tx: Transaction = {
-        id: Date.now(),
-        type: 'received',
-        amount: sessionReward,
-        from: 'Mining rewards',
-        date: new Date(),
-        description: sessionBlocks > 0
-          ? `Mining session payout (${sessionBlocks} block${sessionBlocks === 1 ? '' : 's'})`
-          : 'Mining session payout',
-        status: 'completed'
-      }
-      transactions.update(list => [tx, ...list])
-
+      // ❌ Remove session payout, since pushRecentBlock already logs rewards
 
       // Clear session start time
       $miningState.sessionStartTime = undefined
@@ -482,7 +474,6 @@
       console.error('Failed to stop mining:', e)
     }
   }
-
   // Simulation removed; recent blocks come from backend
 
   // Keep a set of hashes we've already shown to avoid duplicates
@@ -507,27 +498,47 @@
 
   $: displayedBlocks = ($miningState.recentBlocks || []).slice((currentPage - 1) * pageSize, currentPage * pageSize)
 
-  function pushRecentBlock(b: {
-    hash: string;
-    nonce?: number;
-    difficulty?: number;
-    timestamp?: Date;
-    number?: number;
-    reward?: number;
-  }) {
-    const item = {
-      id: `block-${b.hash}-${b.timestamp?.getTime() ?? Date.now()}`,
-      hash: b.hash,
-      reward: typeof b.reward === "number" ? b.reward : blockReward,
-      timestamp: b.timestamp ?? new Date(),
-      difficulty: b.difficulty ?? currentDifficulty,
-      nonce: b.nonce ?? 0,
-      number: b.number ?? 0,
-    };
-    $miningState.recentBlocks = [item, ...($miningState.recentBlocks ?? [])].slice(0, 50);
-    // Reset to first page so newly found blocks are visible
-    currentPage = 1
-  }
+function pushRecentBlock(b: {
+  hash: string;
+  nonce?: number;
+  difficulty?: number;
+  timestamp?: Date;
+  number?: number;
+  reward?: number;
+}) {
+  const reward = typeof b.reward === "number" ? b.reward : blockReward;
+
+  const item = {
+    id: `block-${b.hash}-${b.timestamp?.getTime() ?? Date.now()}`,
+    hash: b.hash,
+    reward,
+    timestamp: b.timestamp ?? new Date(),
+    difficulty: b.difficulty ?? currentDifficulty,
+    nonce: b.nonce ?? 0,
+    number: b.number ?? 0,
+  };
+
+  // Add block to recentBlocks
+  $miningState.recentBlocks = [item, ...($miningState.recentBlocks ?? [])].slice(0, 50);
+
+  // Reset pagination so newest block is visible
+  currentPage = 1;
+
+  // 💰 Immediately credit wallet balance (optimistic update)
+  $miningState.totalRewards = ($miningState.totalRewards ?? 0) + reward;
+
+  // 💳 Add a transaction entry for this block
+  const tx: Transaction = {
+    id: Date.now(),
+    type: 'received',
+    amount: reward,
+    from: 'Mining reward',
+    date: new Date(),
+    description: `Block reward (#${item.number})`,
+    status: 'pending' // mark as pending until backend confirms
+  };
+  transactions.update(list => [tx, ...list]);
+}
 
   async function appendNewBlocksFromBackend() {
     try {


### PR DESCRIPTION
Transactions are now recorded automatically as blocks are mined, removing the need to stop mining to update the history. 

<img width="997" height="317" alt="Screenshot 2025-09-22 at 3 20 47 PM" src="https://github.com/user-attachments/assets/84d53545-4bca-4517-9b08-57032cce58b4" />

<img width="985" height="416" alt="Screenshot 2025-09-22 at 3 21 01 PM" src="https://github.com/user-attachments/assets/04ee94c2-d00c-4a8d-8cb6-26e392587b8a" />
