### PR TITLE
feat(upload): Implemented Stop Publishing/Sharing to Network

### DIFF
--- a/src/pages/Upload.svelte
+++ b/src/pages/Upload.svelte
@@ -115,7 +115,7 @@
   onMount(() => {
     refreshAvailableStorage()
 
-    // totoro: think this is for reacting to drag and drops...
+    // totoro: think this is for reacting to drag and drops... 
     // const unlisten = appWindow.onFileDropEvent((event) => {
     //   switch (event.payload.type) {
     //     case 'hover':
@@ -148,13 +148,20 @@
         addFilesFromPaths([selectedPaths]);
       }
     } catch (e) {
-      console.error("Error opening file dialog:", e);
       showToast(tr('upload.fileDialogError'), 'error');
     }
   }
   
-  function removeFile(fileId: string) {
-    files.update(f => f.filter(file => file.id !== fileId))
+  async function removeFile(fileHash: string) {
+
+    try {
+        await invoke('stop_publishing_file',{fileHash});
+        console.log("stopped publishing file")
+        files.update(f => f.filter(file => file.hash !== fileHash))
+      } catch (error) {
+        console.error(error);
+        showToast(tr('upload.fileFailed', { values: { name: fileHash, error: String(error) } }), 'error');
+      }
   }
   
   async function addFilesFromPaths(paths: string[]) {
@@ -406,7 +413,7 @@
                   </div>
                   
                   <button
-                    on:click={() => removeFile(file.id)}
+                    on:click={() => removeFile(file.hash)}
                     class="group/btn p-2 hover:bg-destructive/10 rounded-lg transition-all duration-200 hover:scale-110"
                     title={$t('upload.stopSharing')}
                     aria-label="Stop sharing file"


### PR DESCRIPTION
Before:
Clicking "X" on the file in upload tab as the provider wouldn't stop you from publishing it to network.
<img width="541" height="212" alt="image" src="https://github.com/user-attachments/assets/c288480d-17d2-43a7-a1db-8d2095724e7b" />

After:
It now does stop you from publishing the file to the network, after `kad_record_ttl` expires, it will no longer be found on network. The default TTL is 36 hours.	
<img width="951" height="234" alt="image" src="https://github.com/user-attachments/assets/cce451ae-3a53-47c0-b165-3194e376a111" />

Also changed replication factor of kademlia 20 to 3 to match documentation.