### PR TITLE
feat: Implement WebRTC decryption for encrypted file transfers

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,8 +285,8 @@ npm run tauri build # Desktop production build
 ### Phase 3: Core P2P Features (In Progress)
 
 - ✅ **File Upload Encryption**: AES-256-GCM encryption with PBKDF2 key derivation for uploaded files
-- ❌ **File Download Decryption**: Key management and decryption for downloaded files
-- ❌ **WebRTC Encryption**: Encrypted P2P chunk transfers
+- ✅ **File Download Decryption**: Key management and decryption for downloaded files
+- ✅ **WebRTC Encryption**: Encrypted P2P chunk transfers
 - ❌ **Key Exchange UI**: Recipient public key input for encrypted sharing
 - ✅ Real P2P file transfer protocol
 - ✅ File versioning system
@@ -331,13 +331,13 @@ npm run tauri build # Desktop production build
 - AES-256-GCM file encryption for uploads
 - PBKDF2 key derivation for encryption
 - ECIES key exchange infrastructure
+- File download decryption with key management
+- WebRTC encrypted chunk transfers
 - No centralized servers to compromise
 - Fully decentralized architecture prevents single points of failure
 
 ### Planned Security
 
-- File download decryption with key management
-- WebRTC encrypted chunk transfers
 - Key exchange UI for encrypted sharing
 - File encryption at rest
 - Signed software updates

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -202,6 +202,11 @@ async fn load_account_from_keystore(
         *active_key = Some(private_key.clone());
     }
 
+    // Update WebRTC service with the active private key for decryption
+    if let Some(webrtc_service) = state.webrtc.lock().await.as_ref() {
+        webrtc_service.set_active_private_key(Some(private_key.clone())).await;
+    }
+
     // Derive account details from private key
     get_account_from_private_key(&private_key)
 }
@@ -2298,6 +2303,11 @@ async fn logout(state: State<'_, AppState>) -> Result<(), ()> {
     // Clear private key from memory
     let mut active_key = state.active_account_private_key.lock().await;
     *active_key = None;
+
+    // Clear private key from WebRTC service
+    if let Some(webrtc_service) = state.webrtc.lock().await.as_ref() {
+        webrtc_service.set_active_private_key(None).await;
+    }
 
     Ok(())
 }


### PR DESCRIPTION
- Added decryption functionality for encrypted chunks received via WebRTC P2P connections using the active account's private key
- Extended WebRTC service to track and manage the active private key for decryption operations during login/logout

Note: currently files can only be decrypted by the original uploader. True encrypted sharing requires a UI for selecting recipients and securely exchanging encryption keys with them. This is tracked as a separate feature: "Key Exchange UI" in the README.