### PR TITLE
fix(network): limit geographic distribution to top 3 regions

### DIFF
--- a/src/lib/components/GeoDistributionCard.svelte
+++ b/src/lib/components/GeoDistributionCard.svelte
@@ -151,7 +151,7 @@
           {tr('network.geoDistribution.emptyState')}
         </div>
       {:else}
-        {#each distribution.regions as region (region.regionId)}
+        {#each distribution.regions.sort((a, b) => b.count - a.count).slice(0, 3) as region (region.regionId)}
           <div class="p-3 rounded-lg border border-border/60 bg-background/70 shadow-sm">
             <div class="flex items-center justify-between gap-3">
               <div class="flex items-center gap-2 min-w-0">


### PR DESCRIPTION
Geographic distribution now only shows up to top 3 regions.

**Before**
<img width="500" height="500" alt="Screenshot 2025-10-05 at 9 20 32 PM" src="https://github.com/user-attachments/assets/d6b59634-ad68-4e18-9a03-c3fad535cbdb" />
**After**
<img width="500" height="500" alt="Screenshot 2025-10-05 at 9 21 45 PM" src="https://github.com/user-attachments/assets/d0ee043f-a90d-4b9b-a27b-0a61261ab5b7" />
