### PR TITLE
Fix: Wallet import error, DHT hash mismatch for encrypted files, and drag-drop behavior

### DIFF
--- a/src/pages/Account.svelte
+++ b/src/pages/Account.svelte
@@ -5,8 +5,9 @@
   import Label from '$lib/components/ui/label.svelte'
   import { Wallet, Copy, ArrowUpRight, ArrowDownLeft, History, Coins, Plus, Import, BadgeX, KeyRound, FileText } from 'lucide-svelte'
   import DropDown from "$lib/components/ui/dropDown.svelte";
-  import { wallet, etcAccount, blacklist} from '$lib/stores' 
+  import { wallet, etcAccount, blacklist} from '$lib/stores'
   import { transactions } from '$lib/stores';
+  import { walletService } from '$lib/wallet';
   import { derived } from 'svelte/store'
   import { invoke } from '@tauri-apps/api/core'
   import QRCode from 'qrcode'

--- a/src/pages/Upload.svelte
+++ b/src/pages/Upload.svelte
@@ -299,6 +299,15 @@
       dropZone.addEventListener('dragleave', handleDragLeave)
       dropZone.addEventListener('drop', handleDrop)
 
+      // Prevent default browser behavior for drag and drop on the entire window
+      const preventDefaults = (e: Event) => {
+        e.preventDefault()
+        e.stopPropagation()
+      }
+
+      window.addEventListener('dragover', preventDefaults)
+      window.addEventListener('drop', preventDefaults)
+
       // Add global drag end handlers to ensure dragging state is reset
       document.addEventListener('dragend', handleDragEnd)
       document.addEventListener('drop', handleDragEnd)
@@ -309,6 +318,8 @@
         dropZone.removeEventListener('dragover', handleDragOver)
         dropZone.removeEventListener('dragleave', handleDragLeave)
         dropZone.removeEventListener('drop', handleDrop)
+        window.removeEventListener('dragover', preventDefaults)
+        window.removeEventListener('drop', preventDefaults)
         document.removeEventListener('dragend', handleDragEnd)
         document.removeEventListener('drop', handleDragEnd)
       }


### PR DESCRIPTION
Fixes Included
1. Fix: Missing walletService import in Account.svelte
Issue: Clicking the "Create Account" button triggered a ReferenceError due to a missing walletService reference.
Solution: Added the missing import statement for walletService from $lib/wallet.

2. Hash mismatch for encrypted files in DHT
Issue: Encrypted files (uploaded via file picker) contained empty file_data, leading the backend to generate invalid CIDs from empty block arrays.vThe DHT stored meaningless CIDs while the UI displayed the Merkle root, causing encrypted files to be undiscoverable and non-downloadable.
Solution: Updated dht.rs to detect empty file_data. If detected, the backend now uses the provided Merkle root directly instead of generating a CID. So encrypted files (file picker) are stored in the DHT using their Merkle root while non-encrypted files (drag-drop) continue using block-based CID generation.

3. Fix: Prevent browser from opening dragged files
Issue: Dragging files anywhere in the UI triggered the browser’s default file-open behavior, making the app inaccessible.
Solution: Added global preventDefault handlers for dragover and drop events at the window level. Files can now only be dropped into the intended upload area, ensuring stable and predictable drag-drop behavior.
