### PR TITLE
Chiral network/doc02 fix upload data flow diagram

### DIFF
--- a/docs/02-architecture.md
+++ b/docs/02-architecture.md
@@ -283,7 +283,7 @@ sequenceDiagram
     participant Client
     participant FileService
     participant DHT
-    participant StorageNode
+    participant ProviderNode
     participant Blockchain
 
     Client->>+FileService: Request File (Merkle Root)
@@ -292,9 +292,8 @@ sequenceDiagram
     FileService->>+StorageNode: Request encrypted chunks
     StorageNode-->>-FileService: Send available encrypted chunks
     FileService->>FileService: Decrypt individual chunks
-    FileService->>FileService: Decrypt and reassemble original file from chunks
     FileService->>FileService: Verify chunk hash against original hash in manifest
-    FileService->>FileService: Assemble file from verified chunks
+    FileService->>FileService: Assemble original file from verified chunks
     FileService->>+Blockchain: Send Payment
     Blockchain-->>-FileService: Payment Confirmed
     FileService-->>-Client: File Ready

--- a/docs/02-architecture.md
+++ b/docs/02-architecture.md
@@ -289,8 +289,8 @@ sequenceDiagram
     Client->>+FileService: Request File (Merkle Root)
     FileService->>+DHT: Lookup File Manifest
     DHT-->>-FileService: Return Manifest (includes chunk hashes)
-    FileService->>+StorageNode: Request encrypted chunks
-    StorageNode-->>-FileService: Send available encrypted chunks
+    FileService->>+ProviderNode: Request encrypted chunks
+    ProviderNode-->>-FileService: Send available encrypted chunks
     FileService->>FileService: Decrypt individual chunks
     FileService->>FileService: Verify chunk hash against original hash in manifest
     FileService->>FileService: Assemble original file from verified chunks

--- a/docs/02-architecture.md
+++ b/docs/02-architecture.md
@@ -266,21 +266,13 @@ Permission Model:
 sequenceDiagram
     participant Client
     participant FileService
-    participant StorageNode
     participant DHT
-    participant Blockchain
 
     Client->>+FileService: Upload File
+    FileService->>FileService: Chunk and/or Encrypt chunk file into 256 KB pieces
     FileService->>FileService: Generate Merkle Root from original chunk hashes
-    FileService->>FileService: Chunk file into 256KB pieces
-    FileService->>FileService: Encrypt and chunk file into 256 KB pieces
-    FileService->>FileService: Encrypt each chunk
-    FileService->>+StorageNode: Upload encrypted chunks
-    StorageNode-->>-FileService: Confirm chunk storage
     FileService->>+DHT: Register File Manifest (Merkle Root, Chunk Hashes)
     DHT-->>-FileService: Confirm Registration
-    FileService->>+Blockchain: Create Payment TX
-    Blockchain-->>-FileService: TX Confirmed
     FileService-->>-Client: Upload Complete
 ```
 


### PR DESCRIPTION
I updated both the upload and download data flow diagrams in document 2 to reflect removals in inconsistent project understanding.

Before (Upload and Download):
<img width="1279" height="957" alt="image" src="https://github.com/user-attachments/assets/2e70944b-1477-4da5-9be2-379a42e4d9ed" />
<img width="1225" height="829" alt="image" src="https://github.com/user-attachments/assets/14915711-9a3a-4f21-b2da-279809737e29" />

After (Upload and Download):
<img width="1159" height="742" alt="image" src="https://github.com/user-attachments/assets/c4536383-3a78-4185-b346-6e53fdf54f06" />
<img width="1300" height="842" alt="image" src="https://github.com/user-attachments/assets/83841bde-da53-42b4-9537-111627430e59" />



