### PR TITLE
Visualize peer geography on network dashbord, fix: harden download te…

### DIFF
--- a/src/lib/components/GeoDistributionCard.svelte
+++ b/src/lib/components/GeoDistributionCard.svelte
@@ -1,0 +1,184 @@
+<script lang="ts">
+  import Card from '$lib/components/ui/card.svelte';
+  import Badge from '$lib/components/ui/badge.svelte';
+  import { peerGeoDistribution } from '$lib/stores';
+  import { GEO_REGIONS, projectToMap, UNKNOWN_REGION_ID } from '$lib/geo';
+  import type { PeerGeoRegionStat, PeerGeoDistribution } from '$lib/stores';
+  import type { GeoRegionConfig } from '$lib/geo';
+  import { MapPin, Globe2 } from 'lucide-svelte';
+  import { t } from 'svelte-i18n';
+  import { get } from 'svelte/store';
+
+  type TranslateFn = (key: string, params?: Record<string, unknown>) => string;
+
+  const getTranslator = (): TranslateFn => get(t) as TranslateFn;
+
+  const tr = (key: string, params?: Record<string, unknown>) => getTranslator()(key, params);
+
+  const MAP_WIDTH = 360;
+  const MAP_HEIGHT = 180;
+
+  let distribution: PeerGeoDistribution = {
+    totalPeers: 0,
+    regions: [],
+    dominantRegionId: null,
+    generatedAt: Date.now(),
+  };
+  let knownRegions: PeerGeoRegionStat[] = [];
+  let unknownBucket: PeerGeoRegionStat | undefined;
+  let maxCount = 0;
+  let hasPeers = false;
+
+  $: distribution = $peerGeoDistribution;
+  $: knownRegions = distribution.regions.filter((region) => region.regionId !== UNKNOWN_REGION_ID);
+  $: unknownBucket = distribution.regions.find((region) => region.regionId === UNKNOWN_REGION_ID);
+  $: maxCount = knownRegions.reduce((max, region) => Math.max(max, region.count), 0);
+  $: hasPeers = distribution.totalPeers > 0;
+
+  function markerRadius(count: number): number {
+    if (count <= 0 || maxCount === 0) {
+      return 0;
+    }
+    const minRadius = 6;
+    const extra = (count / maxCount) * 18;
+    return Math.round((minRadius + extra) * 10) / 10;
+  }
+
+  type MapRegionMarker = {
+    config: GeoRegionConfig;
+    stat?: PeerGeoRegionStat;
+    x: number;
+    y: number;
+    radius: number;
+  };
+
+  let mapRegions: MapRegionMarker[] = [];
+
+  $: mapRegions = GEO_REGIONS.filter((config) => config.id !== UNKNOWN_REGION_ID).map((config) => {
+    const stat = distribution.regions.find((region) => region.regionId === config.id);
+    const { x, y } = projectToMap(config.lat, config.lng, MAP_WIDTH, MAP_HEIGHT);
+    return {
+      config,
+      stat,
+      x,
+      y,
+      radius: markerRadius(stat?.count ?? 0),
+    };
+  });
+</script>
+
+<Card class="p-6 space-y-6">
+  <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
+    <div>
+      <h2 class="text-lg font-semibold">{tr('network.geoDistribution.title')}</h2>
+      <p class="text-sm text-muted-foreground">{tr('network.geoDistribution.subtitle', { values: { peers: distribution.totalPeers } })}</p>
+    </div>
+    {#if distribution.dominantRegionId}
+      <Badge variant="outline" class="flex items-center gap-2">
+        <MapPin class="h-4 w-4 text-primary" />
+        {tr('network.geoDistribution.topRegion', {
+          values: {
+            region: knownRegions.find((region) => region.regionId === distribution.dominantRegionId)?.label ?? distribution.dominantRegionId,
+          }
+        })}
+      </Badge>
+    {:else}
+      <Badge variant="outline" class="flex items-center gap-2">
+        <Globe2 class="h-4 w-4 text-muted-foreground" />
+        {tr('network.geoDistribution.noData')}
+      </Badge>
+    {/if}
+  </div>
+
+  <div class="grid gap-6 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+    <div class="bg-muted/60 border border-border/50 rounded-xl overflow-hidden shadow-inner">
+      <div class="relative">
+        <svg viewBox="0 0 {MAP_WIDTH} {MAP_HEIGHT}" class="w-full h-auto" preserveAspectRatio="xMidYMid meet">
+          <defs>
+            <radialGradient id="geo-glow" cx="50%" cy="50%" r="50%">
+              <stop offset="0%" stop-color="rgba(59,130,246,0.18)" />
+              <stop offset="70%" stop-color="rgba(59,130,246,0.08)" />
+              <stop offset="100%" stop-color="transparent" />
+            </radialGradient>
+          </defs>
+          <rect width="100%" height="100%" fill="url(#geo-glow)" />
+          <g stroke="rgba(148, 163, 184, 0.4)" stroke-width="0.5">
+            {#each Array(7) as _, index}
+              <line x1="0" y1="{(index + 1) * (MAP_HEIGHT / 8)}" x2="{MAP_WIDTH}" y2="{(index + 1) * (MAP_HEIGHT / 8)}" />
+            {/each}
+            {#each Array(11) as _, index}
+              <line x1="{(index + 1) * (MAP_WIDTH / 12)}" y1="0" x2="{(index + 1) * (MAP_WIDTH / 12)}" y2="{MAP_HEIGHT}" />
+            {/each}
+          </g>
+
+          {#each mapRegions as marker (marker.config.id)}
+            <g>
+              {#if marker.radius > 0}
+                <circle
+                  cx="{marker.x}"
+                  cy="{marker.y}"
+                  r="{marker.radius}"
+                  fill="{marker.config.color}"
+                  fill-opacity="0.45"
+                />
+              {/if}
+              <circle
+                cx="{marker.x}"
+                cy="{marker.y}"
+                r="{marker.radius > 0 ? Math.max(3, marker.radius / 3) : 3}"
+                fill="{marker.config.color}"
+                stroke="rgba(15, 23, 42, 0.6)"
+                stroke-width="0.8"
+              >
+                <title>
+                  {tr('network.geoDistribution.tooltip', {
+                    values: {
+                      region: marker.config.label,
+                      count: marker.stat?.count ?? 0,
+                    }
+                  })}
+                </title>
+              </circle>
+            </g>
+          {/each}
+        </svg>
+      </div>
+    </div>
+
+    <div class="space-y-4">
+      {#if !hasPeers}
+        <div class="p-4 bg-muted border border-dashed border-border rounded-lg text-sm text-muted-foreground">
+          {tr('network.geoDistribution.emptyState')}
+        </div>
+      {:else}
+        {#each distribution.regions as region (region.regionId)}
+          <div class="p-3 rounded-lg border border-border/60 bg-background/70 shadow-sm">
+            <div class="flex items-center justify-between gap-3">
+              <div class="flex items-center gap-2 min-w-0">
+                <span class="w-2 h-8 rounded-full" style="background-color: {region.color};"></span>
+                <div>
+                  <p class="font-medium leading-tight">{region.label}</p>
+                  <p class="text-xs text-muted-foreground">{region.count} · {region.percentage.toFixed(1)}%</p>
+                </div>
+              </div>
+              <Badge variant="secondary" class="text-xs">{tr('network.geoDistribution.peersShort', { values: { count: region.count } })}</Badge>
+            </div>
+            <div class="mt-2 h-2 bg-muted rounded-full overflow-hidden">
+              <div
+                class="h-full rounded-full transition-all"
+                style="width: {hasPeers && region.count > 0 ? Math.max(4, region.percentage) : 0}%; background-color: {region.color};"
+              ></div>
+            </div>
+          </div>
+        {/each}
+      {/if}
+      {#if unknownBucket && unknownBucket.count > 0 && hasPeers}
+        <p class="text-xs text-muted-foreground">
+          {tr('network.geoDistribution.unknownNotice', {
+            values: { count: unknownBucket.count }
+          })}
+        </p>
+      {/if}
+    </div>
+  </div>
+</Card>

--- a/src/lib/downloadTelemetry.ts
+++ b/src/lib/downloadTelemetry.ts
@@ -16,7 +16,11 @@ type DownloadAttemptPayload = {
 
 let unlisten: UnlistenFn | null = null;
 
-const tr = (key: string, params?: Record<string, unknown>) => get(t)(key, params);
+type TranslateFn = (key: string, params?: Record<string, unknown>) => string;
+
+const getTranslator = (): TranslateFn => get(t) as TranslateFn;
+
+const tr = (key: string, params?: Record<string, unknown>) => getTranslator()(key, params);
 
 function summarizeHash(hash: string): string {
   if (!hash) return 'unknown';

--- a/src/lib/geo.ts
+++ b/src/lib/geo.ts
@@ -1,0 +1,140 @@
+export interface GeoRegionConfig {
+  id: string;
+  label: string;
+  lat: number;
+  lng: number;
+  color: string;
+  aliases: string[];
+}
+
+export const GEO_REGIONS: GeoRegionConfig[] = [
+  {
+    id: 'usEast',
+    label: 'US-East',
+    lat: 39.0,
+    lng: -77.0,
+    color: '#2563eb',
+    aliases: ['useast', 'us-east', 'na-east', 'northamericaeast', 'us_east'],
+  },
+  {
+    id: 'usWest',
+    label: 'US-West',
+    lat: 37.5,
+    lng: -122.0,
+    color: '#0891b2',
+    aliases: ['uswest', 'us-west', 'na-west', 'northamericawest', 'us_west'],
+  },
+  {
+    id: 'euWest',
+    label: 'EU-West',
+    lat: 50.0,
+    lng: 2.0,
+    color: '#16a34a',
+    aliases: ['euwest', 'eu-west', 'europewest', 'eu_west'],
+  },
+  {
+    id: 'euCentral',
+    label: 'EU-Central',
+    lat: 52.0,
+    lng: 13.4,
+    color: '#65a30d',
+    aliases: ['eucentral', 'eu-central', 'europecentral', 'eu_central', 'eu'],
+  },
+  {
+    id: 'asiaPacific',
+    label: 'Asia-Pacific',
+    lat: 1.35,
+    lng: 103.8,
+    color: '#f97316',
+    aliases: ['asia-pacific', 'asiapacific', 'apac', 'asia', 'asia_pacific'],
+  },
+  {
+    id: 'asiaEast',
+    label: 'Asia-East',
+    lat: 35.7,
+    lng: 139.7,
+    color: '#fb7185',
+    aliases: ['asiaeast', 'asia-east', 'apac-east', 'asia_east', 'jp'],
+  },
+  {
+    id: 'southAmerica',
+    label: 'South America',
+    lat: -23.5,
+    lng: -46.6,
+    color: '#d946ef',
+    aliases: ['southamerica', 'south-america', 'latam', 'sa'],
+  },
+  {
+    id: 'africa',
+    label: 'Africa',
+    lat: 9.1,
+    lng: 21.3,
+    color: '#facc15',
+    aliases: ['africa', 'emea-africa', 'za', 'nigeria'],
+  },
+  {
+    id: 'oceania',
+    label: 'Oceania',
+    lat: -33.8,
+    lng: 151.2,
+    color: '#38bdf8',
+    aliases: ['oceania', 'australia', 'anz', 'apac-south', 'nz'],
+  },
+  {
+    id: 'unknown',
+    label: 'Unknown',
+    lat: 0,
+    lng: 0,
+    color: '#9ca3af',
+    aliases: ['unknown', 'unassigned', 'n/a', ''],
+  },
+];
+
+const REGION_ALIAS_INDEX = new Map<string, GeoRegionConfig>();
+
+for (const region of GEO_REGIONS) {
+  REGION_ALIAS_INDEX.set(region.id.toLowerCase(), region);
+  for (const alias of region.aliases) {
+    REGION_ALIAS_INDEX.set(alias.toLowerCase(), region);
+  }
+}
+
+export const UNKNOWN_REGION_ID = 'unknown';
+
+export function normalizeRegion(value?: string | null): GeoRegionConfig {
+  if (!value) {
+    return REGION_ALIAS_INDEX.get(UNKNOWN_REGION_ID) as GeoRegionConfig;
+  }
+
+  const compact = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, '');
+
+  if (!compact) {
+    return REGION_ALIAS_INDEX.get(UNKNOWN_REGION_ID) as GeoRegionConfig;
+  }
+
+  const explicit = REGION_ALIAS_INDEX.get(value.trim().toLowerCase());
+  if (explicit) {
+    return explicit;
+  }
+
+  const normalized = REGION_ALIAS_INDEX.get(compact);
+  if (normalized) {
+    return normalized;
+  }
+
+  return REGION_ALIAS_INDEX.get(UNKNOWN_REGION_ID) as GeoRegionConfig;
+}
+
+export function projectToMap(
+  lat: number,
+  lng: number,
+  width: number,
+  height: number
+): { x: number; y: number } {
+  const x = ((lng + 180) / 360) * width;
+  const y = ((90 - lat) / 180) * height;
+  return { x, y };
+}

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -1,4 +1,5 @@
 import { writable, derived } from "svelte/store";
+import { normalizeRegion, GEO_REGIONS, UNKNOWN_REGION_ID } from "$lib/geo";
 
 export interface FileItem {
   id: string;
@@ -68,6 +69,22 @@ export interface PeerInfo {
   joinDate: Date;
   lastSeen: Date;
   location?: string;
+}
+
+export interface PeerGeoRegionStat {
+  regionId: string;
+  label: string;
+  count: number;
+  percentage: number;
+  color: string;
+  peers: PeerInfo[];
+}
+
+export interface PeerGeoDistribution {
+  totalPeers: number;
+  regions: PeerGeoRegionStat[];
+  dominantRegionId: string | null;
+  generatedAt: number;
 }
 
 export const suspiciousActivity = writable<
@@ -261,6 +278,57 @@ import { networkStatus } from "./services/networkService";
 export { networkStatus };
 
 export const peers = writable<PeerInfo[]>(dummyPeers);
+
+export const peerGeoDistribution = derived(peers, ($peers): PeerGeoDistribution => {
+  const totals = new Map<string, PeerGeoRegionStat>();
+
+  for (const region of GEO_REGIONS) {
+    totals.set(region.id, {
+      regionId: region.id,
+      label: region.label,
+      count: 0,
+      percentage: 0,
+      color: region.color,
+      peers: [],
+    });
+  }
+
+  for (const peer of $peers) {
+    const region = normalizeRegion(peer.location);
+    const bucket = totals.get(region.id);
+    if (!bucket) {
+      continue;
+    }
+
+    bucket.count += 1;
+    bucket.peers.push(peer);
+  }
+
+  const totalPeers = $peers.length;
+  for (const bucket of totals.values()) {
+    bucket.percentage = totalPeers === 0 ? 0 : Math.round((bucket.count / totalPeers) * 1000) / 10;
+  }
+
+  const buckets = Array.from(totals.values());
+  buckets.sort((a, b) => {
+    if (a.regionId === UNKNOWN_REGION_ID && b.regionId !== UNKNOWN_REGION_ID) return 1;
+    if (b.regionId === UNKNOWN_REGION_ID && a.regionId !== UNKNOWN_REGION_ID) return -1;
+    if (b.count === a.count) {
+      return a.label.localeCompare(b.label);
+    }
+    return b.count - a.count;
+  });
+
+  const dominantRegion = buckets.find((bucket) => bucket.regionId !== UNKNOWN_REGION_ID && bucket.count > 0);
+
+  return {
+    totalPeers,
+    regions: buckets,
+    dominantRegionId: dominantRegion ? dominantRegion.regionId : null,
+    generatedAt: Date.now(),
+  };
+});
+
 export const chatMessages = writable<ChatMessage[]>([]);
 export const networkStats = writable<NetworkStats>(dummyNetworkStats);
 export const downloadQueue = writable<FileItem[]>([]);

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -176,7 +176,17 @@
     "locationHint": "Helps find closer peers for better performance.",
     "enableUpnp": "Enable UPnP",
     "enableNat": "Enable NAT Port Mapping",
-    "enableDht": "Enable DHT"
+    "enableDht": "Enable DHT",
+    "geoDistribution": {
+      "title": "Geographic Distribution",
+      "subtitle": "Mapping {peers} observed peers",
+      "topRegion": "Top region: {region}",
+      "noData": "Awaiting location data",
+      "tooltip": "{region}: {count} peers",
+      "peersShort": "{count} peers",
+      "emptyState": "Connect to the DHT to start mapping peers.",
+      "unknownNotice": "{count} peers have no advertised location yet."
+    }
   },
   "download": {
     "title": "Download Files",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -144,7 +144,17 @@
     "locationHint": "Ayuda a conectar con pares cercanos para un mejor rendimiento.",
     "enableUpnp": "Habilitar UPnP",
     "enableNat": "Habilitar mapeo de puertos NAT",
-    "enableDht": "Habilitar DHT"
+    "enableDht": "Habilitar DHT",
+    "geoDistribution": {
+      "title": "Distribución geográfica",
+      "subtitle": "Mapeando {peers} pares observados",
+      "topRegion": "Región principal: {region}",
+      "noData": "Esperando datos de ubicación",
+      "tooltip": "{region}: {count} pares",
+      "peersShort": "{count} pares",
+      "emptyState": "Conéctate al DHT para comenzar a mapear pares.",
+      "unknownNotice": "{count} pares todavía no informan su ubicación."
+    }
   },
   "regions.usEast": "EE. UU. Este",
   "regions.usWest": "EE. UU. Oeste",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -144,7 +144,17 @@
     "locationHint": "더 나은 성능을 위해 가까운 피어에 연결하는 데 도움이 됩니다.",
     "enableUpnp": "UPnP 활성화",
     "enableNat": "NAT 포트 매핑 활성화",
-    "enableDht": "DHT 활성화"
+    "enableDht": "DHT 활성화",
+    "geoDistribution": {
+      "title": "지리 분포",
+      "subtitle": "{peers}개의 피어 위치를 추적 중",
+      "topRegion": "최다 지역: {region}",
+      "noData": "위치 데이터 대기 중",
+      "tooltip": "{region}: {count}개 피어",
+      "peersShort": "{count}개 피어",
+      "emptyState": "DHT에 연결해 피어 위치를 확인하세요.",
+      "unknownNotice": "{count}개의 피어가 아직 위치를 제공하지 않았습니다."
+    }
   },
   "regions.usEast": "미국 동부",
   "regions.usWest": "미국 서부",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -144,7 +144,17 @@
     "locationHint": "帮助连接附近节点以获得更好性能。",
     "enableUpnp": "启用UPnP",
     "enableNat": "启用NAT端口映射",
-    "enableDht": "启用DHT"
+    "enableDht": "启用DHT",
+    "geoDistribution": {
+      "title": "地理分布",
+      "subtitle": "正在映射 {peers} 个已观测的节点",
+      "topRegion": "节点最多的区域：{region}",
+      "noData": "等待位置数据",
+      "tooltip": "{region}：{count} 个节点",
+      "peersShort": "{count} 个节点",
+      "emptyState": "连接到 DHT 后即可开始绘制节点地图。",
+      "unknownNotice": "仍有 {count} 个节点未提供位置信息。"
+    }
   },
   "regions.usEast": "美国东部",
   "regions.usWest": "美国西部",

--- a/src/pages/Network.svelte
+++ b/src/pages/Network.svelte
@@ -6,6 +6,7 @@
   import Label from '$lib/components/ui/label.svelte'
   import GethStatusCard from '$lib/components/GethStatusCard.svelte'
   import PeerMetrics from '$lib/components/PeerMetrics.svelte'
+  import GeoDistributionCard from '$lib/components/GeoDistributionCard.svelte'
   import { Users, HardDrive, Activity, RefreshCw, UserPlus, Signal, Server, Play, Square, Download, AlertCircle, Wifi } from 'lucide-svelte'
   import { peers, networkStats, networkStatus, userLocation, etcAccount } from '$lib/stores'
   import { get } from 'svelte/store'
@@ -1293,6 +1294,10 @@
         </div>
       </div>
     </Card>
+  </div>
+  
+  <div class="mt-6">
+    <GeoDistributionCard />
   </div>
   
   <!-- Peer Discovery -->

--- a/src/types/external.d.ts
+++ b/src/types/external.d.ts
@@ -1,0 +1,2 @@
+declare module 'svelte-i18n';
+declare module '@tauri-apps/plugin-store';


### PR DESCRIPTION
…lemetry translator

## Summary
- add reusable geo metadata and projection helpers for common regions
- derive per-region peer distribution in the store with dominant region detection and unknown tracking
- surface a Geographic Distribution card on Network with an interactive SVG map, progress bars, and multi-locale copy

## Testing
- [x] npm run check

## Manual Steps
1. npm run dev
2. Open the Network page
3. Confirm the new “Geographic Distribution” card shows totals, handles zero-peers empty state, and tooltips report per-region counts

## Acceptance Checklist
- [ ] Map markers scale relative to peer counts without overlapping labels
- [ ] Empty state renders when no peers are connected
- [ ] Unknown peers message appears only when unresolved locations exist
- [ ] Sorting new peers updates the card automatically