### PR TITLE
implement periodic kademlia node maintenance for routing resilience

### DIFF
--- a/src-tauri/src/dht.rs
+++ b/src-tauri/src/dht.rs
@@ -946,6 +946,8 @@ async fn run_dht_node(
     relay_candidates: HashSet<String>,
     chunk_size: usize,
 ) {
+    let mut dht_maintenance_interval = tokio::time::interval(Duration::from_secs(30 * 60)); 
+    dht_maintenance_interval.tick().await; 
     // Periodic bootstrap interval
     let mut shutdown_ack: Option<oneshot::Sender<()>> = None;
     let mut ping_failures: HashMap<PeerId, u8> = HashMap::new();
@@ -955,6 +957,10 @@ async fn run_dht_node(
 
     'outer: loop {
         tokio::select! {
+            _= dht_maintenance_interval.tick() => {
+                info!("Triggering periodic DHT maintenanace: Kademlia bootstrap and Record Refresh.");
+                let _ = swarm.behaviour_mut().kademlia.bootstrap();
+            }
             cmd = cmd_rx.recv() => {
                 match cmd {
                     Some(DhtCommand::Shutdown(ack)) => {


### PR DESCRIPTION
This pull request implements the necessary periodic maintenance loop for the Kademlia Distributed Hash Table (DHT) to meet the network's resilience requirements. 
Regularly scheduled "health check" that prevents the node's routing information from getting stale, which is critical for long-term network reliability.

- periodic `bootstrap()` call triggers a Kademlia network search that forces the node to refresh its K-Buckets, replacing stale entries with active peer addresses. 
- ensures the node is continuously re-announced to the network, improving its stability and file availability (seeding) capabilities.