### PR TITLE
fix: correct block reward display from 5 to 2 Chiral

### DIFF
--- a/src/pages/Mining.svelte
+++ b/src/pages/Mining.svelte
@@ -611,7 +611,7 @@ function pushRecentBlock(b: {
           difficulty: b.difficulty ? parseInt(b.difficulty, 16) : undefined,
           timestamp: new Date((b.timestamp || 0) * 1000),
           number: b.number,
-          reward: 5
+          reward: 2
         });
       }
       // Hard de-duplication by hash as a safety net


### PR DESCRIPTION
Fixed hardcoded block reward value that was incorrectly showing 5 Chiral instead of the actual 2 Chiral reward amount.

Changes:
- Updated reward value in appendNewBlocksFromBackend function from 5 to 2
-before
<img width="1629" height="411" alt="截屏2025-09-25 22 34 38" src="https://github.com/user-attachments/assets/d03d4a66-b30f-4f58-b7e7-c2c698be1855" />
after
<img width="1920" height="1080" alt="截屏2025-09-25 22 33 56" src="https://github.com/user-attachments/assets/e049b297-7a8a-4add-a127-0088880efed8" />
