### PR TITLE
fix(proxy): Resolve race condition

### DIFF
--- a/src-tauri/src/commands/proxy.rs
+++ b/src-tauri/src/commands/proxy.rs
@@ -92,16 +92,7 @@ pub(crate) async fn proxy_disconnect(
     url: String,
 ) -> Result<(), String> {
     info!("Disconnecting from proxy: {}", url);
-    // // For proto v1: mark offline locally (no full teardown API yet)
-    // let mut proxies = state.proxies.lock().await;
-    // if let Some(p) = proxies.iter_mut().find(|p| p.address == url || p.id == url) {
-    //     p.status = "offline".into();
-    //     let _ = app.emit("proxy_status_update", p.clone());
-    // }
-    // // Note: This doesn't actually disconnect the peer in libp2p in this version.
-    // Ok(())
-    
-    // Update local cache optimistically and capture the peer ID if known
+
     let maybe_peer_id = {
         let mut proxies = state.proxies.lock().await;
         proxies
@@ -114,23 +105,48 @@ pub(crate) async fn proxy_disconnect(
             })
     };
 
-    let dht: Arc<DhtService> = {
-        let guard = state.dht.lock().await;
-        guard
-            .as_ref()
-            .cloned()
-            .ok_or_else(|| "DHT not initialized".to_string())?
+    if let Some(peer_id_str) = maybe_peer_id {
+        if let Ok(peer_id) = PeerId::from_str(&peer_id_str) {
+            if let Some(dht) = state.dht.lock().await.as_ref() {
+                return dht.disconnect_peer(peer_id).await;
+            }
+        }
+    }
+
+    Err("Could not disconnect peer".into())
+}
+
+#[tauri::command]
+pub(crate) async fn proxy_remove(
+    app: tauri::AppHandle,
+    state: tauri::State<'_, AppState>,
+    url: String,
+) -> Result<(), String> {
+    info!("Removing proxy: {}", url);
+
+    let maybe_peer_id = {
+        let mut proxies = state.proxies.lock().await;
+        let maybe_idx = proxies.iter().position(|p| p.address == url || p.id == url);
+        if let Some(idx) = maybe_idx {
+            let p = proxies.remove(idx);
+            Some(p.id)
+        } else {
+            None
+        }
     };
 
-    let peer_id_str = maybe_peer_id.unwrap_or_else(|| url.clone());
-    let peer_id = PeerId::from_str(&peer_id_str).map_err(|_| {
-        warn!("Could not parse peer id for disconnect: {}", peer_id_str);
-        format!("Invalid peer id: {}", peer_id_str)
-    })?;
+    if let Some(peer_id_str) = maybe_peer_id {
+        if let Ok(peer_id) = PeerId::from_str(&peer_id_str) {
+            if let Some(dht) = state.dht.lock().await.as_ref() {
+                let _ = dht.disconnect_peer(peer_id).await;
+            }
+        }
+    }
 
-    dht.disconnect_peer(peer_id).await
-
+    let _ = app.emit("proxy_reset", ());
+    Ok(())
 }
+
 
 #[tauri::command]
 pub(crate) async fn list_proxies(state: State<'_, AppState>) -> Result<Vec<ProxyNode>, String> {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -21,7 +21,7 @@ use std::sync::Mutex as StdMutex;
 
 use lazy_static::lazy_static;
 use crate::commands::proxy::{
-    list_proxies, proxy_connect, proxy_disconnect, proxy_echo, ProxyNode,
+    list_proxies, proxy_connect, proxy_disconnect, proxy_remove, proxy_echo, ProxyNode,
 };
 use dht::{DhtEvent, DhtMetricsSnapshot, DhtService, FileMetadata};
 use ethereum::{
@@ -2630,6 +2630,7 @@ fn main() {
             get_available_storage,
             proxy_connect,
             proxy_disconnect,
+            proxy_remove,
             proxy_echo,
             list_proxies,
             generate_totp_secret,

--- a/src/lib/proxy.ts
+++ b/src/lib/proxy.ts
@@ -157,6 +157,15 @@ export async function disconnectProxy(url: string) {
   }
 }
 
+export async function removeProxy(url: string) {
+  try {
+    await invoke("proxy_remove", { url });
+    proxyNodes.update((nodes) => nodes.filter((n) => n.address !== url));
+  } catch (e) {
+    console.error("proxy_remove failed:", e);
+  }
+}
+
 export async function listProxies() {
   try {
     const incoming = (await invoke<ProxyNode[]>("list_proxies")) ?? [];

--- a/src/lib/proxy.ts
+++ b/src/lib/proxy.ts
@@ -141,6 +141,7 @@ export function disposeProxyEvents() {
 }
 
 export async function connectProxy(url: string, token: string) {
+  await initProxyEvents();
   try {
     await invoke("proxy_connect", { url, token });
   } catch (e) {

--- a/src/pages/Proxy.svelte
+++ b/src/pages/Proxy.svelte
@@ -6,7 +6,7 @@
   import Badge from '$lib/components/ui/badge.svelte'
   import { ShieldCheck, ShieldX, Globe, Activity, Plus, Power, Trash2 } from 'lucide-svelte'
   import { onMount } from 'svelte';
-  import { proxyNodes, connectProxy, disconnectProxy, listProxies } from '$lib/proxy';
+  import { proxyNodes, connectProxy, disconnectProxy, removeProxy, listProxies } from '$lib/proxy';
   import { t } from 'svelte-i18n'
   import DropDown from '$lib/components/ui/dropDown.svelte'
   
@@ -68,8 +68,8 @@
   }
 
   function confirmRemoveNode() {
-    if (nodeToRemove) {
-      disconnectProxy(nodeToRemove.address)
+    if (nodeToRemove && nodeToRemove.address) {
+      removeProxy(nodeToRemove.address)
     }
     showConfirmDialog = false
     nodeToRemove = null
@@ -98,12 +98,12 @@
 <!-- Confirmation Dialog -->
 {#if showConfirmDialog && nodeToRemove}
   <div class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-    <div class="bg-white rounded-lg p-6 max-w-md w-full mx-4">
+    <div class="bg-white rounded-lg p-6 max-w-md w-full mx-4 overflow-hidden">
       <h3 class="text-lg font-semibold mb-4">Confirm Removal</h3>
-      <p class="text-muted-foreground mb-6">
+      <p class="text-muted-foreground mb-6 break-words">
         Confirm the removal of proxy node <span class="font-medium">{nodeToRemove.address}</span>
       </p>
-      <div class="flex gap-3 justify-end">
+      <div class="flex gap-3 justify-center">
         <Button variant="outline" on:click={cancelRemoveNode}>
           Cancel
         </Button>
@@ -260,20 +260,19 @@
     <div class="space-y-3">
       {#each sortedNodes as node}
         <div class="p-4 bg-secondary rounded-lg">
-          <div class="flex items-center justify-between mb-3">
-            <div class="flex items-center gap-3">
-              <div class="w-2 h-2 rounded-full {
-                node.status === 'online' ? 'bg-green-500' : 
-                node.status === 'offline' ? 'bg-red-500' : 
-                node.status === 'connecting' ? 'bg-yellow-500' :
-                'bg-gray-500'
-              }"></div>
-              <div>
-                <p class="font-medium">{node.address || node.id}</p>
-                <p class="text-xs text-muted-foreground">{node.address ? 'Proxy Node' : 'DHT Peer'}</p>
-              </div>
-            </div>
-              <Badge variant={node.status === 'online' ? 'default' :
+           <div class="flex items-center justify-between mb-3">
+                      <div class="flex items-center gap-3 min-w-0">
+                        <div class="w-2 h-2 rounded-full flex-shrink-0 {
+                          node.status === 'online' ? 'bg-green-500' : 
+                          node.status === 'offline' ? 'bg-red-500' : 
+                          node.status === 'connecting' ? 'bg-yellow-500' :
+                          'bg-gray-500'
+                        }"></div>
+                        <div class="min-w-0">
+                          <p class="font-medium break-words" title={node.address || node.id}>{node.address || node.id}</p>
+                          <p class="text-xs text-muted-foreground">{node.address ? 'Proxy Node' : 'DHT Peer'}</p>
+                        </div>
+                      </div>              <Badge variant={node.status === 'online' ? 'default' :
                    node.status === 'offline' ? 'secondary' :
                    node.status === 'connecting' ? 'outline' : 'outline'}
                       class={
@@ -303,7 +302,7 @@
             <Button
               size="sm"
               variant="outline"
-              on:click={() => toggleNode(node.id)}
+              on:click={() => toggleNode(node)}
             >
               <Power class="h-3 w-3 mr-1" />
               {node.status === 'online' ? $t('proxy.disconnect') : $t('proxy.connect')}
@@ -311,6 +310,7 @@
             <Button
               size="sm"
               variant="destructive"
+              disabled={!node.address}
               on:click={() => requestRemoveNode(node)}
             >
               <Trash2 class="h-3 w-3 mr-1" />

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
   },
   build: {
     rollupOptions: {
-      external: ["@tauri-apps/api/tauri"],
+      external: ["@tauri-apps/api/tauri", "@tauri-apps/plugin-fs"],
     },
   },
 });


### PR DESCRIPTION
[Resolve race condition]
The first echo sent from a peer after connecting would not appear. Subsequent echos, or echos from the remote peer, worked correctly.

This was caused by a race condition where an echo could be sent before the initProxyEvents() function had finished setting up the necessary event listeners to capture and display outgoing messages.

By adding 'await' to the initProxyEvents() call, we ensure that the event handling system is fully initialized before any user actions, like sending an echo, can proceed. This guarantees that all sent messages are captured.

[Enable proxy node removal]
The remove button for proxy nodes is now functional. Previously, clicking the button had no effect, and the node was not removed from the configuration. This issue has been resolved, and the button now correctly deletes the selected proxy node as intended.

[Fix UI error] 
The proxy node label was overflowing the removal confirmation layer. Truncated the label to prevents the overflow.

<img width="1279" height="798" alt="스크린샷 2025-10-03 오후 3 32 49" src="https://github.com/user-attachments/assets/39e164d2-7b31-461f-ab54-b8115766d862" />
