### PR TITLE
feat(backend): add service to extract earnings history (block rewards) from chain

### DIFF
--- a/src-tauri/src/ethereum.rs
+++ b/src-tauri/src/ethereum.rs
@@ -1357,3 +1357,33 @@ pub async fn send_transaction(
 
     Ok(tx_hash)
 }
+
+/// Fetches the full details of a block by its number.
+/// This is used by the blockchain indexer to get reward data.
+pub async fn get_block_details_by_number(block_number: u64) -> Result<Option<serde_json::Value>, String> {
+    let client = reqwest::Client::new();
+    let payload = serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "eth_getBlockByNumber",
+        "params": [format!("0x{:x}", block_number), true], // true for full transaction objects
+        "id": 1
+    });
+
+    let response = client
+        .post("http://127.0.0.1:8545")
+        .json(&payload)
+        .send()
+        .await
+        .map_err(|e| format!("Failed to send request for block {}: {}", block_number, e))?;
+
+    let json_response: serde_json::Value = response
+        .json()
+        .await
+        .map_err(|e| format!("Failed to parse response for block {}: {}", block_number, e))?;
+
+    if let Some(error) = json_response.get("error") {
+        return Err(format!("RPC error for block {}: {}", block_number, error));
+    }
+
+    Ok(json_response["result"].clone().into())
+}


### PR DESCRIPTION
This service pulls raw reward data directly from the Geth node, completing the first step in Team Pandas's initiative to replace the mock data in the Analytics earnings history graphs with actual backend data.

This is achieved by implementing the following core capabilities:
1.  **Node Connection:** A new function, `get_block_details_by_number`, is added to `src/ethereum.rs` to connect to the local Geth node's RPC interface.
2.  **Block Scanning:** The function provides the core capability to scan the blockchain by fetching the full details of any block by its number.
3.  **Reward Identification:** The function retrieves the complete block object, which contains the `miner` address and `timestamp` needed to identify and process block rewards.

**Next To-Do:**
The next step Team Pandas will work on is to build an indexing service that will call this function in a loop to scan the chain and cache the historical earnings data in a local database for fast frontend access.