### PR TITLE
feat: add relay server support for NAT traversal

### DIFF
--- a/src-tauri/src/headless.rs
+++ b/src-tauri/src/headless.rs
@@ -160,6 +160,7 @@ pub async fn run_headless(args: CliArgs) -> Result<(), Box<dyn std::error::Error
         None, // cache_size_mb: use default
         enable_autorelay,
         args.relay.clone(),
+        false, // enable_relay_server - disabled by default
     )
     .await?;
     let peer_id = dht_service.get_peer_id().await;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -751,6 +751,7 @@ async fn start_dht_node(
         cache_size_mb,
         enable_autorelay.unwrap_or(false),
         preferred_relays.unwrap_or_default(),
+        false, // enable_relay_server - disabled by default
     )
     .await
     .map_err(|e| format!("Failed to start DHT: {}", e))?;


### PR DESCRIPTION
Implements libp2p relay server behavior to allow nodes to act as relays for other peers, complementing the existing relay client functionality.

Changes:
- Add relay_server behavior to DhtBehaviour struct
- Implement comprehensive relay server event handling (10 event types)
- Add enable_relay_server parameter to DhtService::new()
- Update all call sites with new parameter (default: disabled)
- Add logging for relay server operations and inbound circuits

This enables nodes to facilitate NAT traversal for peers behind restrictive NATs by relaying their traffic, improving network connectivity and supporting the DCUtR hole-punching protocol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)