### PR TITLE
fix: Failed to update network stats: "Command get_network_peer_count …

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2569,6 +2569,7 @@ fn main() {
         .invoke_handler(tauri::generate_handler![
             create_chiral_account,
             import_chiral_account,
+            get_network_peer_count,
             start_geth_node,
             stop_geth_node,
             save_account_to_keystore,
@@ -2827,7 +2828,6 @@ async fn encrypt_file_for_self_upload(
         .await
         .clone()
         .ok_or("No active account. Please log in to encrypt.")?;
-
     let pk_bytes = hex::decode(private_key_hex.trim_start_matches("0x"))
         .map_err(|_| "Invalid private key format".to_string())?;
     let secret_key = StaticSecret::from(


### PR DESCRIPTION
When we connect to the Chiral Network, we get this continuous error: 
<img width="1271" height="275" alt="Screenshot 2025-10-03 at 12 38 44 PM" src="https://github.com/user-attachments/assets/f3758078-305b-43eb-89a5-76f2fc89e8c5" />

This is fixed by registering the command "get_network_peer_count" with the invoke handler. The error does not appear anymore.