### PR TITLE
fix (account): ensure consistent 42-character address generation in website

### DIFF
--- a/src/pages/Account.svelte
+++ b/src/pages/Account.svelte
@@ -352,16 +352,33 @@
       entry.chiral_address.toLowerCase() === address.toLowerCase()
     );
   }
-  
+
   function copyAddress() {
-  const addressToCopy = $etcAccount ? $etcAccount.address : $wallet.address;
-  navigator.clipboard.writeText(addressToCopy);
-  
-  
-  showToast('Address copied to clipboard!', 'success')
-  
-  
-}
+    const addressToCopy = $etcAccount ? $etcAccount.address : $wallet.address;
+    navigator.clipboard.writeText(addressToCopy);
+    
+    
+    showToast('Address copied to clipboard!', 'success')
+  }
+
+  function generateDemoAddress() {
+    const chars = '0123456789abcdef';
+    let address = '0x';
+    for (let i = 0; i < 40; i++) {
+      address += chars[Math.floor(Math.random() * chars.length)];
+    }
+    return address;
+  }
+
+  function generateDemoPrivateKey() {
+    const chars = '0123456789abcdef';
+    let privateKey = '0x';
+    for (let i = 0; i < 64; i++) {
+      privateKey += chars[Math.floor(Math.random() * chars.length)];
+    }
+    return privateKey;
+  }
+
 
   function copyPrivateKey() {
     with2FA(() => {
@@ -612,8 +629,9 @@
     if (isTauri) {
       account = await invoke('create_chiral_account') as { address: string, private_key: string, blacklist: Object[] }
     } else {
-      const demoAddress = '0x' + Math.random().toString(16).substr(2, 40)
-      const demoPrivateKey = '0x' + Math.random().toString(16).substr(2, 64)
+      const demoAddress = generateDemoAddress()
+      const demoPrivateKey = generateDemoPrivateKey()
+
       const demoBlackList = [{node_id: 169245, name: "Jane"}]
       account = {
         address: demoAddress,
@@ -738,7 +756,7 @@
       if (isTauri) {
         account = await invoke('import_chiral_account', { privateKey: importPrivateKey }) as { address: string, private_key: string }
       } else {
-        const demoAddress = '0x' + Math.random().toString(16).substr(2, 40)
+        const demoAddress = generateDemoAddress();
         account = {
           address: demoAddress,
           private_key: importPrivateKey


### PR DESCRIPTION
- Replace Math.random().toString(16).substr() with guaranteed-length hex generation
- Add generateDemoAddress() and generateDemoPrivateKey() helper functions
- Fix address copy functionality returning truncated addresses in web demo
- Addresses are now consistently 42 characters (0x + 40 hex chars)
- Private keys are now consistently 66 characters (0x + 64 hex chars)

Previously:
<img width="1583" height="628" alt="image" src="https://github.com/user-attachments/assets/ff357029-88d1-4556-9516-e2e190c8586b" />
Now:
<img width="992" height="583" alt="image" src="https://github.com/user-attachments/assets/f6d3cd11-3954-489a-a335-63d5cedb7ac0" />
