### PR TITLE
fix(download): prevent duplicate search results by enforcing single root version

### DIFF
--- a/src-tauri/src/dht.rs
+++ b/src-tauri/src/dht.rs
@@ -87,6 +87,7 @@ pub struct FileMetadata {
     pub version: Option<u32>,
     pub parent_hash: Option<String>,
     pub cids: Option<Vec<Cid>>, // list of CIDs for all chunks
+    pub is_root: bool,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -2010,7 +2011,7 @@ impl DhtService {
         let all = self.get_all_file_metadata().await?;
         let mut versions: Vec<FileMetadata> = all
             .into_iter()
-            .filter(|m| m.file_name == file_name)
+            .filter(|m| m.file_name == file_name && m.is_root)
             .collect();
         versions.sort_by(|a, b| b.version.unwrap_or(1).cmp(&a.version.unwrap_or(1)));
 
@@ -2047,12 +2048,13 @@ impl DhtService {
         let latest = self
             .get_latest_version_by_file_name(file_name.clone())
             .await?;
-        let (version, parent_hash) = match latest {
+        let (version, parent_hash, is_root) = match latest {
             Some(ref prev) => (
                 prev.version.map(|v| v + 1).unwrap_or(2),
                 Some(prev.file_hash.clone()),
+                false, // not root if there was a previous version
             ),
-            None => (1, None),
+            None => (1, None, true), // root if first version
         };
         Ok(FileMetadata {
             file_hash,
@@ -2068,6 +2070,7 @@ impl DhtService {
             version: Some(version),
             parent_hash,
             cids: None,
+            is_root: true, 
         })
     }
 

--- a/src-tauri/src/headless.rs
+++ b/src-tauri/src/headless.rs
@@ -196,6 +196,7 @@ pub async fn run_headless(args: CliArgs) -> Result<(), Box<dyn std::error::Error
             parent_hash: None,
             version: Some(1),
             cids: None,
+            is_root: true,
         };
 
         dht_service.publish_file(example_metadata).await?;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -769,6 +769,7 @@ async fn publish_file_metadata(
             parent_hash: None,
             version: Some(1),
             cids: None,
+            is_root: false,
         };
 
         dht.publish_file(metadata).await
@@ -1339,6 +1340,7 @@ async fn upload_file_to_network(
                 parent_hash: None,
                 version: Some(1),
                 cids: None,
+                is_root: true,
             };
 
             match dht.publish_file(metadata.clone()).await {
@@ -1640,6 +1642,7 @@ async fn upload_file_data_to_network(
             parent_hash: None,
             version: Some(1),
             cids: None,
+            is_root: true, 
         };
 
         // Publish to DHT


### PR DESCRIPTION
This PR fixes the duplicate results issue in file searches by ensuring that only one root version of each file is returned.

Before: 
<img width="1938" height="898" alt="image" src="https://github.com/user-attachments/assets/369faefd-205f-4584-be68-2bd44217b523" />

After: 
<img width="2000" height="880" alt="image" src="https://github.com/user-attachments/assets/29412bf5-a9de-4ba9-8bdd-32c23dcc6da6" />