### PR TITLE
fix(account): reset blacklist on new account creation

### DIFF
--- a/src/pages/Account.svelte
+++ b/src/pages/Account.svelte
@@ -632,11 +632,10 @@
       const demoAddress = generateDemoAddress()
       const demoPrivateKey = generateDemoPrivateKey()
 
-      const demoBlackList = [{node_id: 169245, name: "Jane"}]
       account = {
         address: demoAddress,
         private_key: demoPrivateKey,
-        blacklist: demoBlackList
+        blacklist: []
       }
       console.log('Running in web mode - using demo account')
     }
@@ -649,8 +648,8 @@
       pendingTransactions: 0
     }))
 
-    // 🔹 Reset transaction history for new account
     transactions.set([])
+    blacklist.set([])   
 
     showToast('Account Created Successfully!', 'success')
     


### PR DESCRIPTION
This fix make sure that when a new wallet account is created, the blacklist is initialized as an empty array instead of containing demo data. 

Before: 
<img width="2018" height="1376" alt="image" src="https://github.com/user-attachments/assets/be95aa28-94dc-4aa9-88c2-8288f2d5bd24" />

After: 
<img width="999" height="711" alt="image" src="https://github.com/user-attachments/assets/d14dc088-a821-44f4-8833-32775356cc87" />
