### PR TITLE
fix(webrtc): peer connection

### DIFF
--- a/src/lib/services/server/server.cjs
+++ b/src/lib/services/server/server.cjs
@@ -1,0 +1,84 @@
+// WebSocket signaling server for peer discovery and WebRTC signaling
+const WebSocket = require('ws');
+const wss = new WebSocket.Server({ port: 9000 });
+
+// Track connected peers
+const peers = new Map(); // clientId -> WebSocket
+
+wss.on('connection', function connection(ws) {
+  console.log('New client connected');
+  
+  ws.on('message', function incoming(data) {
+    try {
+      const message = JSON.parse(data);
+      console.log('Received message:', message);
+      
+      if (message.type === 'register') {
+        // Register new peer
+        peers.set(message.clientId, ws);
+        ws.clientId = message.clientId;
+        console.log(`Peer registered: ${message.clientId}`);
+        
+        // Send current peer list to new client
+        const peerList = Array.from(peers.keys()).filter(id => id !== message.clientId);
+        ws.send(JSON.stringify({
+          type: 'peers',
+          peers: peerList
+        }));
+        
+        // Notify other peers about new peer
+        broadcastToPeers({
+          type: 'peers',
+          peers: Array.from(peers.keys())
+        }, message.clientId);
+        
+      } else if (message.to) {
+        // Route message to specific peer
+        const targetWs = peers.get(message.to);
+        if (targetWs && targetWs.readyState === WebSocket.OPEN) {
+          targetWs.send(JSON.stringify(message));
+          console.log(`Routed ${message.type} from ${message.from} to ${message.to}`);
+        } else {
+          console.log(`Target peer ${message.to} not found or disconnected`);
+        }
+      } else {
+        // Broadcast to all other clients (fallback)
+        wss.clients.forEach(function each(client) {
+          if (client !== ws && client.readyState === WebSocket.OPEN) {
+            client.send(JSON.stringify(message));
+          }
+        });
+      }
+    } catch (error) {
+      console.error('Error processing message:', error);
+    }
+  });
+  
+  ws.on('close', function() {
+    if (ws.clientId) {
+      console.log(`Peer disconnected: ${ws.clientId}`);
+      peers.delete(ws.clientId);
+      
+      // Notify remaining peers about disconnection
+      broadcastToPeers({
+        type: 'peers',
+        peers: Array.from(peers.keys())
+      });
+    }
+  });
+  
+  ws.on('error', function(error) {
+    console.error('WebSocket error:', error);
+  });
+});
+
+function broadcastToPeers(message, excludeClientId = null) {
+  peers.forEach((ws, clientId) => {
+    if (clientId !== excludeClientId && ws.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify(message));
+    }
+  });
+}
+
+console.log('Signaling server running on ws://localhost:9000');
+console.log('Ready for peer connections...');

--- a/src/lib/services/signalingService.ts
+++ b/src/lib/services/signalingService.ts
@@ -21,7 +21,7 @@ export class SignalingService {
   // handler for WebRTC signaling messages
   private onMessageHandler: ((msg: any) => void) | null = null;
 
-  constructor(private url: string = "ws://localhost:3000") {
+  constructor(private url: string = "ws://localhost:9000") {
     this.clientId = createClientId();
   }
 


### PR DESCRIPTION
**Changes**
- add WebSocket signaling server (`server.cjs`) on port 9000 for peer discovery
- implement peer registration, message routing, and disconnection handling
- update `SignalingService.ts` client to interact with the signaling server
- update `Network.svelte` to:
  - initialize signaling service on mount
  - discover peers dynamically via WebSocket
  - replace mock peer connections with WebRTC sessions
  - add connection state monitoring and toast notifications
- add error handling and validation for WebSocket and WebRTC states