### PR TITLE
Fix: Populate recent blocks list on Mining page

### DIFF
--- a/src/lib/wallet.ts
+++ b/src/lib/wallet.ts
@@ -8,6 +8,20 @@ const seenHashes = new Set<string>();
 // This is the helper function that creates the transaction object
 function pushRecentBlock(b: { hash: string; reward?: number; timestamp?: Date }) {
   const reward = typeof b.reward === 'number' ? b.reward : 0;
+
+  const newBlock = {
+    id: `block-${b.hash}-${b.timestamp?.getTime() ?? Date.now()}`,
+    hash: b.hash,
+    reward: reward,
+    timestamp: b.timestamp ?? new Date(),
+    difficulty: 0,
+    nonce: 0, 
+  };
+  miningState.update(state => ({
+    ...state,
+    recentBlocks: [newBlock, ...(state.recentBlocks ?? [])].slice(0, 50)
+  }));
+
   if (reward > 0) {
     const last4 = b.hash.slice(-4);
     const tx: Transaction = {


### PR DESCRIPTION
The wallet service was correctly fetching new blocks and creating transactions for the account page, but it was not updating the `recentBlocks` array in the `miningState`.

This change modifies the `pushRecentBlock` helper to update both the `transactions` store and the `miningState`, ensuring the UI on the mining page reflects newly mined blocks.

BEFORE: 
<img width="1228" height="824" alt="Screenshot 2025-09-29 at 6 04 28 PM" src="https://github.com/user-attachments/assets/db98055e-5000-44f5-a2b5-4d63a7b1ba32" />

AFTER:
<img width="1212" height="835" alt="Screenshot 2025-09-29 at 6 06 54 PM" src="https://github.com/user-attachments/assets/33bb87c8-22d7-4e1c-aa4c-241c7ec3bd2b" />
