### PR TITLE
feat(nat): surface reachability telemetry and UI card

### DIFF
--- a/docs/04-implementation-guide.md
+++ b/docs/04-implementation-guide.md
@@ -431,6 +431,21 @@ pub async fn download_file(
 
 ## Phase 4: Integration Testing
 
+### NAT reachability instrumentation
+
+- AutoNAT v2 client and server behaviours are mounted alongside Kademlia. The
+  probe interval defaults to 30 s and can be adjusted with
+  `--autonat-probe-interval`; disable probing entirely via `--disable-autonat`.
+- Additional AutoNAT servers can be supplied with repeated
+  `--autonat-server` flags. `--show-reachability` streams a periodic summary in
+  headless mode (state, confidence, observed addresses, last error) so ops can
+  validate reachability without the GUI.
+- The Network → DHT page now surfaces a “Reachability” card that mirrors Kubo’s
+  vocabulary (Direct/Relayed/Unknown), confidence badge, observed external
+  addresses with copy affordances, and the last few probe summaries. Toasts are
+  emitted when reachability changes (restored, degraded, reset) to give desktop
+  operators immediate feedback.
+
 ### Local download resilience & tracing
 
 The desktop runtime now performs up to three local download attempts with an
@@ -446,7 +461,6 @@ frontend event and exposes a `get_download_metrics` command returning aggregate
 success/failure counters and the last 20 attempts. Headless mode gains a
 `--show-downloads` flag that prints the same snapshot at startup so operators can
 confirm retry behaviour without the GUI.
-
 ### Test Network Setup
 
 ```bash

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -854,6 +854,8 @@ dependencies = [
  "tauri-plugin-store",
  "tempfile",
  "tokio",
+ "tokio-socks",
+ "tokio-util",
  "totp-rs",
  "tracing",
  "tracing-subscriber",
@@ -3040,6 +3042,7 @@ dependencies = [
  "futures-timer",
  "getrandom 0.2.16",
  "libp2p-allow-block-list",
+ "libp2p-autonat",
  "libp2p-connection-limits",
  "libp2p-core",
  "libp2p-dns",
@@ -3074,6 +3077,33 @@ dependencies = [
  "libp2p-identity",
  "libp2p-swarm",
  "void",
+]
+
+[[package]]
+name = "libp2p-autonat"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a083675f189803d0682a2726131628e808144911dad076858bfbe30b13065499"
+dependencies = [
+ "async-trait",
+ "asynchronous-codec",
+ "bytes",
+ "either",
+ "futures",
+ "futures-bounded",
+ "futures-timer",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-request-response",
+ "libp2p-swarm",
+ "quick-protobuf",
+ "quick-protobuf-codec",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "thiserror 1.0.69",
+ "tracing",
+ "void",
+ "web-time",
 ]
 
 [[package]]
@@ -6809,6 +6839,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-socks"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4770b8024672c1101b3f6733eab95b18007dbe0847a8afe341fcf79e06043f"
+dependencies = [
+ "either",
+ "futures-util",
+ "thiserror 1.0.69",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6816,6 +6858,7 @@ checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -45,7 +45,7 @@ futures-util = "0.3"
 systemstat = "0.2.5"
 sysinfo = "0.31"
 sys-locale = "0.3"
-libp2p = { version = "0.54", features = ["kad", "mdns", "noise", "tcp", "yamux", "identify", "gossipsub", "macros", "tokio", "rsa", "request-response", "relay", "ping"] }
+libp2p = { version = "0.54", features = ["kad", "mdns", "noise", "tcp", "yamux", "identify", "gossipsub", "macros", "tokio", "rsa", "request-response", "relay", "ping", "autonat"] }
 async-std = { version = "1.12", features = ["attributes"] }
 async-trait = "0.1"
 tracing = "0.1"

--- a/src-tauri/src/dht.rs
+++ b/src-tauri/src/dht.rs
@@ -1,19 +1,14 @@
-use futures_util::StreamExt;
 use async_trait::async_trait;
-
+use futures::future::{BoxFuture, FutureExt};
 use futures::io::{AsyncRead as FAsyncRead, AsyncWrite as FAsyncWrite};
-use futures::AsyncReadExt as _;
-use futures::AsyncWriteExt as _;
-use futures::future::Either;
-
-// Use tokio::io traits as base for the custom AsyncIo trait
-use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt}; 
-use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
+use futures::{AsyncReadExt as _, AsyncWriteExt as _};
+use futures_util::StreamExt;
+use tokio_util::compat::TokioAsyncReadCompatExt;
 
 use libp2p::multiaddr::Protocol;
 use serde::{Deserialize, Serialize};
-use std::collections::{HashMap, HashSet};
-use std::net::{IpAddr, SocketAddr}; 
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::net::{IpAddr, SocketAddr};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -26,15 +21,21 @@ use std::error::Error;
 use std::io::{self};
 use tokio_socks::tcp::Socks5Stream;
 
-use std::task::{Context, Poll};
 use std::pin::Pin;
-use futures::future::{BoxFuture, FutureExt}; 
+use std::task::{Context, Poll};
 
-// MODIFIED: Trait alias uses tokio::io traits
+// Trait alias to abstract over async I/O types used by proxy transport
 pub trait AsyncIo: FAsyncRead + FAsyncWrite + Unpin + Send {}
 impl<T: FAsyncRead + FAsyncWrite + Unpin + Send> AsyncIo for T {}
 
+use libp2p::core::upgrade::Version;
 use libp2p::{
+    autonat::v2,
+    core::{
+        muxing::StreamMuxerBox,
+        // FIXED E0432: ListenerEvent is removed, only import what is available.
+        transport::{Boxed, DialOpts, ListenerId, Transport, TransportError, TransportEvent},
+    },
     identify::{self, Event as IdentifyEvent},
     identity,
     kad::{
@@ -42,22 +43,13 @@ use libp2p::{
         Event as KademliaEvent, GetRecordOk, Mode, PutRecordOk, QueryResult, Record,
     },
     mdns::{tokio::Behaviour as Mdns, Event as MdnsEvent},
+    noise,
     ping::{self, Behaviour as Ping, Event as PingEvent},
     request_response as rr,
-    swarm::{NetworkBehaviour, SwarmEvent},
-    Multiaddr, PeerId, StreamProtocol, Swarm, SwarmBuilder,
-    core::{
-        upgrade, muxing::StreamMuxerBox, 
-        // FIXED E0432: ListenerEvent is removed, only import what is available.
-        transport::{Boxed, Transport, TransportError, ListenerId, DialOpts, TransportEvent},
-    },
-    noise,
-    tcp,
-    yamux,
-    identity::Keypair,
+    swarm::{behaviour::toggle, NetworkBehaviour, SwarmEvent},
+    tcp, Multiaddr, PeerId, StreamProtocol, Swarm, SwarmBuilder,
 };
-use libp2p::core::upgrade::Version;
-
+use rand::rngs::OsRng;
 const EXPECTED_PROTOCOL_VERSION: &str = "/chiral/1.0.0";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -70,9 +62,57 @@ pub struct FileMetadata {
     pub seeders: Vec<String>,
     pub created_at: u64,
     pub mime_type: Option<String>,
+    /// Whether the file is encrypted
     pub is_encrypted: bool,
+    /// The encryption method used (e.g., "AES-256-GCM")
     pub encryption_method: Option<String>,
+    /// Fingerprint of the encryption key for identification
     pub key_fingerprint: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum NatReachabilityState {
+    Unknown,
+    Public,
+    Private,
+}
+
+impl Default for NatReachabilityState {
+    fn default() -> Self {
+        NatReachabilityState::Unknown
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum NatConfidence {
+    Low,
+    Medium,
+    High,
+}
+
+impl Default for NatConfidence {
+    fn default() -> Self {
+        NatConfidence::Low
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NatHistoryItem {
+    pub state: NatReachabilityState,
+    pub confidence: NatConfidence,
+    pub timestamp: u64,
+    pub summary: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct ReachabilityRecord {
+    state: NatReachabilityState,
+    confidence: NatConfidence,
+    timestamp: SystemTime,
+    summary: Option<String>,
 }
 
 #[derive(NetworkBehaviour)]
@@ -82,6 +122,8 @@ struct DhtBehaviour {
     mdns: Mdns,
     ping: ping::Behaviour,
     proxy_rr: rr::Behaviour<ProxyCodec>,
+    autonat_client: toggle::Toggle<v2::client::Behaviour>,
+    autonat_server: toggle::Toggle<v2::server::Behaviour>,
 }
 
 #[derive(Debug)]
@@ -123,6 +165,12 @@ pub enum DhtEvent {
         utf8: Option<String>,
         bytes: usize,
     },
+    NatStatus {
+        state: NatReachabilityState,
+        confidence: NatConfidence,
+        last_error: Option<String>,
+        summary: Option<String>,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -145,6 +193,16 @@ struct DhtMetrics {
     last_error: Option<String>,
     bootstrap_failures: u64,
     listen_addrs: Vec<String>,
+    reachability_state: NatReachabilityState,
+    reachability_confidence: NatConfidence,
+    last_reachability_change: Option<SystemTime>,
+    last_probe_at: Option<SystemTime>,
+    last_reachability_error: Option<String>,
+    observed_addrs: Vec<String>,
+    reachability_history: VecDeque<ReachabilityRecord>,
+    success_streak: u32,
+    failure_streak: u32,
+    autonat_enabled: bool,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -157,6 +215,14 @@ pub struct DhtMetricsSnapshot {
     pub last_error_at: Option<u64>,
     pub bootstrap_failures: u64,
     pub listen_addrs: Vec<String>,
+    pub reachability: NatReachabilityState,
+    pub reachability_confidence: NatConfidence,
+    pub last_reachability_change: Option<u64>,
+    pub last_probe_at: Option<u64>,
+    pub last_reachability_error: Option<String>,
+    pub observed_addrs: Vec<String>,
+    pub reachability_history: Vec<NatHistoryItem>,
+    pub autonat_enabled: bool,
 }
 
 // ------Proxy Protocol Implementation------
@@ -257,7 +323,7 @@ impl Transport for Socks5Transport {
     // FIXED E0050, E0046: Corrected implementation
     fn listen_on(
         &mut self,
-        _id: ListenerId, 
+        _id: ListenerId,
         _addr: libp2p::Multiaddr,
     ) -> Result<(), TransportError<Self::Error>> {
         Err(TransportError::Other(io::Error::new(
@@ -265,11 +331,11 @@ impl Transport for Socks5Transport {
             "SOCKS5 transport does not support listening",
         )))
     }
-    
+
     fn remove_listener(&mut self, _id: ListenerId) -> bool {
         false
     }
-    
+
     fn poll(
         self: Pin<&mut Self>,
         _cx: &mut Context<'_>,
@@ -283,32 +349,36 @@ impl Transport for Socks5Transport {
         _opts: DialOpts,
     ) -> Result<Self::Dial, TransportError<Self::Error>> {
         let proxy = self.proxy;
-        
+
         // Convert Multiaddr to string for SOCKS5 connection
         let target = match addr_to_socket_addr(&addr) {
             Some(socket_addr) => socket_addr.to_string(),
-            None => return Err(TransportError::Other(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                "Invalid address for SOCKS5",
-            ))),
+            None => {
+                return Err(TransportError::Other(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "Invalid address for SOCKS5",
+                )))
+            }
         };
-        
+
         Ok(async move {
-            let stream = Socks5Stream::connect(proxy, target).await
+            let stream = Socks5Stream::connect(proxy, target)
+                .await
                 .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
-            
+
             // CORRECT: Convert tokio stream to futures stream via .compat().
-            let compat = stream.compat(); 
+            let compat = stream.compat();
             // The compat stream correctly implements FAsyncRead/FAsyncWrite required by AsyncIo.
-            Ok(Box::new(compat) as Box<dyn AsyncIo>) 
-        }.boxed())
+            Ok(Box::new(compat) as Box<dyn AsyncIo>)
+        }
+        .boxed())
     }
 }
 
 // Helper function to convert Multiaddr to SocketAddr
 fn addr_to_socket_addr(addr: &libp2p::Multiaddr) -> Option<SocketAddr> {
     use libp2p::multiaddr::Protocol;
-    
+
     let mut iter = addr.iter();
     match (iter.next(), iter.next()) {
         (Some(Protocol::Ip4(ip)), Some(Protocol::Tcp(port))) => {
@@ -327,14 +397,55 @@ impl DhtMetricsSnapshot {
             ts.duration_since(UNIX_EPOCH).ok().map(|d| d.as_secs())
         }
 
+        let DhtMetrics {
+            last_bootstrap,
+            last_success,
+            last_error_at,
+            last_error,
+            bootstrap_failures,
+            listen_addrs,
+            reachability_state,
+            reachability_confidence,
+            last_reachability_change,
+            last_probe_at,
+            last_reachability_error,
+            observed_addrs,
+            reachability_history,
+            autonat_enabled,
+            ..
+        } = metrics;
+
+        let history: Vec<NatHistoryItem> = reachability_history
+            .into_iter()
+            .map(|record| NatHistoryItem {
+                state: record.state,
+                confidence: record.confidence,
+                timestamp: record
+                    .timestamp
+                    .duration_since(UNIX_EPOCH)
+                    .ok()
+                    .map(|d| d.as_secs())
+                    .unwrap_or_default(),
+                summary: record.summary,
+            })
+            .collect();
+
         DhtMetricsSnapshot {
             peer_count,
-            last_bootstrap: metrics.last_bootstrap.and_then(to_secs),
-            last_peer_event: metrics.last_success.and_then(to_secs),
-            last_error: metrics.last_error,
-            last_error_at: metrics.last_error_at.and_then(to_secs),
-            bootstrap_failures: metrics.bootstrap_failures,
-            listen_addrs: metrics.listen_addrs,
+            last_bootstrap: last_bootstrap.and_then(to_secs),
+            last_peer_event: last_success.and_then(to_secs),
+            last_error,
+            last_error_at: last_error_at.and_then(to_secs),
+            bootstrap_failures,
+            listen_addrs,
+            reachability: reachability_state,
+            reachability_confidence,
+            last_reachability_change: last_reachability_change.and_then(to_secs),
+            last_probe_at: last_probe_at.and_then(to_secs),
+            last_reachability_error,
+            observed_addrs,
+            reachability_history: history,
+            autonat_enabled,
         }
     }
 }
@@ -349,6 +460,89 @@ impl DhtMetrics {
         {
             self.listen_addrs.push(addr_str);
         }
+    }
+
+    fn record_observed_addr(&mut self, addr: &Multiaddr) {
+        let addr_str = addr.to_string();
+        if self
+            .observed_addrs
+            .iter()
+            .any(|existing| existing == &addr_str)
+        {
+            return;
+        }
+        self.observed_addrs.push(addr_str);
+        if self.observed_addrs.len() > 8 {
+            self.observed_addrs.remove(0);
+        }
+    }
+
+    fn remove_observed_addr(&mut self, addr: &Multiaddr) {
+        let addr_str = addr.to_string();
+        self.observed_addrs.retain(|existing| existing != &addr_str);
+    }
+
+    fn confidence_from_streak(&self, streak: u32) -> NatConfidence {
+        match streak {
+            0 | 1 => NatConfidence::Low,
+            2 | 3 => NatConfidence::Medium,
+            _ => NatConfidence::High,
+        }
+    }
+
+    fn push_history(&mut self, record: ReachabilityRecord) {
+        self.reachability_history.push_front(record);
+        if self.reachability_history.len() > 10 {
+            self.reachability_history.pop_back();
+        }
+    }
+
+    fn update_reachability(&mut self, state: NatReachabilityState, summary: Option<String>) {
+        let now = SystemTime::now();
+        self.last_probe_at = Some(now);
+
+        match state {
+            NatReachabilityState::Public => {
+                self.success_streak = self.success_streak.saturating_add(1);
+                self.failure_streak = 0;
+                self.last_reachability_error = None;
+                self.reachability_confidence = self.confidence_from_streak(self.success_streak);
+            }
+            NatReachabilityState::Private => {
+                self.failure_streak = self.failure_streak.saturating_add(1);
+                self.success_streak = 0;
+                if let Some(ref s) = summary {
+                    self.last_reachability_error = Some(s.clone());
+                }
+                self.reachability_confidence = self.confidence_from_streak(self.failure_streak);
+            }
+            NatReachabilityState::Unknown => {
+                self.success_streak = 0;
+                self.failure_streak = 0;
+                self.reachability_confidence = NatConfidence::Low;
+                self.last_reachability_error = summary.clone();
+            }
+        }
+
+        let state_changed = self.reachability_state != state;
+        self.reachability_state = state;
+
+        if state_changed {
+            self.last_reachability_change = Some(now);
+        }
+
+        if state_changed || summary.is_some() {
+            self.push_history(ReachabilityRecord {
+                state,
+                confidence: self.reachability_confidence,
+                timestamp: now,
+                summary,
+            });
+        }
+    }
+
+    fn note_probe_failure(&mut self, error: String) {
+        self.last_reachability_error = Some(error);
     }
 }
 
@@ -567,6 +761,18 @@ async fn run_dht_node(
                                 }
                             }
                         }
+                    }
+                    SwarmEvent::Behaviour(DhtBehaviourEvent::AutonatClient(ev)) => {
+                        handle_autonat_client_event(ev, &metrics, &event_tx).await;
+                    }
+                    SwarmEvent::Behaviour(DhtBehaviourEvent::AutonatServer(ev)) => {
+                        debug!(?ev, "AutoNAT server event");
+                    }
+                    SwarmEvent::ExternalAddrConfirmed { address, .. } => {
+                        handle_external_addr_confirmed(&address, &metrics, &event_tx).await;
+                    }
+                    SwarmEvent::ExternalAddrExpired { address, .. } => {
+                        handle_external_addr_expired(&address, &metrics, &event_tx).await;
                     }
                     SwarmEvent::ConnectionEstablished { peer_id, endpoint, .. } => {
                         info!("✅ CONNECTION ESTABLISHED with peer: {}", peer_id);
@@ -921,6 +1127,143 @@ async fn handle_ping_event(event: PingEvent) {
     }
 }
 
+async fn handle_autonat_client_event(
+    event: v2::client::Event,
+    metrics: &Arc<Mutex<DhtMetrics>>,
+    event_tx: &mpsc::Sender<DhtEvent>,
+) {
+    let v2::client::Event {
+        tested_addr,
+        server,
+        bytes_sent,
+        result,
+    } = event;
+
+    let mut metrics_guard = metrics.lock().await;
+    if !metrics_guard.autonat_enabled {
+        return;
+    }
+
+    let addr_str = tested_addr.to_string();
+    let server_str = server.to_string();
+    let (state, summary) = match result {
+        Ok(()) => {
+            metrics_guard.record_observed_addr(&tested_addr);
+            info!(
+                server = %server_str,
+                address = %addr_str,
+                bytes = bytes_sent,
+                "AutoNAT probe succeeded"
+            );
+            (
+                NatReachabilityState::Public,
+                Some(format!(
+                    "Confirmed reachability via {addr_str} (server {server_str})"
+                )),
+            )
+        }
+        Err(err) => {
+            let err_msg = err.to_string();
+            warn!(
+                server = %server_str,
+                address = %addr_str,
+                error = %err_msg,
+                bytes = bytes_sent,
+                "AutoNAT probe failed"
+            );
+            (
+                NatReachabilityState::Private,
+                Some(format!(
+                    "Probe via {addr_str} (server {server_str}) failed: {err_msg}"
+                )),
+            )
+        }
+    };
+
+    metrics_guard.update_reachability(state, summary.clone());
+    let nat_state = metrics_guard.reachability_state;
+    let confidence = metrics_guard.reachability_confidence;
+    let last_error = metrics_guard.last_reachability_error.clone();
+    drop(metrics_guard);
+
+    let _ = event_tx
+        .send(DhtEvent::NatStatus {
+            state: nat_state,
+            confidence,
+            last_error,
+            summary,
+        })
+        .await;
+}
+
+async fn handle_external_addr_confirmed(
+    addr: &Multiaddr,
+    metrics: &Arc<Mutex<DhtMetrics>>,
+    event_tx: &mpsc::Sender<DhtEvent>,
+) {
+    let mut metrics_guard = metrics.lock().await;
+    let nat_enabled = metrics_guard.autonat_enabled;
+    metrics_guard.record_observed_addr(addr);
+    if metrics_guard.reachability_state == NatReachabilityState::Public {
+        drop(metrics_guard);
+        return;
+    }
+    let summary = Some(format!("External address confirmed: {}", addr));
+    metrics_guard.update_reachability(NatReachabilityState::Public, summary.clone());
+    let state = metrics_guard.reachability_state;
+    let confidence = metrics_guard.reachability_confidence;
+    let last_error = metrics_guard.last_reachability_error.clone();
+    drop(metrics_guard);
+
+    if !nat_enabled {
+        return;
+    }
+
+    let _ = event_tx
+        .send(DhtEvent::NatStatus {
+            state,
+            confidence,
+            last_error,
+            summary,
+        })
+        .await;
+}
+
+async fn handle_external_addr_expired(
+    addr: &Multiaddr,
+    metrics: &Arc<Mutex<DhtMetrics>>,
+    event_tx: &mpsc::Sender<DhtEvent>,
+) {
+    let summary_text = format!("External address expired: {}", addr);
+    let mut metrics_guard = metrics.lock().await;
+    let nat_enabled = metrics_guard.autonat_enabled;
+    metrics_guard.remove_observed_addr(addr);
+
+    if metrics_guard.observed_addrs.is_empty()
+        && metrics_guard.reachability_state != NatReachabilityState::Unknown
+    {
+        let summary = Some(summary_text);
+        metrics_guard.update_reachability(NatReachabilityState::Unknown, summary.clone());
+        let state = metrics_guard.reachability_state;
+        let confidence = metrics_guard.reachability_confidence;
+        let last_error = metrics_guard.last_reachability_error.clone();
+        drop(metrics_guard);
+
+        if !nat_enabled {
+            return;
+        }
+
+        let _ = event_tx
+            .send(DhtEvent::NatStatus {
+                state,
+                confidence,
+                last_error,
+                summary,
+            })
+            .await;
+    }
+}
+
 impl Socks5Transport {
     pub fn new(proxy: SocketAddr) -> Self {
         Self { proxy }
@@ -931,7 +1274,7 @@ impl Socks5Transport {
 pub fn build_custom_transport(
     keypair: identity::Keypair,
     proxy_address: Option<String>,
-) -> Result<libp2p::core::transport::Boxed<(PeerId, StreamMuxerBox)>, Box<dyn Error>> {
+) -> Result<Boxed<(PeerId, StreamMuxerBox)>, Box<dyn Error>> {
     let noise_keys = noise::Config::new(&keypair)?;
     let yamux_config = libp2p::yamux::Config::default();
 
@@ -1006,7 +1349,10 @@ impl DhtService {
         bootstrap_nodes: Vec<String>,
         secret: Option<String>,
         is_bootstrap: bool,
-        proxy_address: Option<String>, 
+        enable_autonat: bool,
+        autonat_probe_interval: Option<Duration>,
+        autonat_servers: Vec<String>,
+        proxy_address: Option<String>,
     ) -> Result<Self, Box<dyn Error>> {
         // Generate a new keypair for this node
         // Generate a keypair either from the secret or randomly
@@ -1068,21 +1414,54 @@ impl DhtService {
             std::iter::once(("/chiral/proxy/1.0.0".to_string(), rr::ProtocolSupport::Full));
         let proxy_rr = rr::Behaviour::new(protocols, rr_cfg);
 
+        let probe_interval = autonat_probe_interval.unwrap_or(Duration::from_secs(30));
+        let autonat_client_behaviour = if enable_autonat {
+            info!(
+                "AutoNAT enabled (probe interval: {}s)",
+                probe_interval.as_secs()
+            );
+            Some(v2::client::Behaviour::new(
+                OsRng,
+                v2::client::Config::default().with_probe_interval(probe_interval),
+            ))
+        } else {
+            info!("AutoNAT disabled");
+            None
+        };
+        let autonat_server_behaviour = if enable_autonat {
+            Some(v2::server::Behaviour::new(OsRng))
+        } else {
+            None
+        };
+
         let behaviour = DhtBehaviour {
             kademlia,
             identify,
             mdns,
             ping: Ping::new(ping::Config::new()),
             proxy_rr,
+            autonat_client: toggle::Toggle::from(autonat_client_behaviour),
+            autonat_server: toggle::Toggle::from(autonat_server_behaviour),
         };
+
+        let bootstrap_set: HashSet<String> = bootstrap_nodes.iter().cloned().collect();
+        let mut autonat_targets: HashSet<String> = if enable_autonat && !autonat_servers.is_empty()
+        {
+            autonat_servers.into_iter().collect()
+        } else {
+            HashSet::new()
+        };
+        if enable_autonat {
+            autonat_targets.extend(bootstrap_set.iter().cloned());
+        }
 
         // Use the new SOCKS5-aware transport builder
         let transport = build_custom_transport(local_key.clone(), proxy_address)?;
 
         // Create the swarm
-        let mut swarm = libp2p::SwarmBuilder::with_existing_identity(local_key)
+        let mut swarm = SwarmBuilder::with_existing_identity(local_key)
             .with_tokio()
-            .with_other_transport(|_| Ok(transport)) 
+            .with_other_transport(|_| Ok(transport))
             .expect("Failed to create libp2p transport")
             .with_behaviour(|_| behaviour)?
             .with_swarm_config(
@@ -1127,6 +1506,25 @@ impl DhtService {
             }
         }
 
+        if enable_autonat {
+            for server_addr in &autonat_targets {
+                if bootstrap_set.contains(server_addr) {
+                    continue;
+                }
+                match server_addr.parse::<Multiaddr>() {
+                    Ok(addr) => match swarm.dial(addr.clone()) {
+                        Ok(_) => {
+                            info!("Dialing AutoNAT server: {}", server_addr);
+                        }
+                        Err(e) => {
+                            debug!("Failed to dial AutoNAT server {}: {}", server_addr, e);
+                        }
+                    },
+                    Err(e) => warn!("Invalid AutoNAT server address {}: {}", server_addr, e),
+                }
+            }
+        }
+
         // Trigger initial bootstrap if we have any bootstrap nodes (even if connection failed)
         if !bootstrap_nodes.is_empty() {
             let _ = swarm.behaviour_mut().kademlia.bootstrap();
@@ -1154,6 +1552,11 @@ impl DhtService {
         let proxy_targets = Arc::new(Mutex::new(HashSet::new()));
         let proxy_capable = Arc::new(Mutex::new(HashSet::new()));
         let peer_selection = Arc::new(Mutex::new(PeerSelectionService::new()));
+
+        {
+            let mut guard = metrics.lock().await;
+            guard.autonat_enabled = enable_autonat;
+        }
 
         // Spawn the DHT node task
         tokio::spawn(run_dht_node(
@@ -1336,7 +1739,7 @@ impl DhtService {
     ) -> Vec<String> {
         // First get peers that have the file
         let available_peers = self.get_seeders_for_file(file_hash).await;
-        
+
         if available_peers.is_empty() {
             return Vec::new();
         }
@@ -1422,7 +1825,18 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn shutdown_command_stops_dht_service() {
-        let service = match DhtService::new(0, Vec::new(), None, false).await {
+        let service = match DhtService::new(
+            0,
+            Vec::new(),
+            None,
+            false,
+            false,
+            None,
+            Vec::new(),
+            None,
+        )
+        .await
+        {
             Ok(service) => service,
             Err(err) => {
                 let message = err.to_string();
@@ -1445,6 +1859,7 @@ mod tests {
 
         let snapshot = service.metrics_snapshot().await;
         assert_eq!(snapshot.peer_count, 0);
+        assert_eq!(snapshot.reachability, NatReachabilityState::Unknown);
     }
 
     #[test]
@@ -1464,5 +1879,7 @@ mod tests {
         assert!(snapshot
             .listen_addrs
             .contains(&"/ip4/0.0.0.0/tcp/4001".to_string()));
+        assert!(snapshot.observed_addrs.is_empty());
+        assert!(snapshot.reachability_history.is_empty());
     }
 }

--- a/src-tauri/src/encryption.rs
+++ b/src-tauri/src/encryption.rs
@@ -1,13 +1,13 @@
 use aes_gcm::{
     aead::{Aead, AeadCore, KeyInit, OsRng},
-    Aes256Gcm, Nonce, Key
+    Aes256Gcm, Key, Nonce,
 };
 // PBKDF2 imports handled in function
-use sha2::{Sha256, Digest};
 use rand::RngCore;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use std::path::Path;
 use tokio::fs;
-use serde::{Deserialize, Serialize};
 
 /// Encryption configuration and metadata
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -35,12 +35,12 @@ impl FileEncryption {
     pub fn derive_key_from_password(password: &str, salt: &[u8]) -> Result<[u8; 32], String> {
         use pbkdf2::pbkdf2_hmac;
         use sha2::Sha256;
-        
+
         let password_bytes = password.as_bytes();
         let mut key = [0u8; 32];
-        
+
         pbkdf2_hmac::<Sha256>(password_bytes, salt, 100_000, &mut key);
-        
+
         Ok(key)
     }
 
@@ -66,9 +66,10 @@ impl FileEncryption {
         key: &[u8; 32],
     ) -> Result<EncryptionResult, String> {
         // Read the input file
-        let plaintext = fs::read(input_path).await
+        let plaintext = fs::read(input_path)
+            .await
             .map_err(|e| format!("Failed to read input file: {}", e))?;
-        
+
         let original_size = plaintext.len() as u64;
 
         // Create cipher
@@ -77,13 +78,15 @@ impl FileEncryption {
 
         // Generate random nonce
         let nonce = Aes256Gcm::generate_nonce(&mut OsRng);
-        
+
         // Encrypt the file
-        let ciphertext = cipher.encrypt(&nonce, plaintext.as_ref())
+        let ciphertext = cipher
+            .encrypt(&nonce, plaintext.as_ref())
             .map_err(|e| format!("Encryption failed: {}", e))?;
 
         // Write encrypted file
-        fs::write(output_path, &ciphertext).await
+        fs::write(output_path, &ciphertext)
+            .await
             .map_err(|e| format!("Failed to write encrypted file: {}", e))?;
 
         let encrypted_size = ciphertext.len() as u64;
@@ -116,7 +119,10 @@ impl FileEncryption {
     ) -> Result<u64, String> {
         // Verify encryption method
         if encryption_info.method != "AES-256-GCM" {
-            return Err(format!("Unsupported encryption method: {}", encryption_info.method));
+            return Err(format!(
+                "Unsupported encryption method: {}",
+                encryption_info.method
+            ));
         }
 
         // Verify key fingerprint
@@ -126,7 +132,8 @@ impl FileEncryption {
         }
 
         // Read encrypted file
-        let ciphertext = fs::read(input_path).await
+        let ciphertext = fs::read(input_path)
+            .await
             .map_err(|e| format!("Failed to read encrypted file: {}", e))?;
 
         // Create cipher
@@ -140,11 +147,13 @@ impl FileEncryption {
         let nonce = Nonce::from_slice(&encryption_info.nonce);
 
         // Decrypt the file
-        let plaintext = cipher.decrypt(nonce, ciphertext.as_ref())
+        let plaintext = cipher
+            .decrypt(nonce, ciphertext.as_ref())
             .map_err(|e| format!("Decryption failed: {}", e))?;
 
         // Write decrypted file
-        fs::write(output_path, &plaintext).await
+        fs::write(output_path, &plaintext)
+            .await
             .map_err(|e| format!("Failed to write decrypted file: {}", e))?;
 
         Ok(plaintext.len() as u64)
@@ -165,10 +174,10 @@ impl FileEncryption {
 
         // Encrypt file
         let mut result = Self::encrypt_file(input_path, output_path, &key).await?;
-        
+
         // Update salt in encryption info
         result.encryption_info.salt = salt.to_vec();
-        
+
         Ok(result)
     }
 
@@ -206,7 +215,9 @@ mod tests {
 
         // Generate key and encrypt
         let key = FileEncryption::generate_random_key();
-        let result = FileEncryption::encrypt_file(&input_path, &output_path, &key).await.unwrap();
+        let result = FileEncryption::encrypt_file(&input_path, &output_path, &key)
+            .await
+            .unwrap();
 
         assert_eq!(result.original_size, test_content.len() as u64);
         assert!(result.encrypted_size > 0);
@@ -217,7 +228,9 @@ mod tests {
             &decrypted_path,
             &key,
             &result.encryption_info,
-        ).await.unwrap();
+        )
+        .await
+        .unwrap();
 
         // Verify decrypted content
         let decrypted_content = fs::read_to_string(&decrypted_path).await.unwrap();
@@ -239,11 +252,10 @@ mod tests {
         let password = "super_secure_password_123";
 
         // Encrypt with password
-        let result = FileEncryption::encrypt_file_with_password(
-            &input_path,
-            &output_path,
-            password,
-        ).await.unwrap();
+        let result =
+            FileEncryption::encrypt_file_with_password(&input_path, &output_path, password)
+                .await
+                .unwrap();
 
         // Decrypt with password
         let decrypted_size = FileEncryption::decrypt_file_with_password(
@@ -251,7 +263,9 @@ mod tests {
             &decrypted_path,
             password,
             &result.encryption_info,
-        ).await.unwrap();
+        )
+        .await
+        .unwrap();
 
         // Verify decrypted content
         let decrypted_content = fs::read_to_string(&decrypted_path).await.unwrap();
@@ -273,11 +287,10 @@ mod tests {
         let wrong_password = "wrong_password";
 
         // Encrypt with correct password
-        let result = FileEncryption::encrypt_file_with_password(
-            &input_path,
-            &output_path,
-            correct_password,
-        ).await.unwrap();
+        let result =
+            FileEncryption::encrypt_file_with_password(&input_path, &output_path, correct_password)
+                .await
+                .unwrap();
 
         // Try to decrypt with wrong password - should fail
         let decrypt_result = FileEncryption::decrypt_file_with_password(
@@ -285,7 +298,8 @@ mod tests {
             &decrypted_path,
             wrong_password,
             &result.encryption_info,
-        ).await;
+        )
+        .await;
 
         assert!(decrypt_result.is_err());
         assert!(decrypt_result.unwrap_err().contains("fingerprint mismatch"));

--- a/src-tauri/src/ethereum.rs
+++ b/src-tauri/src/ethereum.rs
@@ -1172,10 +1172,10 @@ pub async fn get_recent_mined_blocks(
         //         None
         //     }
         // };
-        
+
         // Since Geth's default reward (2.0) doesn't match the intended Chiral Network
         // reward, we hardcode the intended value of 5.0 here.
-        let reward = Some(5.0); 
+        let reward = Some(5.0);
 
         out.push(MinedBlock {
             hash,

--- a/src-tauri/src/headless.rs
+++ b/src-tauri/src/headless.rs
@@ -1,9 +1,9 @@
 // Headless mode for running as a bootstrap node on servers
-use crate::dht::{DhtService, FileMetadata};
+use crate::dht::{DhtMetricsSnapshot, DhtService, FileMetadata};
 use crate::ethereum::GethProcess;
 use crate::file_transfer::FileTransferService;
 use clap::Parser;
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 use tokio::signal;
 
 use tracing::{error, info};
@@ -52,6 +52,22 @@ pub struct CliArgs {
     #[arg(long)]
     pub is_bootstrap: bool,
 
+    /// Disable AutoNAT reachability probes
+    #[arg(long)]
+    pub disable_autonat: bool,
+
+    /// Interval in seconds between AutoNAT probes
+    #[arg(long, default_value = "30")]
+    pub autonat_probe_interval: u64,
+
+    /// Additional AutoNAT servers to dial (multiaddr form)
+    #[arg(long)]
+    pub autonat_server: Vec<String>,
+
+    /// Print reachability snapshot at startup (and periodically)
+    #[arg(long)]
+    pub show_reachability: bool,
+
     // SOCKS5 Proxy address (e.g., 127.0.0.1:9050 for Tor or a private VPN SOCKS endpoint)
     #[arg(long)]
     pub socks5_proxy: Option<String>,
@@ -77,6 +93,25 @@ pub async fn run_headless(args: CliArgs) -> Result<(), Box<dyn std::error::Error
         info!("Using default bootstrap nodes: {:?}", bootstrap_nodes);
     }
 
+    let enable_autonat = !args.disable_autonat;
+    let probe_interval = if enable_autonat {
+        Some(Duration::from_secs(args.autonat_probe_interval))
+    } else {
+        None
+    };
+
+    if enable_autonat {
+        info!(
+            "AutoNAT probes enabled (interval: {}s)",
+            args.autonat_probe_interval
+        );
+        if !args.autonat_server.is_empty() {
+            info!("AutoNAT servers: {:?}", args.autonat_server);
+        }
+    } else {
+        info!("AutoNAT probes disabled via CLI");
+    }
+
     // Optionally start local file-transfer service for metrics insight
     let file_transfer_service = if args.show_downloads {
         Some(Arc::new(FileTransferService::new().await.map_err(|e| {
@@ -85,13 +120,15 @@ pub async fn run_headless(args: CliArgs) -> Result<(), Box<dyn std::error::Error
     } else {
         None
     };
-
     // Start DHT node
     let dht_service = DhtService::new(
         args.dht_port,
         bootstrap_nodes.clone(),
         args.secret,
         args.is_bootstrap,
+        enable_autonat,
+        probe_interval,
+        args.autonat_server.clone(),
         args.socks5_proxy,
     )
     .await?;
@@ -175,11 +212,33 @@ pub async fn run_headless(args: CliArgs) -> Result<(), Box<dyn std::error::Error
     info!("Bootstrap node is running. Press Ctrl+C to stop.");
     let dht_arc = Arc::new(dht_service);
 
+    if args.show_reachability {
+        let snapshot = dht_arc.metrics_snapshot().await;
+        log_reachability_snapshot(&snapshot);
+
+        let dht_for_logs = dht_arc.clone();
+        tokio::spawn(async move {
+            loop {
+                if Arc::strong_count(&dht_for_logs) <= 1 {
+                    break;
+                }
+
+                tokio::time::sleep(Duration::from_secs(60)).await;
+
+                let snapshot = dht_for_logs.metrics_snapshot().await;
+                log_reachability_snapshot(&snapshot);
+
+                if !snapshot.autonat_enabled {
+                    break;
+                }
+            }
+        });
+    }
+
     // Spawn the event pump
-    let dht_clone_for_pump = dht_arc.clone();
+    let dht_clone_for_pump = Arc::clone(&dht_arc);
 
     tokio::spawn(async move {
-        use std::time::Duration;
         loop {
             // If the DHT service has been shut down, the weak reference will be None
             let events = dht_clone_for_pump.drain_events(100).await;
@@ -201,6 +260,23 @@ pub async fn run_headless(args: CliArgs) -> Result<(), Box<dyn std::error::Error
 
     info!("Shutting down...");
     Ok(())
+}
+
+fn log_reachability_snapshot(snapshot: &DhtMetricsSnapshot) {
+    info!(
+        "📡 Reachability: {:?} (confidence {:?})",
+        snapshot.reachability, snapshot.reachability_confidence
+    );
+    if let Some(ts) = snapshot.last_probe_at {
+        info!("   Last probe epoch: {}", ts);
+    }
+    if let Some(err) = snapshot.last_reachability_error.as_ref() {
+        info!("   Last error: {}", err);
+    }
+    if !snapshot.observed_addrs.is_empty() {
+        info!("   Observed addresses: {:?}", snapshot.observed_addrs);
+    }
+    info!("   AutoNAT enabled: {}", snapshot.autonat_enabled);
 }
 
 fn get_local_ip() -> Option<String> {

--- a/src-tauri/src/keystore.rs
+++ b/src-tauri/src/keystore.rs
@@ -138,7 +138,12 @@ impl Keystore {
         }
     }
 
-    pub fn set_2fa_secret(&mut self, address: &str, secret: &str, password: &str) -> Result<(), String> {
+    pub fn set_2fa_secret(
+        &mut self,
+        address: &str,
+        secret: &str,
+        password: &str,
+    ) -> Result<(), String> {
         let account = self
             .accounts
             .iter_mut()
@@ -161,7 +166,9 @@ impl Keystore {
 
         // To remove, we must first verify the password is correct.
         // We can do this by trying to decrypt the existing secret.
-        if let (Some(encrypted_secret), Some(iv)) = (&account.encrypted_two_fa_secret, &account.two_fa_iv) {
+        if let (Some(encrypted_secret), Some(iv)) =
+            (&account.encrypted_two_fa_secret, &account.two_fa_iv)
+        {
             decrypt_data(encrypted_secret, &account.salt, iv, password)
                 .map_err(|_| "Invalid password. Cannot disable 2FA.".to_string())?;
         }
@@ -216,7 +223,11 @@ fn encrypt_private_key(
 }
 
 /// Generic function to encrypt any string data using the password and a salt.
-fn encrypt_data(data_to_encrypt: &str, password: &str, salt_hex: &str) -> Result<(String, String), String> {
+fn encrypt_data(
+    data_to_encrypt: &str,
+    password: &str,
+    salt_hex: &str,
+) -> Result<(String, String), String> {
     let salt = hex::decode(salt_hex).map_err(|e| format!("Invalid salt: {}", e))?;
     let key = derive_key(password, &salt);
 
@@ -231,7 +242,12 @@ fn encrypt_data(data_to_encrypt: &str, password: &str, salt_hex: &str) -> Result
 }
 
 /// Generic function to decrypt data.
-fn decrypt_data(encrypted_hex: &str, salt_hex: &str, iv_hex: &str, password: &str) -> Result<String, String> {
+fn decrypt_data(
+    encrypted_hex: &str,
+    salt_hex: &str,
+    iv_hex: &str,
+    password: &str,
+) -> Result<String, String> {
     decrypt_private_key(encrypted_hex, salt_hex, iv_hex, password)
 }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -35,7 +35,7 @@ use std::process::Command;
 use std::{
     io::{BufRead, BufReader},
     sync::Arc,
-    time::{Instant, SystemTime, UNIX_EPOCH},
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 use sysinfo::{Components, System, MINIMUM_CPU_UPDATE_INTERVAL};
 use systemstat::{Platform, System as SystemStat};
@@ -44,11 +44,7 @@ use tauri::{
     tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
     Emitter, Manager, State,
 };
-use tokio::{
-    sync::Mutex,
-    task::JoinHandle,
-    time::{sleep, Duration},
-};
+use tokio::{sync::Mutex, task::JoinHandle, time::sleep};
 use totp_rs::{Algorithm, Secret, TOTP};
 use tracing::{info, warn};
 
@@ -344,6 +340,9 @@ async fn start_dht_node(
     state: State<'_, AppState>,
     port: u16,
     bootstrap_nodes: Vec<String>,
+    enable_autonat: Option<bool>,
+    autonat_probe_interval_secs: Option<u64>,
+    autonat_servers: Option<Vec<String>>,
     proxy_address: Option<String>,
 ) -> Result<String, String> {
     {
@@ -353,14 +352,27 @@ async fn start_dht_node(
         }
     }
 
+    let auto_enabled = enable_autonat.unwrap_or(true);
+    let probe_interval = autonat_probe_interval_secs.map(Duration::from_secs);
+    let autonat_server_list = autonat_servers.unwrap_or_default();
+
     // Get the proxy from the command line, if it was provided at launch
     let cli_proxy = state.socks5_proxy_cli.lock().await.clone();
     // Prioritize the command-line argument. Fall back to the one from the UI.
     let final_proxy_address = cli_proxy.or(proxy_address.clone());
 
-    let dht_service = DhtService::new(port, bootstrap_nodes, None, false, final_proxy_address,)
-        .await
-        .map_err(|e| format!("Failed to start DHT: {}", e))?;
+    let dht_service = DhtService::new(
+        port,
+        bootstrap_nodes,
+        None,
+        false,
+        auto_enabled,
+        probe_interval,
+        autonat_server_list,
+        final_proxy_address,
+    )
+    .await
+    .map_err(|e| format!("Failed to start DHT: {}", e))?;
 
     let peer_id = dht_service.get_peer_id().await;
 
@@ -441,6 +453,20 @@ async fn start_dht_node(
                             proxies.push(new_node.clone());
                             let _ = app_handle.emit("proxy_status_update", new_node);
                         }
+                    }
+                    DhtEvent::NatStatus {
+                        state,
+                        confidence,
+                        last_error,
+                        summary,
+                    } => {
+                        let payload = serde_json::json!({
+                            "state": state,
+                            "confidence": confidence,
+                            "lastError": last_error,
+                            "summary": summary,
+                        });
+                        let _ = app_handle.emit("nat_status_update", payload);
                     }
                     DhtEvent::EchoReceived { from, utf8, bytes } => {
                         // Sending inbox event to frontend
@@ -649,6 +675,20 @@ async fn get_dht_events(state: State<'_, AppState>) -> Result<Vec<String>, Strin
                         }
                     )
                 }
+                DhtEvent::NatStatus {
+                    state,
+                    confidence,
+                    last_error,
+                    summary,
+                } => match serde_json::to_string(&serde_json::json!({
+                    "state": state,
+                    "confidence": confidence,
+                    "lastError": last_error,
+                    "summary": summary,
+                })) {
+                    Ok(json) => format!("nat_status:{json}"),
+                    Err(_) => "nat_status:{}".to_string(),
+                },
                 DhtEvent::PeerRtt { peer, rtt_ms } => format!("peer_rtt:{peer}:{rtt_ms}"),
                 DhtEvent::EchoReceived { from, utf8, bytes } => format!(
                     "echo_received:{}:{}:{}",
@@ -1621,7 +1661,9 @@ async fn get_recommended_peers_for_file(
 ) -> Result<Vec<String>, String> {
     let dht_guard = state.dht.lock().await;
     if let Some(ref dht) = *dht_guard {
-        Ok(dht.get_recommended_peers_for_download(&file_hash, file_size, require_encryption).await)
+        Ok(dht
+            .get_recommended_peers_for_download(&file_hash, file_size, require_encryption)
+            .await)
     } else {
         Err("DHT service not available".to_string())
     }
@@ -1636,7 +1678,8 @@ async fn record_transfer_success(
 ) -> Result<(), String> {
     let dht_guard = state.dht.lock().await;
     if let Some(ref dht) = *dht_guard {
-        dht.record_transfer_success(&peer_id, bytes, duration_ms).await;
+        dht.record_transfer_success(&peer_id, bytes, duration_ms)
+            .await;
         Ok(())
     } else {
         Err("DHT service not available".to_string())
@@ -1659,7 +1702,9 @@ async fn record_transfer_failure(
 }
 
 #[tauri::command]
-async fn get_peer_metrics(state: State<'_, AppState>) -> Result<Vec<crate::peer_selection::PeerMetrics>, String> {
+async fn get_peer_metrics(
+    state: State<'_, AppState>,
+) -> Result<Vec<crate::peer_selection::PeerMetrics>, String> {
     let dht_guard = state.dht.lock().await;
     if let Some(ref dht) = *dht_guard {
         Ok(dht.get_peer_metrics().await)
@@ -1677,7 +1722,7 @@ async fn select_peers_with_strategy(
     require_encryption: bool,
 ) -> Result<Vec<String>, String> {
     use crate::peer_selection::SelectionStrategy;
-    
+
     let selection_strategy = match strategy.as_str() {
         "fastest" => SelectionStrategy::FastestFirst,
         "reliable" => SelectionStrategy::MostReliable,
@@ -1690,7 +1735,14 @@ async fn select_peers_with_strategy(
 
     let dht_guard = state.dht.lock().await;
     if let Some(ref dht) = *dht_guard {
-        Ok(dht.select_peers_with_strategy(&available_peers, count, selection_strategy, require_encryption).await)
+        Ok(dht
+            .select_peers_with_strategy(
+                &available_peers,
+                count,
+                selection_strategy,
+                require_encryption,
+            )
+            .await)
     } else {
         Err("DHT service not available".to_string())
     }
@@ -1773,7 +1825,7 @@ fn main() {
             file_transfer: Mutex::new(None),
             proxies: Arc::new(Mutex::new(Vec::new())),
             file_transfer_pump: Mutex::new(None),
-            socks5_proxy_cli: Mutex::new(args.socks5_proxy), 
+            socks5_proxy_cli: Mutex::new(args.socks5_proxy),
         })
         .invoke_handler(tauri::generate_handler![
             create_chiral_account,

--- a/src-tauri/src/net/proxy_server.rs
+++ b/src-tauri/src/net/proxy_server.rs
@@ -16,15 +16,16 @@ pub async fn run_proxy_server(
     info!("Local peer id: {:?}", local_peer_id);
 
     // SwarmBuilder: TCP + RelayClient + with_behaviour + build()
-    let mut swarm: Swarm<RelayClientBehaviour> =
-        SwarmBuilder::with_existing_identity(local_key)
-            .with_tokio()
-            .with_tcp(tcp::Config::default(), noise::Config::new, yamux::Config::default)?
-            .with_relay_client(noise::Config::new, yamux::Config::default)?                 
-            .with_behaviour(|_keypair, relay_client| {
-                Ok(relay_client)
-            })?
-            .build(); 
+    let mut swarm: Swarm<RelayClientBehaviour> = SwarmBuilder::with_existing_identity(local_key)
+        .with_tokio()
+        .with_tcp(
+            tcp::Config::default(),
+            noise::Config::new,
+            yamux::Config::default,
+        )?
+        .with_relay_client(noise::Config::new, yamux::Config::default)?
+        .with_behaviour(|_keypair, relay_client| Ok(relay_client))?
+        .build();
 
     let listen_addr: Multiaddr = format!("/ip4/0.0.0.0/tcp/{}", port).parse()?;
     swarm.listen_on(listen_addr)?;

--- a/src/lib/dht.ts
+++ b/src/lib/dht.ts
@@ -11,11 +11,24 @@ export const DEFAULT_BOOTSTRAP_NODES = [
   "/ip4/54.198.145.146/tcp/4001/p2p/12D3KooWNHdYWRTe98KMF1cDXXqGXvNjd1SAchDaeP5o4MsoJLu2",
 ];
 
+export type NatReachabilityState = 'unknown' | 'public' | 'private';
+export type NatConfidence = 'low' | 'medium' | 'high';
+
+export interface NatHistoryItem {
+  state: NatReachabilityState;
+  confidence: NatConfidence;
+  timestamp: number;
+  summary?: string | null;
+}
+
 export interface DhtConfig {
   port: number;
   bootstrapNodes: string[];
   showMultiaddr?: boolean;
-  proxyAddress?: string; // The SOCKS5 address for routing (e.g., "127.0.0.1:9050")
+  enableAutonat?: boolean;
+  autonatProbeIntervalSeconds?: number;
+  autonatServers?: string[];
+  proxyAddress?: string;
 }
 
 export interface FileMetadata {
@@ -38,6 +51,14 @@ export interface DhtHealth {
   lastErrorAt: number | null;
   bootstrapFailures: number;
   listenAddrs: string[];
+  reachability: NatReachabilityState;
+  reachabilityConfidence: NatConfidence;
+  lastReachabilityChange: number | null;
+  lastProbeAt: number | null;
+  lastReachabilityError: string | null;
+  observedAddrs: string[];
+  reachabilityHistory: NatHistoryItem[];
+  autonatEnabled: boolean;
 }
 
 export class DhtService {
@@ -71,10 +92,24 @@ export class DhtService {
     }
 
     try {
-      const peerId = await invoke<string>("start_dht_node", {
+      const payload: Record<string, unknown> = {
         port,
         bootstrapNodes,
-      });
+      };
+      if (typeof config?.enableAutonat === 'boolean') {
+        payload.enableAutonat = config.enableAutonat;
+      }
+      if (typeof config?.autonatProbeIntervalSeconds === 'number') {
+        payload.autonatProbeIntervalSecs = config.autonatProbeIntervalSeconds;
+      }
+      if (config?.autonatServers && config.autonatServers.length > 0) {
+        payload.autonatServers = config.autonatServers;
+      }
+      if (typeof config?.proxyAddress === 'string' && config.proxyAddress.trim().length > 0) {
+        payload.proxyAddress = config.proxyAddress;
+      }
+
+      const peerId = await invoke<string>("start_dht_node", payload);
       this.peerId = peerId;
       this.port = port;
       console.log("DHT started with peer ID:", this.peerId);

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -76,7 +76,39 @@
       "peerId": "Peer ID",
       "bootstrapNode": "Bootstrap Node",
       "recentEvents": "Recent Events",
-      "disconnect": "Disconnect from DHT"
+      "disconnect": "Disconnect from DHT",
+      "reachability": {
+        "title": "Reachability",
+        "state": {
+          "public": "Direct (Public)",
+          "private": "Relayed / Private",
+          "unknown": "Unknown"
+        },
+        "confidence": {
+          "low": "Low confidence",
+          "medium": "Moderate confidence",
+          "high": "High confidence"
+        },
+        "lastProbe": "Last probe",
+        "lastChange": "Last change",
+        "lastError": "Last probe error",
+        "observedAddrs": "Observed external addresses",
+        "observedEmpty": "No external addresses learned yet.",
+        "history": "Recent probe history",
+        "historyEmpty": "No reachability probes recorded yet.",
+        "summary": "Summary",
+        "timestamp": "Timestamp",
+        "stateLabel": "State",
+        "autonatDisabled": "AutoNAT probes disabled",
+        "copySuccess": "Observed address copied",
+        "copyError": "Unable to copy address",
+        "genericSummary": "No additional details.",
+        "toast": {
+          "public": "Reachability restored. {summary}",
+          "private": "Reachability degraded. {summary}",
+          "unknown": "Reachability status updated. {summary}"
+        }
+      }
     },
     "networkStatus": "Network Status",
     "dhtPeers": "DHT Peers",

--- a/src/pages/Network.svelte
+++ b/src/pages/Network.svelte
@@ -15,16 +15,22 @@
   import { dhtService, DEFAULT_BOOTSTRAP_NODES } from '$lib/dht'
   import { getStatus as fetchGethStatus, type GethStatus } from '$lib/services/gethService'
   import { resetConnectionAttempts } from '$lib/dhtHelpers'
-  import type { DhtHealth } from '$lib/dht'
+  import type { DhtHealth, NatConfidence, NatReachabilityState } from '$lib/dht'
   import { Clipboard } from "lucide-svelte"
   import { t } from 'svelte-i18n';
   import { showToast } from '$lib/toast';
   import DropDown from '$lib/components/ui/dropDown.svelte'
-  import { settings} from '$lib/stores'; 
 
   // Check if running in Tauri environment
   const isTauri = typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window
   const tr = (k: string, params?: Record<string, any>) => get(t)(k, params)
+
+  type NatStatusPayload = {
+    state: NatReachabilityState
+    confidence: NatConfidence
+    lastError?: string | null
+    summary?: string | null
+  }
   
   let discoveryRunning = false
   let newPeerAddress = ''
@@ -64,9 +70,6 @@
   let chainId = 98765
   let gethStatusCardRef: { refresh?: () => Promise<void> } | null = null
   
-  // Local settings state
-  // let localSettings = get(settings); // Initialize local settings
-
   // DHT variables
   let dhtStatus: 'disconnected' | 'connecting' | 'connected' = 'disconnected'
   let dhtPeerId: string | null = null
@@ -78,6 +81,9 @@
   let dhtError: string | null = null
   let connectionAttempts = 0
   let dhtPollInterval: number | undefined
+  let natStatusUnlisten: (() => void) | null = null
+  let lastNatState: NatReachabilityState | null = null
+  let lastNatConfidence: NatConfidence | null = null
   
   // UI variables
   const nodeAddress = "enode://277ac35977fc0a230e3ca4ccbf6df6da486fd2af9c129925b1193b25da6f013a301788fceed458f03c6c0d289dfcbf7a7ca5c0aef34b680fcbbc8c2ef79c0f71@127.0.0.1:30303"
@@ -106,6 +112,112 @@
 
   function formatHealthMessage(value: string | null): string {
     return value ?? tr('network.dht.health.none')
+  }
+
+  function formatReachabilityState(state?: NatReachabilityState | null): string {
+    switch (state) {
+      case 'public':
+        return tr('network.dht.reachability.state.public')
+      case 'private':
+        return tr('network.dht.reachability.state.private')
+      default:
+        return tr('network.dht.reachability.state.unknown')
+    }
+  }
+
+  function formatNatConfidence(confidence?: NatConfidence | null): string {
+    switch (confidence) {
+      case 'high':
+        return tr('network.dht.reachability.confidence.high')
+      case 'medium':
+        return tr('network.dht.reachability.confidence.medium')
+      default:
+        return tr('network.dht.reachability.confidence.low')
+    }
+  }
+
+  function reachabilityBadgeClass(state?: NatReachabilityState | null): string {
+    switch (state) {
+      case 'public':
+        return 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-300'
+      case 'private':
+        return 'bg-amber-500/10 text-amber-600 dark:text-amber-300'
+      default:
+        return 'bg-muted text-muted-foreground'
+    }
+  }
+
+  function formatNatTimestamp(epoch?: number | null): string {
+    if (!epoch) return tr('network.dht.health.never')
+    return new Date(epoch * 1000).toLocaleString()
+  }
+
+  async function copyObservedAddr(addr: string) {
+    try {
+      await navigator.clipboard.writeText(addr)
+      showToast(tr('network.dht.reachability.copySuccess'), 'success')
+    } catch (error) {
+      console.error('Failed to copy observed address', error)
+      showToast(tr('network.dht.reachability.copyError'), 'error')
+    }
+  }
+
+  function showNatToast(payload: NatStatusPayload) {
+    if (lastNatState === null) {
+      lastNatState = payload.state
+      lastNatConfidence = payload.confidence
+      return
+    }
+
+    if (payload.state === lastNatState && payload.confidence === lastNatConfidence) {
+      lastNatState = payload.state
+      lastNatConfidence = payload.confidence
+      return
+    }
+
+    lastNatState = payload.state
+    lastNatConfidence = payload.confidence
+
+    const rawSummary = payload.summary ?? payload.lastError ?? ''
+    const summaryText = rawSummary.trim().length > 0
+      ? rawSummary
+      : tr('network.dht.reachability.genericSummary')
+
+    let toastKey = 'network.dht.reachability.toast.unknown'
+    let tone: 'success' | 'warning' | 'info' = 'info'
+
+    if (payload.state === 'public') {
+      toastKey = 'network.dht.reachability.toast.public'
+      tone = 'success'
+    } else if (payload.state === 'private') {
+      toastKey = 'network.dht.reachability.toast.private'
+      tone = 'warning'
+    }
+
+    showToast(tr(toastKey, { values: { summary: summaryText } }), tone)
+  }
+
+  async function registerNatListener() {
+    if (!isTauri || natStatusUnlisten) return
+    try {
+      natStatusUnlisten = await listen('nat_status_update', async (event) => {
+        const payload = event.payload as NatStatusPayload
+        if (!payload) return
+        showNatToast(payload)
+        try {
+          const snapshot = await dhtService.getHealth()
+          if (snapshot) {
+            dhtHealth = snapshot
+            lastNatState = snapshot.reachability
+            lastNatConfidence = snapshot.reachabilityConfidence
+          }
+        } catch (error) {
+          console.error('Failed to refresh NAT status', error)
+        }
+      })
+    } catch (error) {
+      console.error('Failed to subscribe to NAT status updates', error)
+    }
   }
   
   async function startDht() {
@@ -171,15 +283,9 @@
         await new Promise(resolve => setTimeout(resolve, 500))
         // DHT not running, start it
         try {
-          
-          const proxyAddress = $settings.enableProxy 
-            ? $settings.proxyAddress 
-            : undefined; // Get proxy address from local settings
-
           const peerId = await dhtService.start({
             port: dhtPort,
-            bootstrapNodes: DEFAULT_BOOTSTRAP_NODES,
-            proxyAddress: proxyAddress, 
+            bootstrapNodes: DEFAULT_BOOTSTRAP_NODES
           })
           dhtPeerId = peerId
           // Also ensure the service knows its own peer ID
@@ -282,6 +388,8 @@
       if (snapshot) {
         dhtHealth = snapshot
         dhtPeerCount = snapshot.peerCount
+        lastNatState = snapshot.reachability
+        lastNatConfidence = snapshot.reachabilityConfidence
       }
       startDhtPolling()
     } catch (error: any) {
@@ -306,6 +414,8 @@
         if (health) {
           dhtHealth = health
           dhtPeerCount = health.peerCount
+          lastNatState = health.reachability
+          lastNatConfidence = health.reachabilityConfidence
         } else {
           dhtPeerCount = await dhtService.getPeerCount()
         }
@@ -347,9 +457,13 @@
           dhtHealth = health
           peerCount = health.peerCount
           dhtPeerCount = peerCount
+          lastNatState = health.reachability
+          lastNatConfidence = health.reachabilityConfidence
         } else {
           peerCount = await dhtService.getPeerCount()
           dhtPeerCount = peerCount
+          lastNatState = null
+          lastNatConfidence = null
         }
 
         // Update connection status based on peer count
@@ -374,6 +488,8 @@
       connectionAttempts = 0
       dhtHealth = null
       copiedListenAddr = null
+      lastNatState = null
+      lastNatConfidence = null
       return
     }
     
@@ -386,6 +502,8 @@
       dhtEvents = [...dhtEvents, `✓ DHT stopped`]
       dhtHealth = null
       copiedListenAddr = null
+      lastNatState = null
+      lastNatConfidence = null
     } catch (error) {
       console.error('Failed to stop DHT:', error)
       dhtEvents = [...dhtEvents, `✗ Failed to stop DHT: ${error}`]
@@ -673,6 +791,7 @@
       
       // Listen for download progress updates (only in Tauri)
       if (isTauri) {
+        await registerNatListener()
         unlistenProgress = await listen('geth-download-progress', (event) => {
           downloadProgress = event.payload as typeof downloadProgress
         })
@@ -689,6 +808,10 @@
       if (unlistenProgress) {
         unlistenProgress()
       }
+      if (natStatusUnlisten) {
+        natStatusUnlisten()
+        natStatusUnlisten = null
+      }
     }
   })
 
@@ -698,6 +821,10 @@
     }
     if (dhtPollInterval) {
       clearInterval(dhtPollInterval)
+    }
+    if (natStatusUnlisten) {
+      natStatusUnlisten()
+      natStatusUnlisten = null
     }
     // Note: We do NOT stop the DHT service here
     // The DHT should persist across page navigations
@@ -989,6 +1116,83 @@
               <p class="text-xs text-muted-foreground">{$t('network.dht.noListenAddresses')}</p>
             </div>
           {/if}
+
+          <div class="pt-4 space-y-4">
+            <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+              <div>
+                <p class="text-xs uppercase text-muted-foreground">{$t('network.dht.reachability.title')}</p>
+                <div class="mt-2 flex items-center gap-2">
+                  <Badge class={reachabilityBadgeClass(dhtHealth?.reachability)}>
+                    {formatReachabilityState(dhtHealth?.reachability)}
+                  </Badge>
+                  <span class="text-sm text-muted-foreground">
+                    {formatNatConfidence(dhtHealth?.reachabilityConfidence)}
+                  </span>
+                </div>
+              </div>
+              <div class="text-sm text-muted-foreground space-y-1 text-right">
+                <p>{$t('network.dht.reachability.lastProbe')}: {formatNatTimestamp(dhtHealth?.lastProbeAt ?? null)}</p>
+                <p>{$t('network.dht.reachability.lastChange')}: {formatNatTimestamp(dhtHealth?.lastReachabilityChange ?? null)}</p>
+                {#if dhtHealth && !dhtHealth.autonatEnabled}
+                  <p class="text-xs text-yellow-600">{$t('network.dht.reachability.autonatDisabled')}</p>
+                {/if}
+              </div>
+            </div>
+
+            <div class="grid gap-4 md:grid-cols-2">
+              <div>
+                <p class="text-xs uppercase text-muted-foreground">{$t('network.dht.reachability.observedAddrs')}</p>
+                {#if dhtHealth?.observedAddrs && dhtHealth.observedAddrs.length > 0}
+                  <div class="mt-2 flex flex-wrap gap-2">
+                    {#each dhtHealth.observedAddrs as addr}
+                      <button
+                        class="inline-flex items-center gap-1 rounded-full bg-muted px-3 py-1 text-xs font-mono hover:bg-muted/80"
+                        on:click={() => copyObservedAddr(addr)}
+                        type="button"
+                      >
+                        {addr}
+                        <Clipboard class="h-3 w-3" />
+                      </button>
+                    {/each}
+                  </div>
+                {:else}
+                  <p class="mt-2 text-sm text-muted-foreground">{$t('network.dht.reachability.observedEmpty')}</p>
+                {/if}
+              </div>
+              <div>
+                <p class="text-xs uppercase text-muted-foreground">{$t('network.dht.reachability.lastError')}</p>
+                <p class="mt-2 text-sm text-muted-foreground">{dhtHealth?.lastReachabilityError ?? tr('network.dht.health.none')}</p>
+              </div>
+            </div>
+
+            <div>
+              <p class="text-xs uppercase text-muted-foreground">{$t('network.dht.reachability.history')}</p>
+              {#if dhtHealth?.reachabilityHistory && dhtHealth.reachabilityHistory.length > 0}
+                <div class="mt-2 overflow-hidden rounded-md border border-muted/40">
+                  <table class="min-w-full text-sm">
+                    <thead class="bg-muted/50 text-left text-xs uppercase text-muted-foreground">
+                      <tr>
+                        <th class="px-3 py-2">{$t('network.dht.reachability.timestamp')}</th>
+                        <th class="px-3 py-2">{$t('network.dht.reachability.stateLabel')}</th>
+                        <th class="px-3 py-2">{$t('network.dht.reachability.summary')}</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {#each dhtHealth.reachabilityHistory as item}
+                        <tr class="border-t border-muted/30">
+                          <td class="px-3 py-2">{formatNatTimestamp(item.timestamp)}</td>
+                          <td class="px-3 py-2">{formatReachabilityState(item.state)}</td>
+                          <td class="px-3 py-2 text-muted-foreground">{item.summary ?? '—'}</td>
+                        </tr>
+                      {/each}
+                    </tbody>
+                  </table>
+                </div>
+              {:else}
+                <p class="mt-2 text-sm text-muted-foreground">{$t('network.dht.reachability.historyEmpty')}</p>
+              {/if}
+            </div>
+          </div>
 
           {#if dhtHealth}
             <div class="grid grid-cols-1 md:grid-cols-2 gap-3 pt-3">


### PR DESCRIPTION
## Summary

  - mount libp2p AutoNAT v2 client/server (feature-gated in rust-
  libp2p) so the desktop node can detect reachability and emit libp2p-
  style NatStatus events; mirrors go-libp2p autonat.go semantics
  example wiring.
  - extend DhtMetricsSnapshot/commands/headless flags with
  reachability state, observed external addrs, and history so
  operators can audit probe outcomes (--disable-autonat, --autonat-
  probe-interval, --autonat-server, --show-reachability); headless
  logs follow punchr’s “summary per probe” approach for future
  ingestion.
  - surface a Network → DHT “Reachability” card (Kubo vocabulary:
  Direct/Relayed/Unknown) with confidence badge, observed address
  chips, probe history, and toast notifications on state changes,
  making AutoNAT decisions visible in the GUI.
  - refresh docs to explain how AutoNAT is configured and why (NAT
  epic groundwork), and keep download retry telemetry notes together
  with the new reachability instrumentation.

  ## Why

  We need reliable NAT-state feedback before building relay/DCUtR
  flows. Re-implementing libp2p’s reachability pipeline (AutoNAT v2,
  observed-address tracking) gives us deterministic, spec-aligned
  signals and lets reviewers/operators diagnose “why can’t I connect?”
  issues without packet captures. The UI/CLI additions follow Kubo/
  punchr patterns so future contributors can map mental models across
  IPFS and Chiral.

  ## Manual Test

  1. Desktop: npm run tauri dev, open Network → DHT, start the DHT.
  Observe the Reachability card transition to “Direct (Public)” once
  probes succeed; unplug or block the port to see the toast flip to
  “Relayed/Private.”
  2. Headless: cargo run -- --headless --show-reachability --autonat-
  server /ip4/<server>/tcp/4001/p2p/<peer> and verify the console
  prints reachability summaries every 60 s.
  3. Optional: start the DHT with dhtService.start({ enableAutonat:
  false }) and confirm the card shows “AutoNAT probes disabled” while
  the backend skips probe logs.

## Before and After
<img width="1512" height="797" alt="image" src="https://github.com/user-attachments/assets/1568c71b-a434-47f3-8b1d-88437442de27" />

<img width="1200" height="702" alt="image" src="https://github.com/user-attachments/assets/fb63bb40-dba6-4040-843b-96b801be01a2" />
<img width="954" height="280" alt="image" src="https://github.com/user-attachments/assets/54ad240b-267c-4c75-83af-2732fd50f00d" />
