### PR TITLE
fix(Account): fix reference error for wallet service is not defined

### DIFF
--- a/src/pages/Account.svelte
+++ b/src/pages/Account.svelte
@@ -6,6 +6,7 @@
   import { Wallet, Copy, ArrowUpRight, ArrowDownLeft, History, Coins, Plus, Import, BadgeX, KeyRound, FileText } from 'lucide-svelte'
   import DropDown from "$lib/components/ui/dropDown.svelte";
   import { wallet, etcAccount, blacklist} from '$lib/stores' 
+  import { walletService } from '$lib/wallet';
   import { transactions } from '$lib/stores';
   import { derived } from 'svelte/store'
   import { invoke } from '@tauri-apps/api/core'


### PR DESCRIPTION
- fix reference error for wallet service is not defined

Before:
<img width="2545" height="1550" alt="Screenshot 2025-10-05 142109" src="https://github.com/user-attachments/assets/f2d175e4-1f56-4f0a-83ff-b4ffba3231d9" />

After:
<img width="2495" height="1475" alt="Screenshot 2025-10-05 142227" src="https://github.com/user-attachments/assets/4a1c59ef-2f9e-442e-963f-775ce217e3a5" />
