### PR TITLE
feat(relay): advertise circuit address on new listener

### DIFF
--- a/src-tauri/src/dht.rs
+++ b/src-tauri/src/dht.rs
@@ -1460,6 +1460,10 @@ async fn run_dht_node(
                     }
                     SwarmEvent::NewListenAddr { address, .. } => {
                         info!("📡 Now listening on: {}", address);
+                        if address.iter().any(|component| matches!(component, Protocol::P2pCircuit)) {
+                            swarm.add_external_address(address.clone());
+                            debug!("Advertised relay external address: {}", address);
+                        }
                         if let Ok(mut m) = metrics.try_lock() {
                             m.record_listen_addr(&address);
                         }


### PR DESCRIPTION
- Detect /p2p-circuit components in NewListenAddr events
 - Call swarm.add_external_address for relay circuit addresses and log the advertisement