### PR TITLE
fix(libp2p): increase handshake timeout to 20s for TCP/relay dials to reduce false failures

### DIFF
--- a/src-tauri/src/dht.rs
+++ b/src-tauri/src/dht.rs
@@ -3152,7 +3152,7 @@ pub fn build_transport_with_relay(
         t.upgrade(Version::V1Lazy)
             .authenticate(noise_cfg.clone())
             .multiplex(yamux_cfg.clone())
-            .timeout(Duration::from_secs(10))
+            .timeout(Duration::from_secs(20))
             .map(|(peer, muxer), _| (peer, StreamMuxerBox::new(muxer)))
             .boxed()
     };
@@ -3183,7 +3183,7 @@ pub fn build_transport_with_relay(
         .upgrade(Version::V1Lazy)
         .authenticate(noise_cfg.clone())
         .multiplex(yamux_cfg.clone())
-        .timeout(Duration::from_secs(10))
+        .timeout(Duration::from_secs(20))
         .map(|(peer, muxer), _| (peer, StreamMuxerBox::new(muxer)))
         .boxed();
 


### PR DESCRIPTION
- Increase libp2p handshake timeout from 10s to 20s for both direct TCP and relay paths to reduce intermittent dial failures on slower or congested networks.