### PR TITLE
doc-03: Rephrased and Clarified Storage Nodes Sections

### DIFF
--- a/docs/03-technical-specifications.md
+++ b/docs/03-technical-specifications.md
@@ -51,7 +51,7 @@
 | **Network** | 100 Mbps symmetric    |
 | **OS**      | Latest stable version |
 
-#### Storage Node Requirements
+#### Recommended Requirements for Providers Who Want to Serve Files
 
 | Component   | Specification      |
 | ----------- | ------------------ |
@@ -273,8 +273,6 @@ Master Key (from mnemonic)
 | Type                | Description          | Base Gas Cost |
 | ------------------- | -------------------- | ------------- |
 | **Transfer**        | Send coins           | 21,000 gas    |
-| **Storage Request** | Request file storage | 100,000 gas   |
-| **Storage Proof**   | Prove file storage   | 50,000 gas    |
 | **File Access**     | Access stored file   | 30,000 gas    |
 
 ### Transaction Structure


### PR DESCRIPTION
Rephrase the Storage Nodes section in Node Requirements: As per the professor, there is no conceptual difference between storage nodes and normal nodes. A storage node would be a server machine that keeps running our software, allocates disk space for storing file chunks, registers availability in the DHT.

Removed Transaction types - Storage Request and Storage Proofs: Chiral Network currently operates without a storage marketplace. All nodes store their own file chunks locally, and there are no on-chain transactions for requesting or proving storage.