### PR TITLE
feat(download): Add retry functionality for failed/canceled downloads

### DIFF
--- a/src/pages/Download.svelte
+++ b/src/pages/Download.svelte
@@ -16,6 +16,7 @@
   let maxConcurrentDownloads: string | number = 3
   let lastValidMaxConcurrent = 3 // Store the last valid value
   let autoStartQueue = true
+  let autoClearCompleted = false // New setting for auto-clearing
   let filterStatus = 'all' // 'all', 'active', 'paused', 'queued', 'completed', 'failed'
   let activeSimulations = new Set<string>() // Track files with active progress simulations
 
@@ -725,7 +726,13 @@ function clearSearch() {
               clearInterval(progressInterval);
               activeSimulations.delete(fileId);
               showNotification(`Download completed: ${fileToDownload.name} saved to ${outputPath}`, 'success');
-
+              
+              // New: Auto-clear if enabled
+              if (autoClearCompleted) {
+                setTimeout(() => {
+                  clearDownload(fileId);
+                }, 5000); // 5-second delay before removing
+              }
               return { ...file, progress: 100, status: 'completed', downloadPath: outputPath };
             }
 
@@ -776,6 +783,20 @@ function clearSearch() {
     }
   }
   
+  function clearDownload(fileId: string) {
+    // Remove from both files and downloadQueue for good measure
+    files.update(f => f.filter(file => file.id !== fileId));
+    downloadQueue.update(q => q.filter(file => file.id !== fileId));
+  }
+
+  function clearAllFinished() {
+    files.update(f => f.filter(file => 
+      file.status !== 'completed' && 
+      file.status !== 'failed' && 
+      file.status !== 'canceled'
+    ));
+  }
+
   function retryDownload(fileId: string) {
     const fileToRetry = filteredDownloads.find(f => f.id === fileId);
     if (!fileToRetry || (fileToRetry.status !== 'failed' && fileToRetry.status !== 'canceled')) {
@@ -984,6 +1005,16 @@ function clearSearch() {
         <div class="flex flex-wrap gap-2">
           <Button
             size="sm"
+            variant="outline"
+            on:click={clearAllFinished}
+            class="text-xs text-destructive border-destructive hover:bg-destructive/10 hover:text-destructive"
+            disabled={completedCount === 0 && failedCount === 0 && allFilteredDownloads.filter(f => f.status === 'canceled').length === 0}
+          >
+            <X class="h-3 w-3 mr-1" />
+            Clear Finished
+          </Button>
+          <Button
+            size="sm"
             variant={filterStatus === 'all' ? 'default' : 'outline'}
             on:click={() => filterStatus = 'all'}
             class="text-xs"
@@ -1069,6 +1100,22 @@ function clearSearch() {
               <span
                 class="inline-block h-3 w-3 rounded-full bg-white transition-transform shadow-sm"
                 style="transform: translateX({autoStartQueue ? '18px' : '2px'})"
+              ></span>
+            </button>
+          </div>
+          <div class="flex items-center gap-2">
+            <Label class="font-medium">Auto-clear:</Label>
+            <button
+              type="button"
+              aria-label="Toggle auto-clear completed downloads"
+              on:click={() => autoClearCompleted = !autoClearCompleted}
+              class="relative inline-flex h-4 w-8 items-center rounded-full transition-colors focus:outline-none"
+              class:bg-green-500={autoClearCompleted}
+              class:bg-muted-foreground={!autoClearCompleted}
+            >
+              <span
+                class="inline-block h-3 w-3 rounded-full bg-white transition-transform shadow-sm"
+                style="transform: translateX({autoClearCompleted ? '18px' : '2px'})"
               ></span>
             </button>
           </div>
@@ -1236,6 +1283,15 @@ function clearSearch() {
                     <FolderOpen class="h-3 w-3 mr-1" />
                     Show in Folder
                   </Button>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    on:click={() => clearDownload(file.id)}
+                    class="h-7 px-3 text-sm text-muted-foreground hover:text-destructive"
+                    title={$t('download.actions.remove', { default: 'Remove' })}
+                  >
+                    <X class="h-3 w-3" />
+                  </Button>
                 {:else if file.status === 'failed' || file.status === 'canceled'}
                   <Button
                     size="sm"
@@ -1247,6 +1303,15 @@ function clearSearch() {
                     {$t('download.actions.retry', { default: 'Retry' })}
                   </Button>
                   <!-- You could also add a "Clear" button here to remove it from the list -->
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    on:click={() => clearDownload(file.id)}
+                    class="h-7 px-3 text-sm text-muted-foreground hover:text-destructive"
+                    title={$t('download.actions.remove', { default: 'Remove' })}
+                  >
+                    <X class="h-3 w-3" />
+                  </Button>
                 {/if}
               </div>
             </div>


### PR DESCRIPTION
Improves user experience by adding a "Retry" button to downloads that have a status of 'failed' or 'canceled'.

Previously, users had no direct way to restart a download that did not complete successfully. This change provides a simple one-click action to re-queue the file for download.

This commit introduces:
- A `retryDownload` function that removes the old entry and adds a new one to the download queue with a 'queued' status.
- A "Retry" button in the UI that is conditionally displayed for items with a 'failed' or 'canceled' status.
- Clear Finished Downloads:
     - An individual "Clear" (X) button has been added to all finished items (completed, failed, canceled) to remove them from the list one by one.
     - A "Clear All Finished" button is now available to remove all non-active downloads at once.
- Auto-Clear Completed Downloads:
    -  A new "Auto-clear" toggle has been added to the download settings. When enabled, successfully completed downloads are automatically removed from the list after a 5-second delay.
