### PR TITLE
fix(mining): fixed wrong balance on found blocks

### DIFF
--- a/src/pages/Mining.svelte
+++ b/src/pages/Mining.svelte
@@ -506,7 +506,8 @@ function pushRecentBlock(b: {
   number?: number;
   reward?: number;
 }) {
-  const reward = typeof b.reward === "number" ? b.reward : blockReward;
+
+  const reward = typeof b.reward === "number" ? b.reward : 0;
 
   const item = {
     id: `block-${b.hash}-${b.timestamp?.getTime() ?? Date.now()}`,
@@ -524,20 +525,19 @@ function pushRecentBlock(b: {
   // Reset pagination so newest block is visible
   currentPage = 1;
 
-  // 💰 Immediately credit wallet balance (optimistic update)
-  $miningState.totalRewards = ($miningState.totalRewards ?? 0) + reward;
-
-  // 💳 Add a transaction entry for this block
-  const tx: Transaction = {
-    id: Date.now(),
-    type: 'received',
-    amount: reward,
-    from: 'Mining reward',
-    date: new Date(),
-    description: `Block reward (#${item.number})`,
-    status: 'pending' // mark as pending until backend confirms
-  };
-  transactions.update(list => [tx, ...list]);
+  // 💳 Still log the transaction, but keep status pending
+  if (reward > 0) {
+    const tx: Transaction = {
+      id: Date.now(),
+      type: 'received',
+      amount: reward,
+      from: 'Mining reward',
+      date: new Date(),
+      description: `Block reward (#${item.number})`,
+      status: 'pending' // will flip to 'completed' when backend confirms
+    };
+    transactions.update(list => [tx, ...list]);
+  }
 }
 
   async function appendNewBlocksFromBackend() {


### PR DESCRIPTION
Fix double-counting on "total rewards" in mining dashboard

Before: 
In the photo, it says that 6 blocks are found, and each block gives a reward of $2, so the total reward should be $12 and not $14. 
<img width="987" height="712" alt="Screenshot 2025-09-23 at 5 19 37 PM" src="https://github.com/user-attachments/assets/fb987c71-b504-4ac7-93ca-9cfd8b57cc8a" />

After: 
<img width="1037" height="832" alt="Screenshot 2025-09-23 at 5 29 06 PM" src="https://github.com/user-attachments/assets/bbe2e440-d062-465d-97af-54637187898a" />