### PR TITLE
Add relay reservation authentication gate

### DIFF
--- a/relay/Cargo.lock
+++ b/relay/Cargo.lock
@@ -514,6 +514,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "web-time",
 ]
 
 [[package]]

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -27,6 +27,7 @@ futures = "0.3"
 rand = "0.8"
 async-trait = "0.1"
 async-std = { version = "1.12", features = ["attributes"] }
+web-time = "1.1"
 
 [profile.dev]
 incremental = true


### PR DESCRIPTION
-gate relay reservations behind a shared authentication token exchanged via the request-response protocol
-track authenticated peers, deny reservation attempts from unauthenticated peers, and clear auth state on disconnect
-pull in the web-time crate to type match the custom rate limiter