### PR TITLE
feat(nat): DRAFT Team Hawks add libp2p AutoNAT/DCUtR/Ping; surface NAT status to UI; add DevTools invoke helper; scaffold WebRTC signaling + test route

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3023,8 +3023,10 @@ dependencies = [
  "futures-timer",
  "getrandom 0.2.16",
  "libp2p-allow-block-list",
+ "libp2p-autonat",
  "libp2p-connection-limits",
  "libp2p-core",
+ "libp2p-dcutr",
  "libp2p-dns",
  "libp2p-gossipsub",
  "libp2p-identify",
@@ -3033,7 +3035,9 @@ dependencies = [
  "libp2p-mdns",
  "libp2p-metrics",
  "libp2p-noise",
+ "libp2p-ping",
  "libp2p-quic",
+ "libp2p-relay",
  "libp2p-request-response",
  "libp2p-swarm",
  "libp2p-tcp",
@@ -3055,6 +3059,33 @@ dependencies = [
  "libp2p-identity",
  "libp2p-swarm",
  "void",
+]
+
+[[package]]
+name = "libp2p-autonat"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a083675f189803d0682a2726131628e808144911dad076858bfbe30b13065499"
+dependencies = [
+ "async-trait",
+ "asynchronous-codec",
+ "bytes",
+ "either",
+ "futures",
+ "futures-bounded",
+ "futures-timer",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-request-response",
+ "libp2p-swarm",
+ "quick-protobuf",
+ "quick-protobuf-codec",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "thiserror 1.0.69",
+ "tracing",
+ "void",
+ "web-time",
 ]
 
 [[package]]
@@ -3093,6 +3124,29 @@ dependencies = [
  "thiserror 1.0.69",
  "tracing",
  "unsigned-varint 0.8.0",
+ "void",
+ "web-time",
+]
+
+[[package]]
+name = "libp2p-dcutr"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3236a2e24cbcf2d05b398b003ed920e1e8cedede13784d90fa3961b109647ce0"
+dependencies = [
+ "asynchronous-codec",
+ "either",
+ "futures",
+ "futures-bounded",
+ "futures-timer",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "lru",
+ "quick-protobuf",
+ "quick-protobuf-codec",
+ "thiserror 1.0.69",
+ "tracing",
  "void",
  "web-time",
 ]
@@ -3245,10 +3299,13 @@ checksum = "77ebafa94a717c8442d8db8d3ae5d1c6a15e30f2d347e0cd31d057ca72e42566"
 dependencies = [
  "futures",
  "libp2p-core",
+ "libp2p-dcutr",
  "libp2p-gossipsub",
  "libp2p-identify",
  "libp2p-identity",
  "libp2p-kad",
+ "libp2p-ping",
+ "libp2p-relay",
  "libp2p-swarm",
  "pin-project",
  "prometheus-client",
@@ -3282,6 +3339,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "libp2p-ping"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "005a34420359223b974ee344457095f027e51346e992d1e0dcd35173f4cdd422"
+dependencies = [
+ "either",
+ "futures",
+ "futures-timer",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "rand 0.8.5",
+ "tracing",
+ "void",
+ "web-time",
+]
+
+[[package]]
 name = "libp2p-quic"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3303,6 +3378,31 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "libp2p-relay"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10df23d7f5b5adcc129f4a69d6fbd05209e356ccf9e8f4eb10b2692b79c77247"
+dependencies = [
+ "asynchronous-codec",
+ "bytes",
+ "either",
+ "futures",
+ "futures-bounded",
+ "futures-timer",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "quick-protobuf",
+ "quick-protobuf-codec",
+ "rand 0.8.5",
+ "static_assertions",
+ "thiserror 1.0.69",
+ "tracing",
+ "void",
+ "web-time",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -42,7 +42,7 @@ futures-util = "0.3"
 systemstat = "0.2.5"
 sysinfo = "0.31"
 sys-locale = "0.3"
-libp2p = { version = "0.54", features = ["kad", "mdns", "noise", "tcp", "yamux", "identify", "gossipsub", "macros", "tokio", "rsa", "request-response"] }
+libp2p = { version = "0.54", features = ["kad", "mdns", "noise", "tcp", "yamux", "identify", "gossipsub", "macros", "tokio", "rsa", "request-response", "relay", "autonat", "dcutr", "ping"] }
 async-std = { version = "1.12", features = ["attributes"] }
 async-trait = "0.1"
 tracing = "0.1"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -452,6 +452,21 @@ async fn get_dht_health(state: State<'_, AppState>) -> Result<Option<DhtMetricsS
 }
 
 #[tauri::command]
+async fn get_nat_status(state: State<'_, AppState>) -> Result<Option<String>, String> {
+    let dht = {
+        let dht_guard = state.dht.lock().map_err(|e| e.to_string())?;
+        dht_guard.as_ref().cloned()
+    };
+
+    if let Some(dht) = dht {
+        let snap = dht.metrics_snapshot().await;
+        Ok(snap.nat_status)
+    } else {
+        Ok(None)
+    }
+}
+
+#[tauri::command]
 async fn get_dht_events(state: State<'_, AppState>) -> Result<Vec<String>, String> {
     let dht = {
         let dht_guard = state.dht.lock().map_err(|e| e.to_string())?;
@@ -837,6 +852,7 @@ fn main() {
             get_dht_health,
             get_dht_peer_count,
             get_dht_peer_id,
+            get_nat_status,
             start_file_transfer_service,
             upload_file_to_network,
             upload_file_data_to_network,

--- a/src/lib/services/networkService.ts
+++ b/src/lib/services/networkService.ts
@@ -3,15 +3,17 @@ import { invoke } from '@tauri-apps/api/core';
 
 // Export network status store
 export const networkStatus = writable<"connected" | "disconnected">("disconnected");
+export const natStatus = writable<string | null>(null);
 
 // Function to update network status
 export async function updateNetworkStatus(): Promise<void> {
   try {
     // Check Geth and DHT status in parallel
-    const [isGethRunning, dhtPeers, blockchainPeers] = await Promise.all([
+    const [isGethRunning, dhtPeers, blockchainPeers, nat] = await Promise.all([
       invoke<boolean>('is_geth_running').catch(() => false),
       invoke<number>('get_dht_peer_count').catch(() => 0),
-      invoke<number>('get_network_peer_count').catch(() => 0)
+      invoke<number>('get_network_peer_count').catch(() => 0),
+      invoke<string | null>('get_nat_status').catch(() => null)
     ]);
     
     // Determine network connection status
@@ -20,8 +22,9 @@ export async function updateNetworkStatus(): Promise<void> {
     } else {
       networkStatus.set("disconnected");
     }
+    natStatus.set(nat);
     
-    console.log(`🌐 Network status updated: ${isGethRunning ? 'Node running' : 'Node stopped'}, DHT peers: ${dhtPeers}, Blockchain peers: ${blockchainPeers}`);
+    console.log(`🌐 Network status updated: ${isGethRunning ? 'Node running' : 'Node stopped'}, DHT peers: ${dhtPeers}, Blockchain peers: ${blockchainPeers}, NAT: ${nat ?? 'unknown'}`);
     
   } catch (error) {
     console.error('Failed to update network status:', error);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import { mount } from "svelte";
 import App from "./App.svelte";
 import "./styles/globals.css";
+import { invoke as tauriInvoke } from "@tauri-apps/api/core";
 
 console.log("Main.ts loading...");
 
@@ -8,6 +9,10 @@ const target = document.getElementById("app");
 console.log("Target element:", target);
 
 let app: any = null;
+
+// Expose a minimal, namespaced helper for DevTools without relying on window.__TAURI__
+// Usage in DevTools: __chiralInvoke('get_nat_status').then(console.log)
+(globalThis as any).__chiralInvoke = tauriInvoke;
 
 if (!target) {
   console.error("Could not find app element!");


### PR DESCRIPTION
Summary
- Implemented first-pass NAT traversal at the libp2p layer (AutoNAT detection, DCUtR, Ping).
- Exposed NAT status via a new Tauri command and surfaced it in the Svelte UI.
- Added a small DevTools helper to invoke backend commands without dynamic imports.
- Scaffolded WebRTC signaling (client/server) and added a hidden test route for future UI testing.
- Updated docs with how to run signaling and TURN config.

Backend (Rust, Tauri/libp2p)
- src-tauri/Cargo.toml
  - Enabled libp2p features: kad, mdns, noise, tcp, yamux, identify, gossipsub, macros, tokio, rsa, request-response, relay, autonat, dcutr, ping.
- src-tauri/src/dht.rs
  - Behaviour
    - Added ping::Behaviour (keep-alive and RTT visibility).
    - Added autonat::Behaviour (NAT status detection).
    - Added dcutr::Behaviour (Direct Connection Upgrade Through Relay).
  - Metrics
    - Added nat_status: Option<String> on DhtMetrics and DhtMetricsSnapshot; tracked AutoNAT events and included in snapshot.
  - Event handling
    - Handled Ping and AutoNAT events (store latest NAT status string).
  - Listening
    - Continued listening on TCP; removed relay-client behaviour wiring for now to avoid version-specific API usage.
- src-tauri/src/main.rs
  - New Tauri command get_nat_status returning Option<String> (reads from DhtMetricsSnapshot).
  - Registered get_nat_status in invoke_handler.

Frontend (Svelte/TypeScript)
- src/lib/services/networkService.ts
  - Added natStatus store.
  - updateNetworkStatus now invokes get_nat_status and logs “NAT: …”.
- src/main.ts
  - Exposed a global DevTools helper: __chiralInvoke = tauriInvoke (from @tauri-apps/api/core).
  - Allows running calls in DevTools Console: __chiralInvoke('get_nat_status').then(console.log)

WebRTC scaffolding
- src/lib/services/signallingService.ts
  - Added typed signaling messages and helpers: sendOffer, sendAnswer, sendCandidate.
  - Optional onMessage callback for inbound messages.
- src/lib/services/server/signalingServer.js
  - Forward offer/answer/candidate between registered clients; maintain and broadcast peer list.
- src/App.svelte
  - Added a “webrtc-test” route and a menu item (hidden unless navigating directly).
- src/lib/components/WebRTCSignallingTest.svelte
  - Left as a simple scaffold (connect button logs intent) to avoid introducing navigation issues before full flow is ready.

Docs
- README.md
  - Added NAT traversal section (STUN/TURN env variables, signaling server instructions, code locations).

Why
- AutoNAT/DCUtR provide immediate, low-friction NAT traversal improvements at the libp2p layer without requiring TURN/WebRTC for core node connectivity.
- Exposing NAT status helps debug connectivity in early phases and confirms environment/network conditions.
- DevTools helper avoids confusion with dynamic import/await contexts during testing.
- Signaling scaffolding and route enable iterative development of a WebRTC data channel path later, while keeping scope limited for this draft.

Testing
- Desktop app (required for Rust/Tauri):
  - npm run tauri dev
  - In DevTools Console (Cmd+Opt+I):
    - __chiralInvoke('get_nat_status').then(console.log)
    - __chiralInvoke('get_dht_peer_id').then(console.log)
    - __chiralInvoke('get_dht_health').then(console.log)
- Two-node connectivity (LAN easiest):
  - Node A: read peer id and listenAddrs from get_dht_health.
  - Node B: dial Node A’s LAN addr with peer id:
    __chiralInvoke('connect_to_peer', { peerAddress: '/ip4/<A_LAN_IP>/tcp/4001/p2p/<A_PEER_ID>' })
  - Verify:
    __chiralInvoke('get_dht_peer_count').then(console.log) // ≥ 1
- Cross-NAT:
  - Port-forward TCP 4001 on Node A’s router to its LAN IP, then dial via public IP from Node B.

Known limitations and next steps
- AutoNAT may log “OutboundProbe … NoServer” until peers connect; this is expected with 0 peers.
- Relay client behaviour is not wired (constructor/API is version-specific in libp2p 0.54). If we need relayed dialing/reservations, we’ll add the proper transport + behaviour initialization for this version.
- The WebRTC test page is routed but intentionally minimal; full ICE/SDP flow can be re-enabled after UI stability checks.
- Consider adding QUIC and/or WebRTC transports in libp2p if needed for broader NAT scenarios.
- Optionally surface NAT and peer details in the Network page UI for end-users.

Files changed (high-level)
- src-tauri/Cargo.toml
- src-tauri/src/dht.rs
- src-tauri/src/main.rs
- src/lib/services/networkService.ts
- src/main.ts
- src/lib/services/signallingService.ts
- src/lib/services/server/signalingServer.js
- src/App.svelte
- README.md

References
- Fork for PR: https://github.com/hawks-nicholas-gitman/chiral-network.git