### PR TITLE
feat(relay): integrate libp2p circuit reservations into DHT transport

### DIFF
--- a/src-tauri/src/commands/proxy.rs
+++ b/src-tauri/src/commands/proxy.rs
@@ -3,10 +3,10 @@ use crate::AppState;
 use tauri::Emitter;
 use tauri::State;
 // use tracing::info;
-use tracing::{info, warn};
 use libp2p::PeerId;
 use std::str::FromStr;
 use std::sync::Arc;
+use tracing::{info, warn};
 
 #[derive(Clone, serde::Serialize)]
 pub struct ProxyNode {
@@ -100,7 +100,7 @@ pub(crate) async fn proxy_disconnect(
     // }
     // // Note: This doesn't actually disconnect the peer in libp2p in this version.
     // Ok(())
-    
+
     // Update local cache optimistically and capture the peer ID if known
     let maybe_peer_id = {
         let mut proxies = state.proxies.lock().await;
@@ -129,7 +129,6 @@ pub(crate) async fn proxy_disconnect(
     })?;
 
     dht.disconnect_peer(peer_id).await
-
 }
 
 #[tauri::command]

--- a/src-tauri/src/dht.rs
+++ b/src-tauri/src/dht.rs
@@ -10,6 +10,7 @@ use futures::{AsyncReadExt as _, AsyncWriteExt as _};
 use futures_util::StreamExt;
 use libp2p::multiaddr::Protocol;
 use multihash_codetable::{Code, MultihashDigest};
+use relay::client::Event as RelayClientEvent;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::net::{IpAddr, SocketAddr};
@@ -45,7 +46,10 @@ use libp2p::{
     core::{
         muxing::StreamMuxerBox,
         // FIXED E0432: ListenerEvent is removed, only import what is available.
-        transport::{Boxed, DialOpts, ListenerId, Transport, TransportError, TransportEvent},
+        transport::{
+            choice::OrTransport, Boxed, DialOpts, ListenerId, Transport, TransportError,
+            TransportEvent,
+        },
     },
     identify::{self, Event as IdentifyEvent},
     identity,
@@ -56,7 +60,7 @@ use libp2p::{
     mdns::{tokio::Behaviour as Mdns, Event as MdnsEvent},
     noise,
     ping::{self, Behaviour as Ping, Event as PingEvent},
-    request_response as rr,
+    relay, request_response as rr,
     swarm::{behaviour::toggle, NetworkBehaviour, SwarmEvent},
     tcp, Multiaddr, PeerId, StreamProtocol, Swarm, SwarmBuilder,
 };
@@ -147,6 +151,7 @@ struct DhtBehaviour {
     webrtc_signaling_rr: rr::Behaviour<WebRTCSignalingCodec>,
     autonat_client: toggle::Toggle<v2::client::Behaviour>,
     autonat_server: toggle::Toggle<v2::server::Behaviour>,
+    relay_client: relay::client::Behaviour,
 }
 #[derive(Debug)]
 pub enum DhtCommand {
@@ -228,7 +233,9 @@ pub enum DhtEvent {
 struct ProxyManager {
     targets: std::collections::HashSet<PeerId>,
     capable: std::collections::HashSet<PeerId>,
-    online:  std::collections::HashSet<PeerId>,
+    online: std::collections::HashSet<PeerId>,
+    relay_pending: std::collections::HashSet<PeerId>,
+    relay_ready: std::collections::HashSet<PeerId>,
 }
 
 impl ProxyManager {
@@ -251,9 +258,24 @@ impl ProxyManager {
         self.targets.remove(id);
         self.capable.remove(id);
         self.online.remove(id);
+        self.relay_pending.remove(id);
+        self.relay_ready.remove(id);
     }
     fn is_proxy(&self, id: &PeerId) -> bool {
         self.targets.contains(id) || self.capable.contains(id)
+    }
+    fn mark_relay_pending(&mut self, id: PeerId) -> bool {
+        if self.relay_ready.contains(&id) {
+            return false;
+        }
+        self.relay_pending.insert(id)
+    }
+    fn mark_relay_ready(&mut self, id: PeerId) -> bool {
+        self.relay_pending.remove(&id);
+        self.relay_ready.insert(id)
+    }
+    fn has_relay_request(&self, id: &PeerId) -> bool {
+        self.relay_pending.contains(id) || self.relay_ready.contains(id)
     }
 }
 
@@ -266,7 +288,6 @@ struct PendingEcho {
 type ProxyMgr = Arc<Mutex<ProxyManager>>;
 
 // ----------------------------------------------------------
-
 
 #[derive(Debug, Clone)]
 enum SearchResponse {
@@ -558,6 +579,100 @@ fn addr_to_socket_addr(addr: &libp2p::Multiaddr) -> Option<SocketAddr> {
             Some(SocketAddr::new(ip.into(), port))
         }
         _ => None,
+    }
+}
+
+fn build_relay_listen_addr(base: &Multiaddr) -> Option<Multiaddr> {
+    let mut addr = base.clone();
+    match addr.pop() {
+        Some(libp2p::multiaddr::Protocol::P2p(_)) => {
+            addr.push(libp2p::multiaddr::Protocol::P2pCircuit);
+            Some(addr)
+        }
+        _ => None,
+    }
+}
+
+fn extract_relay_peer(address: &Multiaddr) -> Option<PeerId> {
+    use libp2p::multiaddr::Protocol;
+
+    let mut last_p2p: Option<PeerId> = None;
+    for protocol in address.iter() {
+        match protocol {
+            Protocol::P2p(peer_id) => {
+                last_p2p = Some(peer_id.clone());
+            }
+            Protocol::P2pCircuit => {
+                return last_p2p.clone();
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+enum RelayTransportOutput {
+    Relay(relay::client::Connection),
+    Direct(Box<dyn AsyncIo>),
+}
+
+impl FAsyncRead for RelayTransportOutput {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<Result<usize, std::io::Error>> {
+        // SAFETY: We never move the inner value after pinning, so projecting via
+        // `get_unchecked_mut` and re-pinning each variant is sound.
+        unsafe {
+            match self.get_unchecked_mut() {
+                RelayTransportOutput::Relay(conn) => Pin::new_unchecked(conn).poll_read(cx, buf),
+                RelayTransportOutput::Direct(stream) => {
+                    Pin::new_unchecked(stream.as_mut()).poll_read(cx, buf)
+                }
+            }
+        }
+    }
+}
+
+impl FAsyncWrite for RelayTransportOutput {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, std::io::Error>> {
+        unsafe {
+            match self.get_unchecked_mut() {
+                RelayTransportOutput::Relay(conn) => Pin::new_unchecked(conn).poll_write(cx, buf),
+                RelayTransportOutput::Direct(stream) => {
+                    Pin::new_unchecked(stream.as_mut()).poll_write(cx, buf)
+                }
+            }
+        }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), std::io::Error>> {
+        // SAFETY: See comment in `poll_read`; variants remain pinned in place.
+        unsafe {
+            match self.get_unchecked_mut() {
+                RelayTransportOutput::Relay(conn) => Pin::new_unchecked(conn).poll_flush(cx),
+                RelayTransportOutput::Direct(stream) => {
+                    Pin::new_unchecked(stream.as_mut()).poll_flush(cx)
+                }
+            }
+        }
+    }
+
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), std::io::Error>> {
+        // SAFETY: See comment in `poll_read`; variants remain pinned in place.
+        unsafe {
+            match self.get_unchecked_mut() {
+                RelayTransportOutput::Relay(conn) => Pin::new_unchecked(conn).poll_close(cx),
+                RelayTransportOutput::Direct(stream) => {
+                    Pin::new_unchecked(stream.as_mut()).poll_close(cx)
+                }
+            }
+        }
     }
 }
 
@@ -856,31 +971,93 @@ async fn run_dht_node(
                     Some(DhtCommand::ConnectPeer(addr)) => {
                         info!("Attempting to connect to: {}", addr);
                         if let Ok(multiaddr) = addr.parse::<Multiaddr>() {
-                            if let Some(p2p) = multiaddr.iter().find_map(|p| {
-                                if let libp2p::multiaddr::Protocol::P2p(peer) = p { Some(peer) } else { None }
-                            }) {
-                                proxy_mgr.lock().await.set_target(PeerId::from(p2p));
+                            let maybe_peer_id = multiaddr.iter().find_map(|p| {
+                                if let libp2p::multiaddr::Protocol::P2p(peer_id) = p {
+                                    Some(peer_id.clone())
+                                } else {
+                                    None
+                                }
+                            });
+
+                            if let Some(peer_id) = maybe_peer_id.clone() {
+                                let mut mgr = proxy_mgr.lock().await;
+                                mgr.set_target(peer_id);
+                                let should_request = !mgr.has_relay_request(&peer_id);
+                                if should_request {
+                                    mgr.mark_relay_pending(peer_id);
+                                }
+                                drop(mgr);
+
+                                if should_request {
+                                    if let Some(relay_addr) = build_relay_listen_addr(&multiaddr) {
+                                        match swarm.listen_on(relay_addr.clone()) {
+                                            Ok(_) => {
+                                                info!(
+                                                    "Requested relay reservation via {}",
+                                                    relay_addr
+                                                );
+                                                let _ = event_tx
+                                                    .send(DhtEvent::ProxyStatus {
+                                                        id: peer_id.to_string(),
+                                                        address: relay_addr.to_string(),
+                                                        status: "relay_pending".into(),
+                                                        latency_ms: None,
+                                                        error: None,
+                                                    })
+                                                    .await;
+                                            }
+                                            Err(err) => {
+                                                warn!(
+                                                    "Failed to request relay reservation via {}: {}",
+                                                    relay_addr, err
+                                                );
+                                                let mut mgr = proxy_mgr.lock().await;
+                                                mgr.relay_pending.remove(&peer_id);
+                                                let _ = event_tx
+                                                    .send(DhtEvent::ProxyStatus {
+                                                        id: peer_id.to_string(),
+                                                        address: relay_addr.to_string(),
+                                                        status: "relay_error".into(),
+                                                        latency_ms: None,
+                                                        error: Some(err.to_string()),
+                                                    })
+                                                    .await;
+                                            }
+                                        }
+                                    } else {
+                                        warn!(
+                                            "Cannot derive relay listen address from {}",
+                                            multiaddr
+                                        );
+                                    }
+                                }
                             }
+
                             match swarm.dial(multiaddr.clone()) {
                                 Ok(_) => {
-                                    info!("✓ Initiated connection to: {}", addr);
+                                    info!("Requested connection to: {}", addr);
                                     info!("  Multiaddr: {}", multiaddr);
                                     info!("  Waiting for ConnectionEstablished event...");
                                 }
                                 Err(e) => {
-                                    error!("✗ Failed to dial {}: {}", addr, e);
-                                    let _ = event_tx.send(DhtEvent::Error(format!("Failed to connect: {}", e))).await;
+                                    error!("Failed to dial {}: {}", addr, e);
+                                    let _ = event_tx
+                                        .send(DhtEvent::Error(format!("Failed to connect: {}", e)))
+                                        .await;
                                 }
                             }
                         } else {
-                            error!("✗ Invalid multiaddr format: {}", addr);
-                            let _ = event_tx.send(DhtEvent::Error(format!("Invalid address: {}", addr))).await;
+                            error!("Invalid multiaddr format: {}", addr);
+                            let _ = event_tx
+                                .send(DhtEvent::Error(format!("Invalid address: {}", addr)))
+                                .await;
                         }
                     }
                     Some(DhtCommand::DisconnectPeer(peer_id)) => {
                         let _ = swarm.disconnect_peer_id(peer_id.clone());
                         proxy_mgr.lock().await.remove_all(&peer_id);
                     }
+
 
                     Some(DhtCommand::GetPeerCount(tx)) => {
                         let count = connected_peers.lock().await.len();
@@ -945,6 +1122,49 @@ async fn run_dht_node(
                     SwarmEvent::Behaviour(DhtBehaviourEvent::Mdns(mdns_event)) => {
                         if !is_bootstrap{
                             handle_mdns_event(mdns_event, &mut swarm, &event_tx).await;
+                        }
+                    }
+                    SwarmEvent::Behaviour(DhtBehaviourEvent::RelayClient(relay_event)) => {
+                        match relay_event {
+                            RelayClientEvent::ReservationReqAccepted { relay_peer_id, .. } => {
+                                let mut mgr = proxy_mgr.lock().await;
+                                let newly_ready = mgr.mark_relay_ready(relay_peer_id);
+                                drop(mgr);
+                                if newly_ready {
+                                    let _ = event_tx
+                                        .send(DhtEvent::ProxyStatus {
+                                            id: relay_peer_id.to_string(),
+                                            address: String::new(),
+                                            status: "relay_ready".into(),
+                                            latency_ms: None,
+                                            error: None,
+                                        })
+                                        .await;
+                                }
+                            }
+                            RelayClientEvent::OutboundCircuitEstablished { relay_peer_id, .. } => {
+                                proxy_mgr.lock().await.set_online(relay_peer_id);
+                                let _ = event_tx
+                                    .send(DhtEvent::ProxyStatus {
+                                        id: relay_peer_id.to_string(),
+                                        address: String::new(),
+                                        status: "relay_circuit".into(),
+                                        latency_ms: None,
+                                        error: None,
+                                    })
+                                    .await;
+                            }
+                            RelayClientEvent::InboundCircuitEstablished { src_peer_id, .. } => {
+                                let _ = event_tx
+                                    .send(DhtEvent::ProxyStatus {
+                                        id: src_peer_id.to_string(),
+                                        address: String::new(),
+                                        status: "relay_inbound".into(),
+                                        latency_ms: None,
+                                        error: None,
+                                    })
+                                    .await;
+                            }
                         }
                     }
                     SwarmEvent::Behaviour(DhtBehaviourEvent::Bitswap(bitswap)) => match bitswap {
@@ -1057,10 +1277,12 @@ async fn run_dht_node(
                         debug!(?ev, "AutoNAT server event");
                     }
                     SwarmEvent::ExternalAddrConfirmed { address, .. } => {
-                        handle_external_addr_confirmed(&address, &metrics, &event_tx).await;
+                        handle_external_addr_confirmed(&address, &metrics, &event_tx, &proxy_mgr)
+                            .await;
                     }
                     SwarmEvent::ExternalAddrExpired { address, .. } => {
-                        handle_external_addr_expired(&address, &metrics, &event_tx).await;
+                        handle_external_addr_expired(&address, &metrics, &event_tx, &proxy_mgr)
+                            .await;
                     }
                     SwarmEvent::ConnectionEstablished { peer_id, endpoint, .. } => {
                         info!("✅ CONNECTION ESTABLISHED with peer: {}", peer_id);
@@ -1098,6 +1320,7 @@ async fn run_dht_node(
                             peers.remove(&peer_id);
                             peers.len()
                         };
+                        proxy_mgr.lock().await.remove_all(&peer_id);
                         info!("   Remaining connected peers: {}", peers_count);
                     }
                     SwarmEvent::NewListenAddr { address, .. } => {
@@ -1542,6 +1765,7 @@ async fn handle_external_addr_confirmed(
     addr: &Multiaddr,
     metrics: &Arc<Mutex<DhtMetrics>>,
     event_tx: &mpsc::Sender<DhtEvent>,
+    proxy_mgr: &ProxyMgr,
 ) {
     let mut metrics_guard = metrics.lock().await;
     let nat_enabled = metrics_guard.autonat_enabled;
@@ -1557,24 +1781,43 @@ async fn handle_external_addr_confirmed(
     let last_error = metrics_guard.last_reachability_error.clone();
     drop(metrics_guard);
 
-    if !nat_enabled {
-        return;
+    if nat_enabled {
+        let _ = event_tx
+            .send(DhtEvent::NatStatus {
+                state,
+                confidence,
+                last_error,
+                summary: summary.clone(),
+            })
+            .await;
     }
 
-    let _ = event_tx
-        .send(DhtEvent::NatStatus {
-            state,
-            confidence,
-            last_error,
-            summary,
-        })
-        .await;
+    if let Some(relay_peer_id) = extract_relay_peer(addr) {
+        let mut mgr = proxy_mgr.lock().await;
+        let newly_ready = mgr.mark_relay_ready(relay_peer_id.clone());
+        drop(mgr);
+        let status = if newly_ready {
+            "relay_ready"
+        } else {
+            "relay_address"
+        };
+        let _ = event_tx
+            .send(DhtEvent::ProxyStatus {
+                id: relay_peer_id.to_string(),
+                address: addr.to_string(),
+                status: status.into(),
+                latency_ms: None,
+                error: None,
+            })
+            .await;
+    }
 }
 
 async fn handle_external_addr_expired(
     addr: &Multiaddr,
     metrics: &Arc<Mutex<DhtMetrics>>,
     event_tx: &mpsc::Sender<DhtEvent>,
+    proxy_mgr: &ProxyMgr,
 ) {
     let summary_text = format!("External address expired: {}", addr);
     let mut metrics_guard = metrics.lock().await;
@@ -1591,16 +1834,30 @@ async fn handle_external_addr_expired(
         let last_error = metrics_guard.last_reachability_error.clone();
         drop(metrics_guard);
 
-        if !nat_enabled {
-            return;
+        if nat_enabled {
+            let _ = event_tx
+                .send(DhtEvent::NatStatus {
+                    state,
+                    confidence,
+                    last_error,
+                    summary: summary.clone(),
+                })
+                .await;
         }
+    }
 
+    if let Some(relay_peer_id) = extract_relay_peer(addr) {
+        let mut mgr = proxy_mgr.lock().await;
+        mgr.relay_ready.remove(&relay_peer_id);
+        mgr.relay_pending.remove(&relay_peer_id);
+        drop(mgr);
         let _ = event_tx
-            .send(DhtEvent::NatStatus {
-                state,
-                confidence,
-                last_error,
-                summary,
+            .send(DhtEvent::ProxyStatus {
+                id: relay_peer_id.to_string(),
+                address: addr.to_string(),
+                status: "relay_expired".into(),
+                latency_ms: None,
+                error: None,
             })
             .await;
     }
@@ -1613,46 +1870,58 @@ impl Socks5Transport {
 }
 
 /// Build a libp2p transport, optionally tunneling through a SOCKS5 proxy.
-pub fn build_custom_transport(
-    keypair: identity::Keypair,
+pub fn build_transport_with_relay(
+    keypair: &identity::Keypair,
+    relay_transport: relay::client::Transport,
     proxy_address: Option<String>,
 ) -> Result<Boxed<(PeerId, StreamMuxerBox)>, Box<dyn Error>> {
-    let noise_keys = noise::Config::new(&keypair)?;
+    let noise_keys = noise::Config::new(keypair)?;
     let yamux_config = libp2p::yamux::Config::default();
 
-    // CORRECTED: The full transport stack is now built inside each branch
-    // to ensure the final types are identical.
-    if let Some(proxy) = proxy_address {
-        info!(
-            "SOCKS5 enabled. Routing all P2P dialing traffic via {}",
-            proxy
-        );
-        let proxy_addr = proxy.parse::<SocketAddr>().map_err(|e| {
-            io::Error::new(
-                io::ErrorKind::InvalidInput,
-                format!("Invalid proxy address: {}", e),
-            )
-        })?;
-        let socks5_transport = Socks5Transport::new(proxy_addr);
+    let transport = match (proxy_address, relay_transport) {
+        (Some(proxy), relay_transport) => {
+            info!(
+                "SOCKS5 enabled. Routing all P2P dialing traffic via {}",
+                proxy
+            );
+            let proxy_addr = proxy.parse::<SocketAddr>().map_err(|e| {
+                io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!("Invalid proxy address: {}", e),
+                )
+            })?;
+            let socks5_transport = Socks5Transport::new(proxy_addr);
 
-        Ok(socks5_transport
-            .upgrade(Version::V1)
-            .authenticate(noise_keys)
-            .multiplex(yamux_config)
-            .timeout(Duration::from_secs(30))
-            .boxed())
-    } else {
-        info!("Direct P2P connection mode.");
-        let direct_tcp = tcp::tokio::Transport::new(tcp::Config::default())
-            .map(|s, _| Box::new(s.0.compat()) as Box<dyn AsyncIo>);
+            OrTransport::new(relay_transport, socks5_transport)
+                .map(|either, _| match either {
+                    futures::future::Either::Left(conn) => RelayTransportOutput::Relay(conn),
+                    futures::future::Either::Right(stream) => RelayTransportOutput::Direct(stream),
+                })
+                .upgrade(Version::V1)
+                .authenticate(noise_keys)
+                .multiplex(yamux_config)
+                .timeout(Duration::from_secs(30))
+                .boxed()
+        }
+        (None, relay_transport) => {
+            info!("Direct P2P connection mode.");
+            let direct_tcp = tcp::tokio::Transport::new(tcp::Config::default())
+                .map(|s, _| Box::new(s.0.compat()) as Box<dyn AsyncIo>);
 
-        Ok(direct_tcp
-            .upgrade(Version::V1)
-            .authenticate(noise_keys)
-            .multiplex(yamux_config)
-            .timeout(Duration::from_secs(30))
-            .boxed())
-    }
+            OrTransport::new(relay_transport, direct_tcp)
+                .map(|either, _| match either {
+                    futures::future::Either::Left(conn) => RelayTransportOutput::Relay(conn),
+                    futures::future::Either::Right(stream) => RelayTransportOutput::Direct(stream),
+                })
+                .upgrade(Version::V1)
+                .authenticate(noise_keys)
+                .multiplex(yamux_config)
+                .timeout(Duration::from_secs(30))
+                .boxed()
+        }
+    };
+
+    Ok(transport)
 }
 
 impl DhtService {
@@ -1807,7 +2076,10 @@ impl DhtService {
 
         let blockstore = Arc::new(InMemoryBlockstore::new());
         let bitswap = beetswap::Behaviour::new(blockstore);
-        let behaviour = DhtBehaviour {
+        let (relay_transport, relay_client_behaviour) = relay::client::new(local_peer_id);
+        let autonat_client_toggle = toggle::Toggle::from(autonat_client_behaviour);
+        let autonat_server_toggle = toggle::Toggle::from(autonat_server_behaviour);
+        let mut behaviour = Some(DhtBehaviour {
             kademlia,
             identify,
             mdns,
@@ -1815,9 +2087,10 @@ impl DhtService {
             ping: Ping::new(ping::Config::new()),
             proxy_rr,
             webrtc_signaling_rr,
-            autonat_client: toggle::Toggle::from(autonat_client_behaviour),
-            autonat_server: toggle::Toggle::from(autonat_server_behaviour),
-        };
+            autonat_client: autonat_client_toggle,
+            autonat_server: autonat_server_toggle,
+            relay_client: relay_client_behaviour,
+        });
 
         let bootstrap_set: HashSet<String> = bootstrap_nodes.iter().cloned().collect();
         let mut autonat_targets: HashSet<String> = if enable_autonat && !autonat_servers.is_empty()
@@ -1830,15 +2103,15 @@ impl DhtService {
             autonat_targets.extend(bootstrap_set.iter().cloned());
         }
 
-        // Use the new SOCKS5-aware transport builder
-        let transport = build_custom_transport(local_key.clone(), proxy_address)?;
+        // Use the new relay-aware transport builder
+        let transport = build_transport_with_relay(&local_key, relay_transport, proxy_address)?;
 
         // Create the swarm
         let mut swarm = SwarmBuilder::with_existing_identity(local_key)
             .with_tokio()
             .with_other_transport(|_| Ok(transport))
             .expect("Failed to create libp2p transport")
-            .with_behaviour(|_| behaviour)?
+            .with_behaviour(move |_| behaviour.take().expect("behaviour already taken"))?
             .with_swarm_config(
                 |c| c.with_idle_connection_timeout(Duration::from_secs(300)), // 5 minutes
             )
@@ -2070,7 +2343,7 @@ impl DhtService {
             version: Some(version),
             parent_hash,
             cids: None,
-            is_root: true, 
+            is_root: true,
         })
     }
 
@@ -2647,7 +2920,9 @@ async fn assemble_file_from_chunks(
 }
 
 fn not_loopback(ip: &Multiaddr) -> bool {
-    multiaddr_to_ip(ip).map(|ip| !ip.is_loopback()).unwrap_or(false)
+    multiaddr_to_ip(ip)
+        .map(|ip| !ip.is_loopback())
+        .unwrap_or(false)
 }
 
 fn multiaddr_to_ip(addr: &Multiaddr) -> Option<IpAddr> {


### PR DESCRIPTION
- Plugged the libp2p relay client into the transport stack so relay plus TCP/SOCKS dialing works transparently
- ProxyManager now tracks relay reservation state, and the DHT loop emits ProxyStatus updates as reservations progress or fail
- AutoNAT and relay events keep the proxy state in sync, while the proxy command keeps its tracing imports intact