### PR TITLE
Doc 2: Update Storage Node Structure, Add Pricing Model and Payment Structure to DHT 

### DIFF
--- a/docs/02-architecture.md
+++ b/docs/02-architecture.md
@@ -109,6 +109,7 @@ File Metadata Structure:
   created_at: 1640995200,
   mime_type: "application/pdf",
   total_chunks: 16
+  price_per_mb: 0.001           // Chiral per MB (initially fixed, configurable)
 }
 ```
 
@@ -129,9 +130,9 @@ providers = dht.get_providers(file_hash);
 connect(providers[0]);  // Connect to seeders directly
 ```
 
-#### Decentralized Incentives
+#### Peer-to-Peer Compensation
 
-Rewards distributed via blockchain without centralized markets:
+When a user downloads a file, they pay the seeders who provide the chunks. Rewards are distributed via blockchain:
 
 ```rust
 // Proof-of-Storage validation
@@ -141,6 +142,16 @@ struct StorageProof {
     merkle_proof: MerkleProof,
     timestamp: u64,
 }
+
+// Payment transaction for chunk delivery
+struct ChunkPayment {
+    from: Address,           // Downloader
+    to: Address,             // Seeder
+    file_hash: Hash,
+    chunks_delivered: Vec<u32>,
+    amount: u64,             // Chiral amount
+}
+
 ```
 
 ### 4. Network Communication


### PR DESCRIPTION
Removed rewardRate field from Storage Node structure and added seeding array to track files being shared by the node.

- Removed rewardRate Field: Base on what the professor said, we should start with fixed pricing that providers can adjust, not node-specific reward algorithms
- Added seeding Array: Explicitly tracks which files a node is currently sharing/seeding

Updated Peer Discovery Mechanism documentation to include pricing in file metadata and added payment transaction structure for direct peer-to-peer payments (no marketplace), based on Q&A clarifications with Professor Shuai. 

- Professor Shuai's said that we can start off with a fixed but changeable price. This stores pricing information directly in DHT metadata so clients can see costs before downloading. 

- Added ChunkPayment Structure: Shows how payments tie into the blockchain transaction system