### PR TITLE
fix(download): Prevent automatic timeout error on initial load of the Download page

### DIFF
--- a/src/lib/components/download/DownloadSearchSection.svelte
+++ b/src/lib/components/download/DownloadSearchSection.svelte
@@ -36,12 +36,44 @@
 
   const unsubscribe = dhtSearchHistory.subscribe((entries) => {
     historyEntries = entries;
-    if (!activeHistoryId && entries.length > 0) {
-      activeHistoryId = entries[0].id;
-      latestStatus = entries[0].status;
-      latestMetadata = entries[0].metadata ?? null;
-      searchError = entries[0].errorMessage ?? null;
-      hasSearched = entries.length > 0;
+    // if (!activeHistoryId && entries.length > 0) {
+    //   activeHistoryId = entries[0].id;
+    //   latestStatus = entries[0].status;
+    //   latestMetadata = entries[0].metadata ?? null;
+    //   searchError = entries[0].errorMessage ?? null;
+    //   hasSearched = entries.length > 0;
+    // }
+    if (entries.length > 0) {
+      // 1. Always set the active ID from the most recent entry for the history dropdown.
+      activeHistoryId = entries[0].id; 
+
+      // 2. Control the main UI state based on whether a search has been initiated in this session.
+      if (!hasSearched) {
+        // If it's a fresh load (hasSearched is false):
+        // Keep the input clear, and the result panel empty.
+        searchHash = ''; 
+        latestStatus = 'pending'; 
+        latestMetadata = null;
+        searchError = null;
+      } else {
+        // If the user has searched in this session, ensure the current search results are displayed.
+        const entry = entries.find(e => e.id === activeHistoryId) || entries[0];
+        if (entry) {
+          latestStatus = entry.status;
+          latestMetadata = entry.metadata ?? null;
+          searchError = entry.errorMessage ?? null;
+          searchHash = entry.hash;
+        }
+      }
+    } else {
+      activeHistoryId = null;
+      // On empty history, ensure the main state is also reset.
+      if (!hasSearched) {
+        searchHash = '';
+        latestStatus = 'pending';
+        latestMetadata = null;
+        searchError = null;
+      }
     }
   });
 


### PR DESCRIPTION
Before:
The Download page would load and immediately perform a file search even without user input. This led to a timeout message despite the user not searching for any downloaded files.
<img width="1488" height="665" alt="Screenshot 2025-10-03 200538" src="https://github.com/user-attachments/assets/2ab8ddbf-b6a1-4d55-9a00-1a73ab54013b" />
<img width="1491" height="677" alt="Screenshot 2025-10-03 190756" src="https://github.com/user-attachments/assets/27a2aa93-e5e4-48c0-b5e6-28e91cc31764" />

After:
The Download page loads without any unexpected searches not performed by the user.
<img width="1461" height="1153" alt="Screenshot 2025-10-03 203130" src="https://github.com/user-attachments/assets/0361629b-a71d-4d05-ad61-66b50cfba24e" />

- Decouples the main search state from persistent search history (dhtSearchHistory) during component initialization.
- This prevents the component from automatically loading the hash and 'error' status of the last failed search on mount, which unintentionally triggered a new, immediate, and failed search.
- The component now loads into a clean, 'pending' state, waiting for user input.