### PR TITLE
feat(upload): add Key Exchange UI for recipient-specific encrypted sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ npm run tauri build # Desktop production build
 - ✅ **File Upload Encryption**: AES-256-GCM encryption with PBKDF2 key derivation for uploaded files
 - ✅ **File Download Decryption**: Key management and decryption for downloaded files
 - ✅ **WebRTC Encryption**: Encrypted P2P chunk transfers
-- ❌ **Key Exchange UI**: Recipient public key input for encrypted sharing
+- ✅ **Key Exchange UI**: Recipient public key input for encrypted sharing
 - ✅ Real P2P file transfer protocol
 - ✅ File versioning system
 - ✅ Advanced bandwidth scheduling
@@ -333,12 +333,13 @@ npm run tauri build # Desktop production build
 - ECIES key exchange infrastructure
 - File download decryption with key management
 - WebRTC encrypted chunk transfers
+- Key exchange UI for recipient-specific encryption
 - No centralized servers to compromise
 - Fully decentralized architecture prevents single points of failure
 
 ### Planned Security
 
-- Key exchange UI for encrypted sharing
+- ✅ Key exchange UI for encrypted sharing
 - File encryption at rest
 - Signed software updates
 - Two-factor authentication

--- a/src/lib/services/encryption.ts
+++ b/src/lib/services/encryption.ts
@@ -17,10 +17,18 @@ export const encryptionService = {
   /**
    * Invokes the backend to chunk and encrypt a file.
    * @param filePath The absolute path to the file.
+   * @param recipientPublicKey Optional recipient's X25519 public key (hex-encoded). If not provided, encrypts for self.
    * @returns A promise that resolves to the file manifest.
    */
-  async encryptFile(filePath: string): Promise<FileManifestForJs> {
-    return await invoke('encrypt_file_for_self_upload', { filePath });
+  async encryptFile(filePath: string, recipientPublicKey?: string): Promise<FileManifestForJs> {
+    if (recipientPublicKey) {
+      return await invoke('encrypt_file_for_recipient', { 
+        filePath, 
+        recipientPublicKey 
+      });
+    } else {
+      return await invoke('encrypt_file_for_self_upload', { filePath });
+    }
   },
 
   /**

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -791,6 +791,16 @@
       "error": "Unable to check disk space",
       "checking": "Checking...",
       "lowDescription": "Low free space may prevent new uploads."
+    },
+    "encryption": {
+      "title": "Encrypted Sharing",
+      "subtitle": "Share files encrypted for specific recipients",
+      "enableForRecipient": "Enable encrypted sharing for specific recipient",
+      "recipientPublicKey": "Recipient's Public Key",
+      "publicKeyPlaceholder": "Enter recipient's X25519 public key (64 hex characters)",
+      "publicKeyHint": "Enter the recipient's X25519 public key (hex format, 64 characters). The file will be encrypted so only they can decrypt it. Leave empty to encrypt for yourself.",
+      "invalidPublicKey": "⚠️ Invalid public key format. Must be 64 hexadecimal characters.",
+      "encryptedBadge": "Encrypted"
     }
   }
 }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -625,6 +625,16 @@
       "error": "No se pudo comprobar el espacio en disco",
       "checking": "Comprobando...",
       "lowDescription": "El espacio libre bajo puede impedir compartir archivos nuevos."
+    },
+    "encryption": {
+      "title": "Compartir Cifrado",
+      "subtitle": "Compartir archivos cifrados para destinatarios específicos",
+      "enableForRecipient": "Habilitar compartir cifrado para destinatario específico",
+      "recipientPublicKey": "Clave Pública del Destinatario",
+      "publicKeyPlaceholder": "Ingrese la clave pública X25519 del destinatario (64 caracteres hexadecimales)",
+      "publicKeyHint": "Ingrese la clave pública X25519 del destinatario (formato hexadecimal, 64 caracteres). El archivo se cifrará para que solo ellos puedan descifrarlo. Déjelo vacío para cifrar para usted mismo.",
+      "invalidPublicKey": "⚠️ Formato de clave pública inválido. Debe tener 64 caracteres hexadecimales.",
+      "encryptedBadge": "Cifrado"
     }
   },
   "download": {

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -637,6 +637,16 @@
       "error": "디스크 공간을 확인할 수 없습니다",
       "checking": "확인 중...",
       "lowDescription": "여유 공간이 부족하면 새 파일을 공유할 수 없습니다."
+    },
+    "encryption": {
+      "title": "암호화 공유",
+      "subtitle": "특정 수신자를 위해 암호화된 파일 공유",
+      "enableForRecipient": "특정 수신자를 위한 암호화 공유 활성화",
+      "recipientPublicKey": "수신자 공개 키",
+      "publicKeyPlaceholder": "수신자의 X25519 공개 키 입력 (64자리 16진수)",
+      "publicKeyHint": "수신자의 X25519 공개 키를 입력하세요 (16진수 형식, 64자). 파일이 암호화되어 수신자만 해독할 수 있습니다. 비워두면 자신을 위해 암호화됩니다.",
+      "invalidPublicKey": "⚠️ 공개 키 형식이 잘못되었습니다. 64자리 16진수여야 합니다.",
+      "encryptedBadge": "암호화됨"
     }
   },
   "download": {

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -633,6 +633,16 @@
       "error": "无法检查磁盘空间",
       "checking": "正在检查...",
       "lowDescription": "可用空间过低可能导致无法继续分享文件。"
+    },
+    "encryption": {
+      "title": "加密分享",
+      "subtitle": "为特定接收者加密分享文件",
+      "enableForRecipient": "启用为特定接收者加密分享",
+      "recipientPublicKey": "接收者公钥",
+      "publicKeyPlaceholder": "输入接收者的 X25519 公钥（64 个十六进制字符）",
+      "publicKeyHint": "输入接收者的 X25519 公钥（十六进制格式，64 个字符）。文件将被加密，只有他们可以解密。留空表示为自己加密。",
+      "invalidPublicKey": "⚠️ 公钥格式无效。必须是 64 个十六进制字符。",
+      "encryptedBadge": "已加密"
     }
   },
   "download": {

--- a/src/pages/Upload.svelte
+++ b/src/pages/Upload.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import Card from '$lib/components/ui/card.svelte'
   import Badge from '$lib/components/ui/badge.svelte'
-  import { File as FileIcon, X, Plus, FolderOpen, FileText, Image, Music, Video, Archive, Code, FileSpreadsheet, Upload, Download, RefreshCw } from 'lucide-svelte'
+  import { File as FileIcon, X, Plus, FolderOpen, FileText, Image, Music, Video, Archive, Code, FileSpreadsheet, Upload, Download, RefreshCw, Lock, Key } from 'lucide-svelte'
   import { files, type FileItem, etcAccount } from '$lib/stores'
   import { t } from 'svelte-i18n';
   import { get } from 'svelte/store'
@@ -12,7 +12,9 @@
   import { open } from "@tauri-apps/plugin-dialog";
   import { invoke } from "@tauri-apps/api/core";
   import { dhtService } from '$lib/dht';
-  import { encryptionService } from '$lib/services/encryption'; 
+  import { encryptionService } from '$lib/services/encryption';
+  import Label from '$lib/components/ui/label.svelte';
+  import Input from '$lib/components/ui/input.svelte'; 
 
   const tr = (k: string, params?: Record<string, any>): string => (get(t) as (key: string, params?: any) => string)(k, params)
   // Check if running in Tauri environment
@@ -62,6 +64,11 @@
   let storageError: string | null = null
   let lastChecked: Date | null = null
   let isUploading = false
+  
+  // Encrypted sharing state
+  let useEncryptedSharing = false
+  let recipientPublicKey = ''
+  let showEncryptionOptions = false
 
   $: storageLabel = isRefreshingStorage
     ? tr('upload.storage.checking')
@@ -397,7 +404,9 @@
         const fileName = filePath.split(/[\/\\]/).pop() || '';
         
         // --- ENCRYPTION FLOW ---
-        const manifest = await encryptionService.encryptFile(filePath);
+        // Pass recipient public key if encrypted sharing is enabled and key is provided
+        const recipientKey = useEncryptedSharing && recipientPublicKey.trim() ? recipientPublicKey.trim() : undefined;
+        const manifest = await encryptionService.encryptFile(filePath, recipientKey);
 
         // Check for duplicates using the Merkle Root
         if (get(files).some((f: FileItem) => f.hash === manifest.merkleRoot)) {
@@ -573,6 +582,78 @@
   </Card>
   {/if}
 
+  <!-- Encrypted Sharing Options -->
+  {#if isTauri}
+  <Card class="p-4">
+    <button 
+      class="w-full flex items-center justify-between cursor-pointer hover:opacity-80 transition-opacity"
+      on:click={() => showEncryptionOptions = !showEncryptionOptions}
+    >
+      <div class="flex items-center gap-3">
+        <div class="flex items-center justify-center w-10 h-10 bg-gradient-to-br from-purple-500/10 to-purple-500/5 rounded-lg border border-purple-500/20">
+          <Lock class="h-5 w-5 text-purple-600" />
+        </div>
+        <div class="text-left">
+          <h3 class="text-sm font-semibold text-foreground">Encrypted Sharing</h3>
+          <p class="text-xs text-muted-foreground">Share files encrypted for specific recipients</p>
+        </div>
+      </div>
+      <svg 
+        class="h-5 w-5 text-muted-foreground transition-transform duration-200 {showEncryptionOptions ? 'rotate-180' : ''}" 
+        fill="none" 
+        stroke="currentColor" 
+        viewBox="0 0 24 24"
+      >
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+      </svg>
+    </button>
+    
+    {#if showEncryptionOptions}
+      <div class="mt-4 space-y-4 pt-4 border-t border-border">
+        <div class="flex items-center gap-2">
+          <input
+            type="checkbox"
+            id="use-encrypted-sharing"
+            bind:checked={useEncryptedSharing}
+            class="cursor-pointer"
+          />
+          <Label for="use-encrypted-sharing" class="cursor-pointer text-sm">
+            Enable encrypted sharing for specific recipient
+          </Label>
+        </div>
+        
+        {#if useEncryptedSharing}
+          <div class="space-y-2 pl-6">
+            <div class="flex items-center gap-2">
+              <Key class="h-4 w-4 text-muted-foreground" />
+              <Label for="recipient-public-key" class="text-sm font-medium">
+                Recipient's Public Key
+              </Label>
+            </div>
+            <Input
+              id="recipient-public-key"
+              bind:value={recipientPublicKey}
+              placeholder="Enter recipient's X25519 public key (64 hex characters)"
+              class="font-mono text-sm"
+              disabled={isUploading}
+            />
+            <p class="text-xs text-muted-foreground">
+              Enter the recipient's X25519 public key (hex format, 64 characters). 
+              The file will be encrypted so only they can decrypt it. 
+              Leave empty to encrypt for yourself.
+            </p>
+            {#if recipientPublicKey && !(/^[0-9a-fA-F]{64}$/.test(recipientPublicKey.trim()))}
+              <p class="text-xs text-destructive">
+                ⚠️ Invalid public key format. Must be 64 hexadecimal characters.
+              </p>
+            {/if}
+          </div>
+        {/if}
+      </div>
+    {/if}
+  </Card>
+  {/if}
+
   <Card class="drop-zone relative p-6 transition-all duration-200 border-dashed {isDragging ? 'border-primary bg-primary/5 scale-[1.01]' : isUploading ? 'border-orange-500 bg-orange-500/5' : 'border-muted-foreground/25 hover:border-muted-foreground/50'}"
         role="button"
         tabindex="0"
@@ -707,6 +788,15 @@
                           on:click={() => showVersionHistory(file.name)}
                         >
                           v{file.version}
+                        </Badge>
+                      {/if}
+                      {#if file.isEncrypted}
+                        <Badge
+                          class="bg-purple-100 text-purple-800 text-xs px-2 py-0.5 flex items-center gap-1"
+                          title="This file is encrypted end-to-end"
+                        >
+                          <Lock class="h-3 w-3" />
+                          Encrypted
                         </Badge>
                       {/if}
                       <div class="flex items-center gap-1">


### PR DESCRIPTION
Implements the Key Exchange UI feature for encrypted file sharing with specific recipients. Users can now input a recipient's X25519 public key when uploading files, enabling end-to-end encrypted sharing where only the intended recipient can decrypt the files.

<img width="934" height="379" alt="image" src="https://github.com/user-attachments/assets/38db3bb1-c08f-420a-8471-88b8fa80b364" />