### PR TITLE
Fix illegal invocation error preventing downloads from starting

### DIFF
--- a/src/lib/services/signalingService.ts
+++ b/src/lib/services/signalingService.ts
@@ -2,11 +2,12 @@ import { writable, type Writable } from "svelte/store";
 import { invoke } from "@tauri-apps/api/core";
 
 function createClientId(): string {
-  const randomUUID = globalThis?.crypto?.randomUUID;
-  if (typeof randomUUID === "function") {
-    return randomUUID();
+  // Check if crypto.randomUUID exists and call it directly to preserve 'this' context
+  if (globalThis?.crypto?.randomUUID) {
+    return globalThis.crypto.randomUUID();
   }
 
+  // Fallback for environments without crypto.randomUUID
   const timePart = Date.now().toString(36);
   const randomPart = Math.random().toString(36).slice(2, 10);
   return `client-${timePart}-${randomPart}`;


### PR DESCRIPTION
App crashed with `TypeError: Illegal invocation`. when starting a download or retrying existing downloads. This prevented any P2P downloads from even attempting to start.

   ### Cause

- In `signalingService.ts`, the `createClientId()` function was storing `crypto.randomUUID` in a variable before calling it. This caused the function to lose its `this` context, breaking the Web Crypto API call.

### Fix

- Changed line 6-7 to call `globalThis.crypto.randomUUID()` directly instead of storing it first
- Preserves proper `this` binding for the crypto API