### PR TITLE
fix: correct mining balance and reward display

### DIFF
--- a/src-tauri/src/ethereum.rs
+++ b/src-tauri/src/ethereum.rs
@@ -1159,7 +1159,7 @@ pub async fn get_recent_mined_blocks(
 
         // Since Geth's default reward (2.0) doesn't match the intended Chiral Network
         // reward, we hardcode the intended value of 5.0 here.
-        let reward = Some(5.0);
+        let reward = Some(2.0);
 
         out.push(MinedBlock {
             hash,

--- a/src/pages/Account.svelte
+++ b/src/pages/Account.svelte
@@ -640,6 +640,7 @@
       wallet.update(w => ({
         ...w,
         address: account.address,
+        
         pendingTransactions: 0
       }))
       importPrivateKey = ''


### PR DESCRIPTION
**Problem:** Mining page displayed 0.00 Chiral and 0 blocks, but blocks were being mined.

**Solution:** 
- Use miningState.recentBlocks in refreshBalance() instead of separate backend call
- Updated block reward from 5 to 2 Chiral

**Files changed:** wallet.ts, Mining.svelte, ethereum.rs

before
<img width="1920" height="1080" alt="截屏2025-10-09 20 40 25" src="https://github.com/user-attachments/assets/9f07029b-c8c7-40c3-9b21-2172d3448a0c" />
<img width="1920" height="1080" alt="截屏2025-10-09 22 46 48" src="https://github.com/user-attachments/assets/1df9762f-9297-49f7-bff9-e54b442f888f" />
<img width="1920" height="1080" alt="截屏2025-10-09 22 46 53" src="https://github.com/user-attachments/assets/a18d4a48-52a1-4dae-a2c6-9dd7ee99f66b" />
 after
<img width="1920" height="1080" alt="截屏2025-10-09 20 40 09" src="https://github.com/user-attachments/assets/37122afe-f888-4c6a-b036-e7bbd2b82233" />
<img width="1920" height="1080" alt="截屏2025-10-09 20 40 13" src="https://github.com/user-attachments/assets/c9bbb276-b1ff-4522-9f71-545eec6cfe08" />
