### PR TITLE
fix: Clean up stale Geth lock files on Windows startup to prevent "datadir already used" errors

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2033,6 +2033,29 @@ fn main() {
                     .output();
             }
 
+            #[cfg(windows)]
+            {
+                use std::process::Command;
+                // On Windows, use taskkill to terminate geth processes
+                let _ = Command::new("taskkill")
+                    .args(["/F", "/IM", "geth.exe"])
+                    .output();
+            }
+
+            // Also remove the lock file if it exists
+            let lock_file = std::path::Path::new(DEFAULT_GETH_DATA_DIR).join("LOCK");
+            if lock_file.exists() {
+                println!("Removing stale LOCK file: {:?}", lock_file);
+                let _ = std::fs::remove_file(&lock_file);
+            }
+
+            // Remove geth.ipc file if it exists (another common lock point)
+            let ipc_file = std::path::Path::new(DEFAULT_GETH_DATA_DIR).join("geth.ipc");
+            if ipc_file.exists() {
+                println!("Removing stale IPC file: {:?}", ipc_file);
+                let _ = std::fs::remove_file(&ipc_file);
+            }
+
             println!("App setup complete");
             println!("Window should be visible now!");
 


### PR DESCRIPTION
### Problem
The application frequently fails to start Geth with the error "Fatal: Failed to create the protocol stack: datadir already used by another process". This occurs when:
- The application crashes or is force-closed without properly terminating Geth
- Stale lock files (`LOCK` and `geth.ipc`) are left in the data directory
- Previous cleanup logic only worked on Unix systems

### Changes
Added Windows-specific cleanup logic in the application setup phase:
- Terminates any orphaned `geth.exe` processes using `taskkill`
- Removes stale `LOCK` file from the data directory if present
- Removes stale `geth.ipc` file from the data directory if present

This complements the existing Unix cleanup code (`pkill`) to ensure cross-platform reliability.

### Testing
- Verified that stale lock files are properly removed on Windows startup
- Confirmed that Geth can start successfully after application crashes
- Existing Unix cleanup logic remains unchanged

### Notes
This is a startup-time fix. For complete robustness, similar cleanup should also be added to the `GethProcess::stop()` method to ensure graceful shutdown always removes these lock files.

Previous chiral node log:
INFO [09-29|18:10:03.240] Maximum peer count ETH=50 total=50
Fatal: Failed to create the protocol stack: datadir already used by another process
Now