### PR TITLE
feat: Establish unified identifiers for file retrieval

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,6 +11,7 @@ pub mod webrtc_service;
 // Required modules for encryption and keystore functionality
 pub mod encryption;
 pub mod keystore;
+pub mod manager;
 
 // Proxy latency optimization module
 pub mod proxy_latency;


### PR DESCRIPTION
This commit refactors the file publishing and identification logic to create a consistent foundation for retrieving files by both Merkle Hash and CID.

1.  Unified Primary Identifier: The DHT publishing logic in `dht.rs` is updated to always use the Merkle root of a file's original content as its primary `file_hash`. This applies to both encrypted and unencrypted files, ensuring a single, verifiable identifier for discovery and integrity.

2.  Linked Discovery to Retrieval: A `cids` field has been added to the `FileMetadata` struct. For files stored in Bitswap, this field now holds the root CID, creating a clear link between the discovery layer (DHT) and the retrieval layer (Bitswap).

3.  Enabled Manifest Exchange: New message types (`WebRTCManifestRequest`, `WebRTCManifestResponse`) and a `WebRTCMessage` enum have been added to `webrtc_service.rs`. This lays the groundwork for the private exchange of the `FileManifest` required for downloading encrypted files.
