### PR TITLE
docs-08: Removed Professional & Community Support, Fixed documentation links to point back to GitHub! 

### DIFF
--- a/docs/08-deployment-guide.md
+++ b/docs/08-deployment-guide.md
@@ -801,18 +801,14 @@ chiral-node --fork-block 12345 --override
 
 ### Documentation
 
-- Deployment Docs: https://docs.chiral.network/deployment
-- API Reference: https://docs.chiral.network/api
-- Troubleshooting: https://docs.chiral.network/troubleshooting
+- Deployment Docs: https://github.com/chiral-network/chiral-network/blob/main/docs/08-deployment-guide.md
+- API Reference:   https://github.com/chiral-network/chiral-network/blob/main/docs/05-api-documentation.md
+- Troubleshooting: N/A
 
 ### Community Support
 
-- Discord: https://discord.gg/chiralnetwork
-- Forum: https://forum.chiral.network
-- Email: support@chiral.network
+TBD
 
 ### Professional Support
 
-- Enterprise Support: enterprise@chiral.network
-- SLA Options: 24/7, 4-hour response
-- Training: Available on request
+TBD


### PR DESCRIPTION
Doc Currently Gives Impression of Community and Professional Support, so replaced those sections with TBD until the project is completely finished since at the current moment this doesn't really exist. Additionally, updated the documentation links to properly point back to our repo.  

Was originally going to change the deployment guide by removing the notion of storage nodes but refrained from doing so until further confirmation. With the current understanding the client is it's own storage node so mentioning it may give the wrong idea. There are other misc. things in this doc that may need to be removed in the future (I have no idea if we will have a chiral-CLI) but that can wait.