### PR TITLE
fix (download): prevent frontend freeze when fetching file metadata over DHT

### DIFF
--- a/src/lib/components/download/DownloadSearchSection.svelte
+++ b/src/lib/components/download/DownloadSearchSection.svelte
@@ -46,14 +46,14 @@
     // }
     if (entries.length > 0) {
       // 1. Always set the active ID from the most recent entry for the history dropdown.
-      activeHistoryId = entries[0].id; 
+      activeHistoryId = entries[0].id;
 
       // 2. Control the main UI state based on whether a search has been initiated in this session.
       if (!hasSearched) {
         // If it's a fresh load (hasSearched is false):
         // Keep the input clear, and the result panel empty.
-        searchHash = ''; 
-        latestStatus = 'pending'; 
+        searchHash = '';
+        latestStatus = 'pending';
         latestMetadata = null;
         searchError = null;
       } else {
@@ -181,6 +181,7 @@
         lastSearchDuration = elapsed;
 
         if (metadata) {
+          metadata.fileHash = metadata.merkleRoot || "";
           latestMetadata = metadata;
           latestStatus = 'found';
           dhtSearchHistory.updateEntry(entry.id, {
@@ -192,6 +193,7 @@
             tr('download.search.status.foundNotification', { values: { name: metadata.fileName } }),
             'success',
           );
+          isSearching = false;
         } else {
           latestStatus = 'not_found';
           dhtSearchHistory.updateEntry(entry.id, {

--- a/src/lib/dht.ts
+++ b/src/lib/dht.ts
@@ -38,6 +38,7 @@ export interface FileMetadata {
   fileData?: Uint8Array | number[];
   seeders: string[];
   createdAt: number;
+  merkleRoot?: string;
   mimeType?: string;
   isEncrypted: boolean;
   encryptionMethod?: string;
@@ -187,8 +188,6 @@ export class DhtService {
       throw error;
     }
   }
-
-
 
   async downloadFile(fileMetadata: FileMetadata): Promise<FileMetadata> {
     try {

--- a/src/pages/Upload.svelte
+++ b/src/pages/Upload.svelte
@@ -64,7 +64,7 @@
   let storageError: string | null = null
   let lastChecked: Date | null = null
   let isUploading = false
-  
+
   // Encrypted sharing state
   let useEncryptedSharing = false
   let recipientPublicKey = ''
@@ -625,7 +625,7 @@
   <!-- Encrypted Sharing Options -->
   {#if isTauri}
   <Card class="p-4">
-    <button 
+    <button
       class="w-full flex items-center justify-between cursor-pointer hover:opacity-80 transition-opacity"
       on:click={() => showEncryptionOptions = !showEncryptionOptions}
     >
@@ -638,16 +638,16 @@
           <p class="text-xs text-muted-foreground">{$t('upload.encryption.subtitle')}</p>
         </div>
       </div>
-      <svg 
-        class="h-5 w-5 text-muted-foreground transition-transform duration-200 {showEncryptionOptions ? 'rotate-180' : ''}" 
-        fill="none" 
-        stroke="currentColor" 
+      <svg
+        class="h-5 w-5 text-muted-foreground transition-transform duration-200 {showEncryptionOptions ? 'rotate-180' : ''}"
+        fill="none"
+        stroke="currentColor"
         viewBox="0 0 24 24"
       >
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
       </svg>
     </button>
-    
+
     {#if showEncryptionOptions}
       <div class="mt-4 space-y-4 pt-4 border-t border-border">
         <div class="flex items-center gap-2">
@@ -661,7 +661,7 @@
             {$t('upload.encryption.enableForRecipient')}
           </Label>
         </div>
-        
+
         {#if useEncryptedSharing}
           <div class="space-y-2 pl-6">
             <div class="flex items-center gap-2">


### PR DESCRIPTION
Fixes a frontend freeze when retrieving file metadata over the DHT network for files not uploaded by the current user on the download tab. Also temporarily populates the fileHash field using the merkleRoot value since fileHash is not currently returned from the backend.