### PR TITLE
fix(analytics): correctly calculate and label last block contribution %

### DIFF
--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -393,6 +393,8 @@ export const miningState = writable<MiningState>({
   miningHistory: [],
 });
 
+export const miningProgress = writable({ cumulative: 0, lastBlock: 0 });
+
 export const totalEarned = derived(
   miningState,
   ($miningState) => $miningState.totalRewards


### PR DESCRIPTION
This update replaces the dummy hard-coded 12.5% value with a live calculation of the most recent block’s contribution to total rewards, ensuring the percentage dynamically reflects actual mining activity.

Before: 
<img width="524" height="278" alt="image" src="https://github.com/user-attachments/assets/02b8d1ed-db54-4ce0-b78b-8469829de85b" />

After: 
<img width="492" height="252" alt="image" src="https://github.com/user-attachments/assets/26efb8dd-02bf-49db-9ae7-507b2d1e593e" />
