### PR TITLE
fix: increase block search range from 100 to 1000 blocks

### DIFF
--- a/src-tauri/src/ethereum.rs
+++ b/src-tauri/src/ethereum.rs
@@ -988,7 +988,7 @@ pub async fn get_mined_blocks_count(miner_address: &str) -> Result<u64, String> 
         .map_err(|e| format!("Failed to parse block number: {}", e))?;
 
     // Check recent blocks (last 100 or current block count, whichever is smaller)
-    let blocks_to_check = std::cmp::min(100, current_block);
+    let blocks_to_check = std::cmp::min(1000, current_block);
     let start_block = current_block.saturating_sub(blocks_to_check);
 
     // Normalize the miner address for comparison

--- a/src/pages/Mining.svelte
+++ b/src/pages/Mining.svelte
@@ -109,8 +109,7 @@
 
   $: displayedTemperature = temperatureUnit === 'F' ? toFahrenheit(temperature).toFixed(1) : temperature.toFixed(1);
 
-  $: expectedTotalRewards = $miningState.blocksFound * 2;
-  $: $miningState.totalRewards = expectedTotalRewards;
+
   
 
   function parseHashRate(rateStr: string): number {
@@ -314,10 +313,15 @@
           if (hashRateFromLogs > 0) {
             // Use actual hash rate from logs
             $miningState.hashRate = formatHashRate(hashRateFromLogs)
-            if (blocksFound > $miningState.blocksFound) {
-              $miningState.blocksFound = blocksFound*5; 
-              //Visualization Now Handled By Backend
-            }
+            
+            console.log('From mining stats - blocks:', blocksFound);
+            console.log('Current blocksFound before:', $miningState.blocksFound);
+            
+            $miningState.blocksFound = blocksFound;
+            
+            console.log('blocksFound after:', $miningState.blocksFound);
+          
+            
           } else if ($miningState.activeThreads > 0) {
             // Fall back to simulation if no log data yet
             const elapsed = (Date.now() - sessionStartTime) / 1000 // seconds
@@ -410,11 +414,16 @@
       }  
               
       // Update blocks mined from blockchain query
+      
       if (results[4] !== undefined) {
         const blocksMined = results[4] as number;
-        if (blocksMined > $miningState.blocksFound) {
-          $miningState.blocksFound = blocksMined;
-        }
+        
+        console.log('Backend returned blocks:', blocksMined);
+        console.log('Current blocksFound before update:', $miningState.blocksFound);
+        
+        $miningState.blocksFound = blocksMined;
+        
+        console.log('blocksFound after update:', $miningState.blocksFound);
       }
     }
   } catch (e) {


### PR DESCRIPTION
- Fixed blocks found counter stopping at 101
- debug console.log statements
- Increased search range in get_mined_blocks_count from 100 to 1000 blocks
- This allows the block counter to continue growing instead of being limited by recent block range
before
<img width="1920" height="1080" alt="截屏2025-09-25 22 44 28" src="https://github.com/user-attachments/assets/36295de4-1158-4ebd-bee9-1d99422722d3" />
after
<img width="1920" height="1080" alt="截屏2025-09-26 00 24 50" src="https://github.com/user-attachments/assets/8fc9e2d2-b0dd-44dc-a8ef-69c6e3bbde44" />
