### PR TITLE
fix(network): Synchronized port number when re-entering Network page

### DIFF
--- a/src/pages/Network.svelte
+++ b/src/pages/Network.svelte
@@ -415,6 +415,9 @@
         dhtPeerId = backendPeerId
         dhtService.setPeerId(backendPeerId)
 
+        // Sync the port from the service
+        dhtPort = dhtService.getPort()
+
         // Pull health/peers and update UI without attempting a restart
         const health = await dhtService.getHealth()
         if (health) {


### PR DESCRIPTION
[Synchronized port number]

The DHT port number was hardcoded to 4001 on component mount, causing the UI to display the wrong port when reconnecting to an already-running DHT service on a different port. 
Now syncs the actual port from the DhtService when mounting the component.

Problem: 
<img width="1119" height="728" alt="스크린샷 2025-10-05 오후 3 40 09" src="https://github.com/user-attachments/assets/3aef6183-bea5-46d5-acf7-2e9990905014" />
