### PR TITLE
fix(account) blacklist and key save options showing up with no account

### DIFF
--- a/src/pages/Account.svelte
+++ b/src/pages/Account.svelte
@@ -1967,6 +1967,7 @@
   </Card>
   {/if}
 
+  {#if $etcAccount}
   <Card class="p-6">
     <div class="flex items-center gap-2 mb-4">
       <KeyRound class="h-5 w-5 text-muted-foreground" />
@@ -2021,7 +2022,9 @@
       {/if}
     </div>
   </Card>
-
+  {/if}
+  
+  {#if $etcAccount}
   <Card class="p-6">
     <div class="flex items-center justify-between mb-4">
       <div>
@@ -2278,6 +2281,7 @@
       
     </div>
   </Card>
+  {/if}
 
   <!-- Transaction Receipt Modal -->
   <TransactionReceipt


### PR DESCRIPTION
Internal features were exposed to an unregistered user on the account page, specifically the Blacklisting and Save to Keystore features.

Before:

<img width="1252" height="931" alt="Screenshot 2025-09-24 150429" src="https://github.com/user-attachments/assets/4b108993-de72-4b76-aa42-4ea14e3983bc" />

After:

<img width="1232" height="927" alt="Screenshot 2025-09-24 150244" src="https://github.com/user-attachments/assets/2fde631f-c942-467b-84c4-361aea5bc9d8" />



