### PR TITLE
feat(upload): add timezone to upload page

### DIFF
--- a/src/pages/Upload.svelte
+++ b/src/pages/Upload.svelte
@@ -91,7 +91,11 @@
   $: lastCheckedLabel = lastChecked
     ? tr('upload.storage.lastChecked', {
         values: {
-          time: lastChecked.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+          time: new Intl.DateTimeFormat(undefined, {
+            hour: '2-digit',
+            minute: '2-digit',
+            timeZoneName: 'short'
+          }).format(lastChecked)
         }
       })
     : null


### PR DESCRIPTION
Added time zone to upload page for consistency with other pages. 
<img width="543" height="312" alt="image" src="https://github.com/user-attachments/assets/1c78c1df-efa3-4167-af7f-99fe0b4834a8" />
