### PR TITLE
feat: enforce proxy-backed anonymous routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ This implementation synthesizes concepts from multiple design teams, focusing on
 - ✅ **Relay Health Monitoring**: Track relay connection status and performance
 - ✅ **Custom Relay Nodes**: Add trusted relay nodes manually
 - ✅ **Headless Relay Configuration**: CLI flags for --enable-autorelay, --relay, --autonat-server
-- ❌ **Privacy Protection**: Route traffic through proxy nodes (no traffic routing implemented)
+- ✅ **Privacy Protection**: Route traffic through proxy nodes with enforced SOCKS5 routing
 - ❌ **Load Balancing**: Automatic distribution across multiple proxies (no parallel downloads or file segmentation)
 - ❌ **Latency Optimization**: Choose proxies based on performance (no download process uses latency framework)
 - ✅ **Custom Node Addition**: Add trusted proxy nodes manually
@@ -86,7 +86,7 @@ This implementation synthesizes concepts from multiple design teams, focusing on
 - ✅ **End-to-End Encryption**: AES-256-GCM encryption with PBKDF2 key derivation (can be enabled in Settings)
 - ✅ **Wallet Security**: Secure credential management with HD wallets
 - ✅ **Stream Authentication**: HMAC-based cryptographic verification of data integrity during file transfers
-- ❌ **Anonymous Routing**: Hide your IP from other peers (no IP hiding or anonymization implemented)
+- ✅ **Anonymous Routing**: Hide your IP from other peers with proxy-enforced anonymous mode
 - ✅ **No Commercial Tracking**: No marketplace means no transaction tracking
 
 ### 7. Mining & Network Security
@@ -103,7 +103,7 @@ This implementation synthesizes concepts from multiple design teams, focusing on
 - ✅ **Storage Management**: Configure storage location and limits
 - ✅ **Network Configuration**: Set bandwidth limits and connection parameters
 - ✅ **Advanced Bandwidth Scheduling**: Set different bandwidth limits for specific times and days
-- ✅ **Privacy Controls**: Mandatory encryption, proxy support, and anonymous mode (anonymous mode not implemented)
+- ✅ **Privacy Controls**: Mandatory encryption, proxy support, and anonymous mode
 - ✅ **Notification Preferences**: Customize alerts and notifications
 - ✅ **Advanced Options**: Fine-tune DHT, chunk size, and cache settings (configurable through UI)
 - ✅ **Import/Export**: Backup and restore settings

--- a/docs/06-security-privacy.md
+++ b/docs/06-security-privacy.md
@@ -242,6 +242,8 @@ Encrypted Encrypted Encrypted Plain
   (3x)      (2x)      (1x)     text
 ```
 
+**Implementation status:** Anonymous mode now enforces SOCKS5 proxy routing for every libp2p dial, binds listeners to loopback-only interfaces, and disables AutoNAT/DCUtR features that would otherwise reveal reachability details. Relay candidates are auto-selected from bootstrap nodes when custom relays are unavailable, ensuring all external peers see only proxy or relay addresses.
+
 #### Mix Networks
 
 - Random delays (0-5 seconds)

--- a/src-tauri/src/headless.rs
+++ b/src-tauri/src/headless.rs
@@ -160,6 +160,7 @@ pub async fn run_headless(args: CliArgs) -> Result<(), Box<dyn std::error::Error
         None, // cache_size_mb: use default
         enable_autorelay,
         args.relay.clone(),
+        false,
     )
     .await?;
     let peer_id = dht_service.get_peer_id().await;

--- a/src-tauri/tests/nat_traversal_e2e_test.rs
+++ b/src-tauri/tests/nat_traversal_e2e_test.rs
@@ -59,6 +59,7 @@ async fn test_autonat_detection() {
         Some(1024),                   // cache_size_mb
         false,                        // enable_autorelay
         Vec::new(),                   // preferred_relays
+        false,
     )
     .await;
 
@@ -107,6 +108,7 @@ async fn test_dht_peer_discovery() {
         Some(1024),
         false, // enable_autorelay
         Vec::new(), // preferred_relays
+        false,
     )
     .await
     .expect("Failed to create service1");
@@ -145,6 +147,7 @@ async fn test_dht_peer_discovery() {
         Some(1024),
         false, // enable_autorelay
         Vec::new(), // preferred_relays
+        false,
     )
     .await
     .expect("Failed to create service2");
@@ -195,6 +198,7 @@ async fn test_file_publish_and_search() {
         Some(1024),
         false, // enable_autorelay
         Vec::new(), // preferred_relays
+        false,
     )
     .await
     .expect("Failed to create service1");
@@ -225,6 +229,7 @@ async fn test_file_publish_and_search() {
         Some(1024),
         false, // enable_autorelay
         Vec::new(), // preferred_relays
+        false,
     )
     .await
     .expect("Failed to create service2");
@@ -282,6 +287,7 @@ async fn test_dcutr_enabled() {
         Some(1024),
         false, // enable_autorelay
         Vec::new(), // preferred_relays
+        false,
     )
     .await
     .expect("Failed to create service");
@@ -334,6 +340,7 @@ async fn test_multiple_autonat_servers() {
         Some(1024),
         false, // enable_autorelay
         Vec::new(), // preferred_relays
+        false,
     )
     .await
     .expect("Failed to create service");
@@ -369,6 +376,7 @@ async fn test_reachability_history_tracking() {
         Some(1024),
         false, // enable_autorelay
         Vec::new(), // preferred_relays
+        false,
     )
     .await
     .expect("Failed to create service");
@@ -416,6 +424,7 @@ async fn test_connection_metrics_tracking() {
         Some(1024),
         false, // enable_autorelay
         Vec::new(), // preferred_relays
+        false,
     )
     .await
     .expect("Failed to create service1");
@@ -446,6 +455,7 @@ async fn test_connection_metrics_tracking() {
         Some(1024),
         false, // enable_autorelay
         Vec::new(), // preferred_relays
+        false,
     )
     .await
     .expect("Failed to create service2");
@@ -497,6 +507,7 @@ async fn test_nat_resilience_private_to_public() {
         Some(1024),
         false, // enable_autorelay
         Vec::new(), // preferred_relays
+        false,
     )
     .await
     .expect("Failed to create public peer");
@@ -536,6 +547,7 @@ async fn test_nat_resilience_private_to_public() {
         Some(1024),
         false, // enable_autorelay
         Vec::new(), // preferred_relays
+        false,
     )
     .await
     .expect("Failed to create private peer");
@@ -597,6 +609,7 @@ async fn test_nat_resilience_connection_fallback() {
         Some(1024),
         false, // enable_autorelay
         Vec::new(), // preferred_relays
+        false,
     )
     .await;
 

--- a/src/lib/dht.ts
+++ b/src/lib/dht.ts
@@ -29,6 +29,7 @@ export interface DhtConfig {
   cacheSizeMb?: number;
   enableAutorelay?: boolean;
   preferredRelays?: string[];
+  anonymousMode?: boolean;
 }
 
 export interface FileMetadata {
@@ -150,6 +151,9 @@ export class DhtService {
         config.proxyAddress.trim().length > 0
       ) {
         payload.proxyAddress = config.proxyAddress;
+      }
+      if (typeof config?.anonymousMode === "boolean") {
+        payload.anonymousMode = config.anonymousMode;
       }
       if (typeof config?.chunkSizeKb === "number") {
         payload.chunkSizeKb = config.chunkSizeKb;

--- a/src/pages/Network.svelte
+++ b/src/pages/Network.svelte
@@ -348,16 +348,33 @@
         await new Promise(resolve => setTimeout(resolve, 500))
         // DHT not running, start it
         try {
+          const anonymousModeEnabled = $settings.anonymousMode
+          const proxyEnabled = $settings.enableProxy || anonymousModeEnabled
+          const proxyAddress = proxyEnabled
+            ? ($settings.proxyAddress || "").trim()
+            : ""
+          const enableAutonat = anonymousModeEnabled
+            ? false
+            : $settings.enableAutonat
+          const enableAutorelay = anonymousModeEnabled
+            ? true
+            : $settings.enableAutorelay
+
           const peerId = await dhtService.start({
             port: dhtPort,
             bootstrapNodes: dhtBootstrapNodes,
-            enableAutonat: $settings.enableAutonat,
+            enableAutonat,
             autonatProbeIntervalSeconds: $settings.autonatProbeInterval,
             autonatServers: $settings.autonatServers,
-            enableAutorelay: $settings.enableAutorelay,
-            preferredRelays: $settings.preferredRelays || [],
+            enableAutorelay,
+            preferredRelays:
+              enableAutorelay && $settings.preferredRelays
+                ? $settings.preferredRelays
+                : [],
             chunkSizeKb: $settings.chunkSize,
             cacheSizeMb: $settings.cacheSize,
+            proxyAddress: proxyEnabled && proxyAddress.length > 0 ? proxyAddress : undefined,
+            anonymousMode: anonymousModeEnabled,
           })
           dhtPeerId = peerId
           // Also ensure the service knows its own peer ID

--- a/src/pages/Settings.svelte
+++ b/src/pages/Settings.svelte
@@ -115,6 +115,12 @@
   $: autonatServersText = localSettings.autonatServers?.join('\n') || '';
   $: preferredRelaysText = localSettings.preferredRelays?.join('\n') || '';
 
+  $: if (localSettings.anonymousMode) {
+    localSettings.enableProxy = true;
+    localSettings.enableAutonat = false;
+    localSettings.enableAutorelay = true;
+  }
+
   // Check for changes
   $: hasChanges = JSON.stringify(localSettings) !== JSON.stringify(savedSettings);
 


### PR DESCRIPTION
-enforce an anonymous mode flag across the Tauri backend to force SOCKS5 dialing, disable AutoNAT/DCUtR, and bind libp2p listeners to loopback only
-plumb anonymous-mode aware proxy/autorelay settings through the Svelte UI and DHT service wrapper so the frontend always starts the node through the proxy
-refresh documentation and status tables to reflect the new anonymous routing implementation