### PR TITLE
refactor(dht): Clarify file identifiers and improve download logic

### DIFF
--- a/src-tauri/src/dht.rs
+++ b/src-tauri/src/dht.rs
@@ -72,9 +72,8 @@ pub const RAW_CODEC: u64 = 0x55;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FileMetadata {
-    /// The CID (Content Identifier) used for retrieval from the DHT/Bitswap network.
-    /// This is the root CID that points to a block containing child chunk CIDs.
-    pub file_hash: String, // This is the root CID
+    /// The Merkle root of the original file chunks, used as the primary identifier for integrity.
+    pub merkle_root: String,
     pub file_name: String,
     pub file_size: u64,
     pub file_data: Vec<u8>, // holds the actual file data
@@ -85,10 +84,9 @@ pub struct FileMetadata {
     pub is_encrypted: bool,
     /// The encryption method used (e.g., "AES-256-GCM")
     pub encryption_method: Option<String>,
-    /// Fingerprint of the encryption key for identification
+    /// Fingerprint of the encryption key for identification.
+    /// This is now deprecated in favor of the merkle_root.
     pub key_fingerprint: Option<String>,
-    /// The Merkle root hash for integrity verification (optional, separate from file_hash)
-    pub merkle_root: Option<String>,
     // --- VERSIONING FIELDS ---
     pub version: Option<u32>,
     pub parent_hash: Option<String>,
@@ -1200,23 +1198,23 @@ async fn run_dht_node(
                             }
 
                             // The file_hash is the Merkle Root. The root_cid is for retrieval.
-                            metadata.file_hash = hex::encode(merkle_root);
+                            metadata.merkle_root = hex::encode(merkle_root);
                             metadata.cids = Some(vec![root_cid]); // Store the root CID for bitswap retrieval
-                            metadata.file_data.clear();
+                            metadata.file_data.clear(); // Don't store full data in DHT record
 
                             println!("Publishing file with root CID: {} (merkle_root: {:?})",
-                                root_cid, metadata.file_hash);
+                                root_cid, metadata.merkle_root);
                         } else {
                             // File data is empty - chunks and root block are already in Bitswap
                             // (from streaming upload or pre-processed encrypted file)
                             // Use the provided file_hash (which should already be a CID)
-                            println!("Publishing file with pre-computed CID: {} (merkle_root: {:?})",
-                                metadata.file_hash, metadata.merkle_root);
+                            println!("Publishing file with pre-computed Merkle root: {} and CID: {:?}",
+                                metadata.merkle_root, metadata.cids);
                         }
 
                         // Store minimal metadata in DHT
                         let dht_metadata = serde_json::json!({
-                            "file_hash": metadata.file_hash,
+                            "merkle_root": metadata.merkle_root,
                             "file_name": metadata.file_name,
                             "file_size": metadata.file_size,
                             "created_at": metadata.created_at,
@@ -1227,7 +1225,6 @@ async fn run_dht_node(
                             "version": metadata.version,
                             "parent_hash": metadata.parent_hash,
                             "cids": metadata.cids, // The root CID for Bitswap
-                            "merkle_root": metadata.merkle_root, // <-- Ensure Merkle root is included
                         });
 
                         let dht_record_data = match serde_json::to_vec(&dht_metadata) {
@@ -1238,7 +1235,7 @@ async fn run_dht_node(
                             }
                         };
 
-                        let key = kad::RecordKey::new(&metadata.file_hash.as_bytes());
+                        let key = kad::RecordKey::new(&metadata.merkle_root.as_bytes());
                         let record = Record {
                                     key,
                                     value: dht_record_data,
@@ -1248,22 +1245,22 @@ async fn run_dht_node(
 
                         match swarm.behaviour_mut().kademlia.put_record(record, kad::Quorum::One){
                             Ok(query_id) => {
-                                info!("started providing file: {}, query id: {:?}", metadata.file_hash, query_id);
+                                info!("started providing file: {}, query id: {:?}", metadata.merkle_root, query_id);
                             }
                             Err(e) => {
-                                error!("failed to start providing file {}: {}", metadata.file_hash, e);
+                                error!("failed to start providing file {}: {}", metadata.merkle_root, e);
                                 let _ = event_tx.send(DhtEvent::Error(format!("failed to start providing: {}", e))).await;
                             }
                         }
 
                         // Register this peer as a provider for the file
-                        let provider_key = kad::RecordKey::new(&metadata.file_hash.as_bytes());
+                        let provider_key = kad::RecordKey::new(&metadata.merkle_root.as_bytes());
                         match swarm.behaviour_mut().kademlia.start_providing(provider_key) {
                             Ok(query_id) => {
-                                info!("registered as provider for file: {}, query id: {:?}", metadata.file_hash, query_id);
+                                info!("registered as provider for file: {}, query id: {:?}", metadata.merkle_root, query_id);
                             }
                             Err(e) => {
-                                error!("failed to register as provider for file {}: {}", metadata.file_hash, e);
+                                error!("failed to register as provider for file {}: {}", metadata.merkle_root, e);
                                 let _ = event_tx.send(DhtEvent::Error(format!("failed to register as provider: {}", e))).await;
                             }
                         }
@@ -1271,15 +1268,18 @@ async fn run_dht_node(
                     }
                     Some(DhtCommand::DownloadFile(file_metadata)) =>{
                         // Get root CID from file hash
-                        let root_cid: Cid = match file_metadata.file_hash.parse() {
-                            Ok(cid) => cid,
-                            Err(e) => {
-                                error!("Invalid root CID in file metadata: {}", e);
-                                let _ = event_tx.send(DhtEvent::Error(format!("Invalid root CID: {}", e))).await;
-                                return;
-                            }
-                        };
+                        let root_cid_result = file_metadata.cids.as_ref()
+                            .and_then(|cids| cids.first())
+                            .ok_or_else(|| {
+                                let msg = format!("No root CID found for file with Merkle root: {}", file_metadata.merkle_root);
+                                error!("{}", msg);
+                                msg
+                            });
 
+                        let root_cid = match root_cid_result {
+                            Ok(cid) => cid.clone(),
+                            Err(e) => { let _ = event_tx.send(DhtEvent::Error(e)).await; continue; }
+                        };
                         // Request the root block which contains the CIDs
                         let root_query_id = swarm.behaviour_mut().bitswap.get(&root_cid);
 
@@ -1711,7 +1711,7 @@ async fn run_dht_node(
                             if let Some(metadata) = root_query_mapping.lock().await.remove(&query_id) {
                                 // This is the root block containing CIDs - parse and request all data blocks
                                 if let Ok(cids) = serde_json::from_slice::<Vec<Cid>>(&data) {
-                                    info!("Received root block for file {} with {} CIDs", metadata.file_hash, cids.len());
+                                    info!("Received root block for file {} with {} CIDs", metadata.merkle_root, cids.len());
 
                                     // Create queries map for this file's data blocks
                                     let mut file_queries = HashMap::new();
@@ -1729,11 +1729,11 @@ async fn run_dht_node(
                                     };
 
                                     // Store the active download
-                                    active_downloads.lock().await.insert(metadata.file_hash.clone(), active_download);
+                                    active_downloads.lock().await.insert(metadata.merkle_root.clone(), active_download);
 
-                                    info!("Started tracking download for file {} with {} chunks", metadata.file_hash, cids.len());
+                                    info!("Started tracking download for file {} with {} chunks", metadata.merkle_root, cids.len());
                                 } else {
-                                    error!("Failed to parse root block as CIDs array for file {}", metadata.file_hash);
+                                    error!("Failed to parse root block as CIDs array for file {}", metadata.merkle_root);
                                 }
                             } else {
                                 // This is a data block query - find the corresponding file and handle it
@@ -1745,7 +1745,7 @@ async fn run_dht_node(
                                     for (file_hash, active_download) in active_downloads_guard.iter_mut() {
                                         if let Some(chunk_index) = active_download.queries.remove(&query_id) {
                                             // This query belongs to this file - store the chunk
-                                            active_download.downloaded_chunks.insert(chunk_index as usize, data.clone());
+                                            active_download.downloaded_chunks.insert(chunk_index, data.clone());
 
                                             // Check if all chunks for this file are downloaded
                                             if active_download.queries.is_empty() {
@@ -1753,8 +1753,8 @@ async fn run_dht_node(
 
                                                 // Reassemble the file
                                                 let mut file_data = Vec::new();
-                                                for i in 0..active_download.downloaded_chunks.len() {
-                                                    if let Some(chunk) = active_download.downloaded_chunks.get(&i) {
+                                                for i in 0..active_download.downloaded_chunks.len() as u32 {
+                                    if let Some(chunk) = active_download.downloaded_chunks.get(&(i as u32)) {
                                                         file_data.extend_from_slice(chunk);
                                                     }
                                                 }
@@ -2176,14 +2176,14 @@ async fn handle_kademlia_event(
                                 Some(file_name),
                                 Some(file_size),
                                 Some(created_at),
-                            ) = (
-                                metadata_json.get("file_hash").and_then(|v| v.as_str()),
+                            ) = ( // Use merkle_root as the primary identifier
+                                metadata_json.get("merkle_root").and_then(|v| v.as_str()),
                                 metadata_json.get("file_name").and_then(|v| v.as_str()),
                                 metadata_json.get("file_size").and_then(|v| v.as_u64()),
                                 metadata_json.get("created_at").and_then(|v| v.as_u64()),
                             ) {
                                 let metadata = FileMetadata {
-                                    file_hash: file_hash.to_string(),
+                                    merkle_root: file_hash.to_string(),
                                     file_name: file_name.to_string(),
                                     file_size,
                                     file_data: Vec::new(), // Will be populated during download
@@ -2208,10 +2208,6 @@ async fn handle_kademlia_event(
                                         .get("key_fingerprint")
                                         .and_then(|v| v.as_str())
                                         .map(|s| s.to_string()),
-                                    merkle_root: metadata_json
-                                        .get("merkle_root")
-                                        .and_then(|v| v.as_str())
-                                        .map(|s| s.to_string()),
                                     version: metadata_json
                                         .get("version")
                                         .and_then(|v| v.as_u64())
@@ -2220,7 +2216,10 @@ async fn handle_kademlia_event(
                                         .get("parent_hash")
                                         .and_then(|v| v.as_str())
                                         .map(|s| s.to_string()),
-                                    cids: None, // CIDs are in the root block
+                                    cids: metadata_json.get("cids").and_then(|v| {
+                                        serde_json::from_value::<Option<Vec<Cid>>>(v.clone())
+                                            .unwrap_or(None)
+                                    }),
                                     is_root: metadata_json
                                         .get("is_root")
                                         .and_then(|v| v.as_bool())
@@ -2228,7 +2227,7 @@ async fn handle_kademlia_event(
                                 };
 
                                 let notify_metadata = metadata.clone();
-                                let file_hash = notify_metadata.file_hash.clone();
+                                let file_hash = notify_metadata.merkle_root.clone();
                                 info!("File discovered: {} ({})", notify_metadata.file_name, file_hash);
                                 let _ = event_tx.send(DhtEvent::FileDiscovered(metadata)).await;
 
@@ -2918,7 +2917,7 @@ pub struct DhtService {
 struct ActiveDownload {
     metadata: FileMetadata,
     queries: HashMap<beetswap::QueryId, u32>, // query_id -> chunk_index
-    downloaded_chunks: HashMap<usize, Vec<u8>>, // chunk_index -> data
+    downloaded_chunks: HashMap<u32, Vec<u8>>, // chunk_index -> data
 }
 
 impl DhtService {
@@ -3269,7 +3268,7 @@ impl DhtService {
         self.file_metadata_cache
             .lock()
             .await
-            .insert(metadata.file_hash.clone(), metadata.clone());
+            .insert(metadata.merkle_root.clone(), metadata.clone());
         self.cmd_tx
             .send(DhtCommand::PublishFile(metadata))
             .await
@@ -3285,7 +3284,7 @@ impl DhtService {
         self.file_metadata_cache
             .lock()
             .await
-            .insert(metadata.file_hash.clone(), metadata.clone());
+            .insert(metadata.merkle_root.clone(), metadata.clone());
     }
     /// List all known FileMetadata (from cache, i.e., locally published or discovered)
     pub async fn get_all_file_metadata(&self) -> Result<Vec<FileMetadata>, String> {
@@ -3304,10 +3303,9 @@ impl DhtService {
             .filter(|m| m.file_name == file_name) // Remove is_root filter - get all versions
             .collect();
         versions.sort_by(|a, b| b.version.unwrap_or(1).cmp(&a.version.unwrap_or(1)));
-
         // For each version, try to find seeders (peers that have this file)
         for version in &mut versions {
-            version.seeders = self.get_seeders_for_file(&version.file_hash).await;
+            version.seeders = self.get_seeders_for_file(&version.merkle_root).await;
         }
 
         Ok(versions)
@@ -3342,13 +3340,13 @@ impl DhtService {
         let (version, parent_hash, is_root) = match latest {
             Some(ref prev) => (
                 prev.version.map(|v| v + 1).unwrap_or(2),
-                Some(prev.file_hash.clone()),
+                Some(prev.merkle_root.clone()),
                 false, // not root if there was a previous version
             ),
             None => (1, None, true), // root if first version
         };
         Ok(FileMetadata {
-            file_hash,
+            merkle_root: file_hash,
             file_name,
             file_size,
             file_data,
@@ -3358,7 +3356,6 @@ impl DhtService {
             is_encrypted,
             encryption_method,
             key_fingerprint,
-            merkle_root: None,
             version: Some(version),
             parent_hash,
             cids: None,
@@ -3753,11 +3750,11 @@ impl DhtService {
     /// Discover and verify available peers for a specific file
     pub async fn discover_peers_for_file(
         &self,
-        metadata: &FileMetadata,
+        metadata: &FileMetadata, // This now contains the merkle_root
     ) -> Result<Vec<String>, String> {
         info!(
             "Starting peer discovery for file: {} with {} seeders",
-            metadata.file_hash,
+            metadata.merkle_root,
             metadata.seeders.len()
         );
 

--- a/src-tauri/src/headless.rs
+++ b/src-tauri/src/headless.rs
@@ -206,7 +206,7 @@ pub async fn run_headless(args: CliArgs) -> Result<(), Box<dyn std::error::Error
 
         // Publish some example metadata to seed the network
         let example_metadata = FileMetadata {
-            file_hash: "QmBootstrap123Example".to_string(),
+            merkle_root: "QmBootstrap123Example".to_string(),
             file_name: "welcome.txt".to_string(),
             file_size: 1024,
             file_data: b"Hello, world!".to_vec(),
@@ -219,7 +219,6 @@ pub async fn run_headless(args: CliArgs) -> Result<(), Box<dyn std::error::Error
             is_encrypted: false,
             encryption_method: None,
             key_fingerprint: None,
-            merkle_root: None,
             parent_hash: None,
             version: Some(1),
             cids: None,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -503,7 +503,7 @@ async fn upload_versioned_file(
 
         // Store file data locally for seeding
         let ft = {
-            let ft_guard = state.file_transfer.lock().await;
+            let ft_guard = state.file_transfer.lock().await; // Store the file locally for seeding
             ft_guard.as_ref().cloned()
         };
         if let Some(ft) = ft {
@@ -1148,14 +1148,15 @@ async fn get_dht_events(state: State<'_, AppState>) -> Result<Vec<String>, Strin
                 DhtEvent::PeerDisconnected { peer_id } => {
                     format!("peer_disconnected:{}", peer_id)
                 }
-                DhtEvent::FileDiscovered(meta) => format!(
-                    "file_discovered:{}:{}:{}",
-                    meta.file_hash, meta.file_name, meta.file_size
-                ),
+                DhtEvent::FileDiscovered(meta) => {
+                    // Serialize the full metadata object to JSON for the frontend
+                    let payload = serde_json::to_string(&meta).unwrap_or_else(|_| "{}".to_string());
+                    format!("file_discovered:{}", payload)
+                }
                 DhtEvent::DownloadedFile(_) => "file_downloaded".to_string(),
                 DhtEvent::PublishedFile(meta) => format!(
-                    "file_published:{}:{}:{}",
-                    meta.file_hash, meta.file_name, meta.file_size
+                    "file_published:{}:{}:{}", // Use merkle_root as the primary identifier
+                    meta.merkle_root, meta.file_name, meta.file_size
                 ),
                 DhtEvent::FileNotFound(hash) => format!("file_not_found:{}", hash),
                 DhtEvent::Error(err) => format!("error:{}", err),
@@ -1818,7 +1819,7 @@ async fn download_file_from_network(
                     if metadata.seeders.is_empty() {
                         return Err(format!(
                             "No seeders available for file: {} ({})",
-                            metadata.file_name, metadata.file_hash
+                            metadata.file_name, metadata.merkle_root
                         ));
                     }
 
@@ -1872,8 +1873,8 @@ async fn download_file_from_network(
 
                                 // Send WebRTC offer via DHT signaling
                                 let offer_request = dht::WebRTCOfferRequest {
-                                    offer_sdp: offer,
-                                    file_hash: metadata.file_hash.clone(),
+                                    offer_sdp: offer, // The Merkle root is now the primary file hash
+                                    file_hash: metadata.merkle_root.clone(),
                                     requester_peer_id: dht_service.get_peer_id().await,
                                 };
 
@@ -1913,7 +1914,7 @@ async fn download_file_from_network(
 
                                                         // Send file request over WebRTC data channel
                                                         let file_request = crate::webrtc_service::WebRTCFileRequest {
-                                                            file_hash: metadata.file_hash.clone(),
+                                                            file_hash: metadata.merkle_root.clone(),
                                                             file_name: metadata.file_name.clone(),
                                                             file_size: metadata.file_size,
                                                             requester_peer_id: dht_service.get_peer_id().await,
@@ -2178,7 +2179,7 @@ async fn upload_file_chunk(
             .as_secs();
 
         let metadata = dht::FileMetadata {
-            file_hash: root_cid.to_string(), // Use root CID for retrieval
+            merkle_root: merkle_root, // Store Merkle root for verification
             file_name: session.file_name.clone(),
             file_size: session.file_size,
             file_data: vec![], // Empty - data is stored in Bitswap blocks
@@ -2188,10 +2189,9 @@ async fn upload_file_chunk(
             is_encrypted: false,
             encryption_method: None,
             key_fingerprint: None,
-            merkle_root: Some(merkle_root), // Store Merkle root for verification
             parent_hash: None,
             version: Some(1),
-            cids: None, // CIDs are stored in the root block, not in metadata
+            cids: Some(vec![root_cid.clone()]), // The root CID for retrieval
             is_root: true,
         };
 
@@ -3948,7 +3948,7 @@ async fn upload_and_publish_file(
 
     // 4. Publish to DHT with versioning support
     let dht = {
-        let dht_guard = state.dht.lock().await;
+        let dht_guard = state.dht.lock().await; // Use the Merkle root as the file hash
         dht_guard.as_ref().cloned()
     };
 
@@ -3957,20 +3957,20 @@ async fn upload_and_publish_file(
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
             .as_secs();
-
+        
         // Use prepare_versioned_metadata to handle version incrementing and parent_hash
         let mime_type = detect_mime_type_from_filename(&file_name).unwrap_or_else(|| "application/octet-stream".to_string());
         let metadata = dht
             .prepare_versioned_metadata(
-                manifest.merkle_root.clone(),
+                manifest.merkle_root.clone(), // This is the Merkle root
                 file_name.clone(),
                 file_size,
                 vec![], // Empty - chunks already stored
                 created_at,
                 Some(mime_type),
                 true, // is_encrypted
-                Some("AES-256-GCM".to_string()),
-                None, // key_fingerprint
+                Some("AES-256-GCM".to_string()), // Encryption method
+                None, // key_fingerprint (deprecated)
             )
             .await?;
 
@@ -3988,7 +3988,7 @@ async fn upload_and_publish_file(
                 .map_err(|e| format!("Failed to read file for local storage: {}", e))?;
             
             ft.store_file_data(manifest.merkle_root.clone(), file_name.clone(), file_data)
-                .await;
+                .await; // Store with Merkle root as key
         }
         
         dht.publish_file(metadata).await?;

--- a/src-tauri/src/multi_source_download.rs
+++ b/src-tauri/src/multi_source_download.rs
@@ -378,7 +378,7 @@ impl MultiSourceDownloadService {
             let size = remaining.min(chunk_size);
 
             // Calculate chunk hash (simplified - in real implementation this would be pre-calculated)
-            let hash = format!("{}_{}", metadata.file_hash, chunk_id);
+            let hash = format!("{}_{}", metadata.merkle_root, chunk_id);
 
             chunks.push(ChunkInfo {
                 chunk_id,
@@ -664,7 +664,7 @@ impl MultiSourceDownloadService {
 
         if let Some(metadata) = metadata {
             let file_request = WebRTCFileRequest {
-                file_hash: metadata.file_hash.clone(),
+                file_hash: metadata.merkle_root.clone(),
                 file_name: metadata.file_name.clone(),
                 file_size: metadata.file_size,
                 requester_peer_id: self.dht_service.get_peer_id().await,
@@ -815,7 +815,7 @@ impl MultiSourceDownloadService {
         };
 
         MultiSourceProgress {
-            file_hash: download.file_metadata.file_hash.clone(),
+            file_hash: download.file_metadata.merkle_root.clone(),
             file_name: download.file_metadata.file_name.clone(),
             total_size: download.file_metadata.file_size,
             downloaded_size,
@@ -909,7 +909,7 @@ impl MultiSourceDownloadService {
         };
 
         MultiSourceProgress {
-            file_hash: download.file_metadata.file_hash.clone(),
+            file_hash: download.file_metadata.merkle_root.clone(),
             file_name: download.file_metadata.file_name.clone(),
             total_size: download.file_metadata.file_size,
             downloaded_size,

--- a/src-tauri/src/reputation.rs
+++ b/src-tauri/src/reputation.rs
@@ -283,7 +283,7 @@ impl ReputationDhtService {
 
         // Store in DHT (using existing file metadata structure as template)
         let metadata = crate::dht::FileMetadata {
-            file_hash: key.clone(),
+            merkle_root: key.clone(),
             file_name: format!("reputation_{}.json", event.id),
             file_size: serialized.len() as u64,
             file_data: serialized,
@@ -293,7 +293,6 @@ impl ReputationDhtService {
             is_encrypted: false,
             encryption_method: None,
             key_fingerprint: None,
-            merkle_root: None,
             version: Some(1),
             parent_hash: None,
             cids: None, // Not needed for reputation events
@@ -326,7 +325,7 @@ impl ReputationDhtService {
             .map_err(|e| format!("Serialization error: {}", e))?;
 
         let metadata = crate::dht::FileMetadata {
-            file_hash: key.clone(),
+            merkle_root: epoch.merkle_root.clone(),
             file_name: format!("merkle_root_{}.json", epoch.epoch_id),
             file_size: serialized.len() as u64,
             file_data: serialized,
@@ -336,7 +335,6 @@ impl ReputationDhtService {
             is_encrypted: false,
             encryption_method: None,
             key_fingerprint: None,
-            merkle_root: Some(epoch.merkle_root.clone()),
             version: Some(1),
             parent_hash: None,
             cids: None, // Not needed for merkle roots

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -353,7 +353,8 @@
       "addedToQueue": "File added to the download queue.",
       "autostart": "Download automatically started.",
       "searchFailed": "Search failed: {error}",
-      "downloadFailed": "Download failed for {name}."
+      "downloadFailed": "Download failed for {name}.",
+      "downloadComplete": "Download complete for {name}."
     },
     "search": {
       "status": {


### PR DESCRIPTION
Refactored the file identification and retrieval system to improve code clarity. The`file_hash` field has been renamed to `merkle_root` throughout the codebase to explicitly designate the Merkle root as the primary, verifiable identifier for file content

-  Identifier Refactoring:
    - Renamed `FileMetadata.file_hash` to `merkle_root` to make its purpose clear.
    - Updated all associated logic in `dht`, `main`, `multi_source_download`, and `reputation` services to use `merkle_root` as the primary key for file records and lookups.

-  Improved Download Logic:
    - It now correctly prioritizes the `MultiSourceDownloadService` for parallel downloads.
    - Implemented a proper fallback to the basic DHT/Bitswap download mechanism if the multi-source service is unavailable.

- Explicit Content Addressing:
    - The `cids` field in `FileMetadata` is now consistently used to store the root CID, which is the entry point for retrieving file blocks from the Bitswap network
