### PR TITLE
Use DHT backend for runDiscovery() function

### DIFF
--- a/src/pages/Network.svelte
+++ b/src/pages/Network.svelte
@@ -617,18 +617,11 @@
       return;
     }
 
-    // In Tauri mode, use DHT backend for peer discovery
+    // In Tauri mode, peer discovery happens automatically via DHT events
+    // This button just shows the current count
     if (isTauri) {
-      try {
-        showToast('Discovering peers via DHT...', 'info');
-        const peers = await invoke<string[]>('get_dht_connected_peers');
-        discoveredPeers = peers;
-        console.log('Discovered peers from DHT:', discoveredPeers);
-        showToast(tr('network.peerDiscovery.discoveryStarted', { values: { count: discoveredPeers.length } }), 'success');
-      } catch (error) {
-        console.error('Failed to discover peers:', error);
-        showToast('Failed to discover peers: ' + error, 'error');
-      }
+      const discoveryCount = discoveredPeerEntries.length;
+      showToast(tr('network.peerDiscovery.discoveryStarted', { values: { count: discoveryCount } }), 'info');
       return;
     }
 


### PR DESCRIPTION
fix(network): use DHT backend for runDiscovery() function
 - to switch from WebRTC to DHT backend for the discovery function in Tauri mode.
 - runDiscovery() function tried to connect to the WebRTC signaling server (regardless of whether you were in Tauri or web mode). I Added an if (isTauri) check that calls the DHT backend via invoke('get_dht_connected_peers') instead.

<img width="983" height="582" alt="스크린샷 2025-10-14 오전 9 34 55" src="https://github.com/user-attachments/assets/8e4cd2f7-ae23-453c-b41d-abce25e3f3db" />

fix(network): resolve undefined discoveredPeers variable error

- The runDiscovery() function in Tauri mode was attempting to use an undefined variable 'discoveredPeers', causing a ReferenceError when the discovery button was clicked. Since peer discovery happens automatically via DHT events through the peerEventService, the discovery button now simply displays the current count from discoveredPeerEntries instead of manually invoking the backend to fetch peers.
