### PR TITLE
add Dockerfile for running bootstrap nodes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,52 @@
+FROM rust:1.90 as builder
+
+
+RUN apt-get update && \
+    apt-get install -y \
+    libwebkit2gtk-4.1-dev \
+    libgtk-3-dev\
+    build-essential \
+    curl \
+    wget \
+    file \
+    libxdo-dev \
+    libssl-dev \
+    libayatana-appindicator3-dev \
+    librsvg2-dev
+
+WORKDIR /app
+
+
+# make empty dist directory to prevent error
+RUN mkdir -p dist
+
+
+# Copy source and build the binary
+COPY src-tauri /app/src-tauri
+RUN cd src-tauri && NO_STRIP=true cargo build --release
+
+# ---
+
+FROM debian:trixie-slim
+
+RUN apt-get update && \
+    apt-get install -y \
+    libwebkit2gtk-4.1-dev \
+    libgtk-3-0 \
+    libxdo3 \
+    libssl3 \
+    libayatana-appindicator3-1 \
+    librsvg2-2
+
+WORKDIR /app
+
+# Copy the built binary
+COPY --from=builder /app/src-tauri/target/release/chiral-network /usr/local/bin/chiral-network
+
+EXPOSE 4001 
+EXPOSE 8545
+
+ENV ENABLE_GETH=""
+
+# Add --enable-geth if ENABLE_GETH is set to true
+ENTRYPOINT ["/bin/sh", "-c", "exec /usr/local/bin/chiral-network --headless --dht-port 4001 --show-multiaddr ${ENABLE_GETH:+--enable-geth}"]

--- a/src-tauri/src/headless.rs
+++ b/src-tauri/src/headless.rs
@@ -91,6 +91,18 @@ pub struct CliArgs {
 }
 
 pub async fn run_headless(args: CliArgs) -> Result<(), Box<dyn std::error::Error>> {
+    use tracing_subscriber::{fmt, prelude::*, EnvFilter};
+    tracing_subscriber::registry()
+        .with(fmt::layer())
+        .with(
+            EnvFilter::from_default_env()
+                .add_directive("chiral_network=info".parse().unwrap())
+                .add_directive("libp2p=info".parse().unwrap())
+                .add_directive("libp2p_kad=debug".parse().unwrap())
+                .add_directive("libp2p_swarm=debug".parse().unwrap()),
+        )
+        .init();
+
     info!("Starting Chiral Network in headless mode");
     info!("DHT Port: {}", args.dht_port);
 


### PR DESCRIPTION
a Dockerfile lays out steps for Docker to create a container that runs a certain app. i created a Dockerfile for running a bootstrap node, since I wanted to host a bootstrap node myself and I use Docker.

to use it, you would do these commands

```sh
sudo docker build -t chiral-network /path/to/chiral-network
sudo docker run chiral-network -d -p 4001:4001 -p 8545:8545
```

i was able to successfully start a node with this Dockerfile. its information is

```
/ip4/914000.xyz/tcp/4001/p2p/12D3KooWAtUGHwQa9mp9JStgMPVCNfeNu6UTGRz6b81PCnJQM5s5
```

or if the domain name doesn't work for some reason

```
/ip4/134.199.240.145/tcp/4001/p2p/12D3KooWAtUGHwQa9mp9JStgMPVCNfeNu6UTGRz6b81PCnJQM5s5
```

there are some issues i need to look into though
- it can connect to other nodes but other nodes cannot connect to it. i think this is a problem on my end but i will make sure
- currently, a peer ID is generated every time the headless node starts, and only lasts until the node is stopped. this is catastrophic in case of an outage, because then nodes will not be able to connect to the bootstrap due to the peer ID being wrong. i want to create the option of having a permanent peer ID for bootstrap nodes.
  - i will make a github issue