### PR TITLE
(fix): Implement backward compatibility for keystore decryption

### DIFF
--- a/src-tauri/src/keystore.rs
+++ b/src-tauri/src/keystore.rs
@@ -418,7 +418,27 @@ fn decrypt_data(
     iv_hex: &str,
     password: &str,
 ) -> Result<String, String> {
-    decrypt_private_key(encrypted_hex, salt_hex, iv_hex, password)
+    // First, try with the current (higher) iteration count and new hash algorithm
+    let result = try_decrypt(encrypted_hex, salt_hex, iv_hex, password, |p, s| {
+        derive_key(p, s)
+    });
+
+    if result.is_ok() {
+        return result;
+    }
+
+    // If that fails, fall back to the legacy (lower) iteration count and old hash algorithm
+    let legacy_derive = |password: &str, salt: &[u8]| -> [u8; 32] {
+        use hmac::Hmac;
+        use pbkdf2::pbkdf2;
+        use sha3::Sha3_256; // The old "new" standard was Sha3
+        let mut key = [0u8; 32];
+        pbkdf2::<Hmac<Sha3_256>>(password.as_bytes(), salt, 4096, &mut key)
+            .expect("PBKDF2 legacy derivation should not fail with Sha3");
+        key
+    };
+
+    try_decrypt(encrypted_hex, salt_hex, iv_hex, password, legacy_derive)
 }
 
 fn decrypt_private_key(
@@ -427,20 +447,28 @@ fn decrypt_private_key(
     iv: &str,
     password: &str,
 ) -> Result<String, String> {
-    // Decode hex
-    let salt_bytes = hex::decode(salt).map_err(|e| format!("Invalid salt: {}", e))?;
-    let iv_bytes = hex::decode(iv).map_err(|e| format!("Invalid IV: {}", e))?;
-    let mut ciphertext =
-        hex::decode(encrypted).map_err(|e| format!("Invalid ciphertext: {}", e))?;
+    // This function now simply wraps decrypt_data to ensure consistent decryption logic.
+    decrypt_data(encrypted, salt, iv, password)
+}
 
-    // Derive key from password
-    let key = derive_key(password, &salt_bytes);
+/// Helper function to perform decryption with a given key derivation function.
+fn try_decrypt<F>(
+    encrypted_hex: &str,
+    salt_hex: &str,
+    iv_hex: &str,
+    password: &str,
+    derive_fn: F,
+) -> Result<String, String>
+where
+    F: Fn(&str, &[u8]) -> [u8; 32],
+{
+    let salt_bytes = hex::decode(salt_hex).map_err(|_| "Invalid salt format".to_string())?;
+    let iv_bytes = hex::decode(iv_hex).map_err(|_| "Invalid IV format".to_string())?;
+    let mut ciphertext = hex::decode(encrypted_hex).map_err(|_| "Invalid ciphertext".to_string())?;
 
-    // Decrypt
-    let iv_array: [u8; 16] = iv_bytes
-        .try_into()
-        .map_err(|_| "Invalid IV length".to_string())?;
+    let key = derive_fn(password, &salt_bytes);
 
+    let iv_array: [u8; 16] = iv_bytes.try_into().map_err(|_| "Invalid IV length".to_string())?;
     let mut cipher = Aes256Ctr::new(&key.into(), &iv_array.into());
     cipher.apply_keystream(&mut ciphertext);
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -493,6 +493,7 @@
       "successSimulated": "Account loaded (demo mode)",
       "error": "Failed to load account: {error}",
       "savePassword": "Save password on this computer (expires in 30 days)",
+      "savePasswordDisabled": "For security, the 'Save Password' feature is currently disabled. Please enter your password each time you unlock your account.",
       "savePasswordWarning": "Warning: Saving your password locally is convenient but less secure. Use with caution.",
       "addressMismatch": "Decryption error: address does not match."
     }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -409,6 +409,7 @@
       "success": "Cuenta cargada correctamente",
       "successSimulated": "Cuenta cargada (modo demo)",
       "error": "Error al cargar la cuenta: {error}",
+      "savePasswordDisabled": "Por seguridad, la función 'Guardar contraseña' está actualmente deshabilitada. Por favor, introduce tu contraseña cada vez que desbloquees tu cuenta.",
       "savePassword": "Guardar contraseña en este equipo (caduca en 30 días)",
       "savePasswordWarning": "Advertencia: Guardar tu contraseña localmente es conveniente pero menos seguro. Úsalo con precaución.",
       "addressMismatch": "Error de descifrado: la dirección no coincide."

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -415,9 +415,13 @@
       "success": "계정을 성공적으로 불러왔습니다!",
       "successSimulated": "시뮬레이션된 계정 불러오기 성공!",
       "error": "오류: {error}",
+      "savePasswordDisabled": "보안을 위해 '비밀번호 저장' 기능이 현재 비활성화되어 있습니다. 계정을 잠금 해제할 때마다 비밀번호를 입력해주세요.",
       "savePassword": "이 컴퓨터에 비밀번호 저장 (30일 후 만료)",
       "savePasswordWarning": "경고: 비밀번호를 로컬에 저장하는 것은 편리하지만 보안에 취약합니다. 주의해서 사용하세요.",
       "addressMismatch": "복호화 오류: 주소가 일치하지 않습니다."
+    },
+    "password": {
+      "password": "비밀번호"
     }
   },
   "blacklist": {

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -415,9 +415,13 @@
       "success": "账户加载成功",
       "successSimulated": "账户已加载（演示模式）",
       "error": "加载账户时出错: {error}",
+      "savePasswordDisabled": "为安全起见，'保存密码'功能当前已禁用。请在每次解锁账户时输入您的密码。",
       "savePassword": "在这台电脑上保存密码（30天后过期）",
       "savePasswordWarning": "警告：在本地保存密码虽然方便，但安全性较低。请谨慎使用。",
       "addressMismatch": "解密错误：地址不匹配。"
+    },
+    "password": {
+      "password": "密码"
     }
   },
   "security": {


### PR DESCRIPTION
The keystore login was broken, the function has been updated to be fully backward-compatible.

Before:
<img width="1254" height="763" alt="Screenshot 2025-10-07 at 9 02 37 AM" src="https://github.com/user-attachments/assets/f6724c3d-fa80-426c-bcfb-625f415d8171" />

After - successful login:
<img width="1281" height="768" alt="Screenshot 2025-10-07 at 9 19 44 AM" src="https://github.com/user-attachments/assets/146c58df-c123-495b-abdc-c9519025b82c" />
