### PR TITLE
fix(language): internationalize contents in the Network page

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -75,6 +75,16 @@
       "peers": "Connected Peers",
       "peerId": "Peer ID",
       "bootstrapNode": "Bootstrap Node",
+      "listenAddresses": "Listen Addresses",
+      "noListenAddresses": "No listen addresses available. DHT may be running in client-only mode.",
+      "health": {
+        "lastBootstrap": "Last Bootstrap",
+        "lastPeer": "Last Peer Event",
+        "lastError": "Last Error",
+        "failures": "Bootstrap Failures",
+        "never": "Never",
+        "none": "None"
+      },
       "recentEvents": "Recent Events",
       "disconnect": "Disconnect from DHT"
     },


### PR DESCRIPTION
**Before**
<img width="500" height="500" alt="Screenshot 2025-09-28 at 9 02 48 AM" src="https://github.com/user-attachments/assets/ba289f93-c5cb-4e3a-b149-014a049ece62" />

**After**
<img width="500" height="500" alt="Screenshot 2025-09-28 at 9 05 28 AM" src="https://github.com/user-attachments/assets/a99b238d-b972-4b01-88e8-6b0e3a67ebb6" />
