### PR TITLE
fix(network): fix DHT connection failure due to undefined variable reference

### DIFF
--- a/src/pages/Network.svelte
+++ b/src/pages/Network.svelte
@@ -393,8 +393,8 @@
       // Try to connect to bootstrap nodes
       let connectionSuccessful = false
 
-      if (DEFAULT_BOOTSTRAP_NODES.length > 0) {
-        dhtEvents = [...dhtEvents, `[Attempt ${connectionAttempts}] Connecting to ${DEFAULT_BOOTSTRAP_NODES.length} bootstrap node(s)...`]
+      if (dhtBootstrapNodes.length > 0) {
+        dhtEvents = [...dhtEvents, `[Attempt ${connectionAttempts}] Connecting to ${dhtBootstrapNodes.length} bootstrap node(s)...`]
         
         // Add another small delay to show the connection attempt
         await new Promise(resolve => setTimeout(resolve, 1000))


### PR DESCRIPTION
Replace undefined 'DEFAULT_BOOTSTRAP_NODES' with correct 'dhtBootstrapNodes' variable in Network.svelte. 
This fixes the ReferenceError that occurred on first connection attempt when switching DHT ports. 
The error caused connections to fail initially but succeed on retry because the retry path would skip the problematic code.

Problem:
<img width="988" height="565" alt="스크린샷 2025-10-12 오후 12 59 22" src="https://github.com/user-attachments/assets/4e7bc8b5-0186-4717-900b-e2a3666e159a" />
