### PR TITLE
fix(analytics): sync total earnings with mining rewards

### DIFF
--- a/src/pages/Analytics.svelte
+++ b/src/pages/Analytics.svelte
@@ -9,6 +9,8 @@
   import { t } from 'svelte-i18n'
   import { suspiciousActivity } from '$lib/stores'; // only import
   import type { FileItem } from '$lib/stores';
+  import { miningState } from '$lib/stores';
+
   
   let uploadedFiles: FileItem[] = []
   let downloadedFiles: FileItem[] = []
@@ -388,7 +390,7 @@
       <div class="flex items-center justify-between">
         <div>
           <p class="text-sm text-muted-foreground">{$t('analytics.totalEarnings')}</p>
-          <p class="text-2xl font-bold">{($wallet.totalEarned ?? 0).toFixed(2)} Chiral</p>
+          <p class="text-2xl font-bold">{($miningState.totalRewards ?? 0).toFixed(2)} Chiral</p>
           <p class="text-xs text-green-600 flex items-center gap-1 mt-1">
             <TrendingUp class="h-3 w-3" />
             {$t('analytics.earningsThisWeek')}


### PR DESCRIPTION
This PR fixes the Analytics Dashboard so that Total Earnings is pulled directly from miningState.totalRewards instead of the placeholder wallet value.

Mining Page: 
<img width="2018" height="988" alt="image" src="https://github.com/user-attachments/assets/90dd906f-6571-4835-a1ea-d14ae3cd2823" />

Before: 
<img width="1998" height="978" alt="image" src="https://github.com/user-attachments/assets/6f8f59d0-0e91-470c-84f0-a021cea907da" />

After: 
<img width="2018" height="974" alt="image" src="https://github.com/user-attachments/assets/c8c56e86-260b-4dac-932f-32b35e13613e" />
