### PR TITLE
feat(mining): display block rewards with last 4 hash digits in transaction history 

### DIFF
--- a/src/pages/Mining.svelte
+++ b/src/pages/Mining.svelte
@@ -465,8 +465,6 @@
       $miningState.hashRate = '0 H/s'
       $miningState.activeThreads = 0 
 
-      // ❌ Remove session payout, since pushRecentBlock already logs rewards
-
       // Clear session start time
       $miningState.sessionStartTime = undefined
       // Clear mining history when stopping
@@ -533,15 +531,15 @@ function pushRecentBlock(b: {
   // Reset pagination so newest block is visible
   currentPage = 1;
 
-  // 💳 Still log the transaction, but keep status pending
   if (reward > 0) {
+    const last4 = b.hash.slice(-4); // grab last 4 chars of hash
     const tx: Transaction = {
       id: Date.now(),
       type: 'received',
       amount: reward,
       from: 'Mining reward',
       date: new Date(),
-      description: `Block reward (#${item.number})`,
+      description: `Block Reward (…${last4})`,
       status: 'pending' // will flip to 'completed' when backend confirms
     };
     transactions.update(list => [tx, ...list]);


### PR DESCRIPTION
Block rewards were previously shown only with the block number, which makes it hard to distinguish between them. This update appends the last four digits of the block hash (e.g., …5a40) for clearer identification in the transaction history.

Before: 
<img width="968" height="249" alt="image" src="https://github.com/user-attachments/assets/fad86067-26d4-492c-9799-4cda088fb9b9" />

After: 
<img width="940" height="210" alt="image" src="https://github.com/user-attachments/assets/51c2ad58-1493-4c9c-ad01-2a5ec9f8d771" />
