### PR TITLE
feat(settings): Auto-expand sections with validation errors

### DIFF
--- a/src/pages/Settings.svelte
+++ b/src/pages/Settings.svelte
@@ -29,6 +29,10 @@
   import { settings, type AppSettings } from "$lib/stores";
 
   let showResetConfirmModal = false;
+  let storageSectionOpen = false;
+  let networkSectionOpen = false;
+  let advancedSectionOpen = false;
+
   // Settings state
   let defaultSettings: AppSettings = {
     // Storage settings
@@ -112,6 +116,20 @@
     userLocation.set(localSettings.userLocation);
     importExportFeedback = null;
     showToast("Settings Updated!");
+  }
+
+  $: {
+    // Expand Storage section if it has any errors
+    const hasStorageError = !!maxStorageError || !!errors.maxStorageSize || !!errors.cleanupThreshold;
+    storageSectionOpen = hasStorageError;
+
+    // Expand Network section if it has any errors
+    const hasNetworkError = !!errors.maxConnections || !!errors.port || !!errors.uploadBandwidth || !!errors.downloadBandwidth;
+    networkSectionOpen = hasNetworkError;
+
+    // Expand Advanced section if it has any errors
+    const hasAdvancedError = !!errors.chunkSize || !!errors.cacheSize;
+    advancedSectionOpen = hasAdvancedError;
   }
 
   function handleConfirmReset() {
@@ -405,7 +423,7 @@ function sectionMatches(section: string, query: string) {
 
   <!-- Storage Settings -->
   {#if sectionMatches("storage", search)}
-    <Expandable>
+    <Expandable bind:isOpen={storageSectionOpen}>
       <div slot="title" class="flex items-center gap-3">
         <HardDrive class="h-6 w-6 text-blue-600" />
         <h2 class="text-xl font-semibold text-black">{$t("storage.title")}</h2>
@@ -489,7 +507,7 @@ function sectionMatches(section: string, query: string) {
 
   <!-- Network Settings -->
   {#if sectionMatches("network", search)}
-    <Expandable>
+    <Expandable bind:isOpen={networkSectionOpen}>
       <div slot="title" class="flex items-center gap-3">
         <Wifi class="h-6 w-6 text-blue-600" />
         <h2 class="text-xl font-semibold text-black">{$t("network.title")}</h2>
@@ -758,7 +776,7 @@ function sectionMatches(section: string, query: string) {
 
   <!-- Advanced Settings -->
   {#if sectionMatches("advanced", search)}
-    <Expandable>
+    <Expandable bind:isOpen={advancedSectionOpen}>
       <div slot="title" class="flex items-center gap-3">
         <Database class="h-6 w-6 text-blue-600" />
         <h2 class="text-xl font-semibold text-black">{$t("advanced.title")}</h2>


### PR DESCRIPTION
Summary: Improves the user experience on the settings page by automatically expanding any section in Settings that contains a validation error.

Before:
Previously, if the "Save" button was disabled due to an error (e.g., max storage size exceeding available space), the error message was hidden within its collapsed section. This made it difficult for the user to identify what needed to be fixed and created the false impression that the 'Save Settings' button was broken.
<img width="1502" height="1091" alt="Screenshot 2025-10-01 200806" src="https://github.com/user-attachments/assets/ddbb33aa-7aa5-4118-9b71-3be1f552fbb8" />
<img width="1495" height="1144" alt="Screenshot 2025-10-01 190031" src="https://github.com/user-attachments/assets/2c339f7c-8a85-4476-9c12-48909491fc6d" />

After:
This change implements reactive logic that:
- Monitors all validation error states.
- Sets the `isOpen` property of an `Expandable` section to true if any validation error within it is active.
- Ensures the user is immediately guided to the input that requires their attention.
<img width="2143" height="1439" alt="Screenshot 2025-10-01 200822" src="https://github.com/user-attachments/assets/0097e911-9ad6-4ab3-a549-9e0a9bed78e7" />

