### PR TITLE
fix(network): fix misleading success message on peer connection

### DIFF
--- a/src/pages/Network.svelte
+++ b/src/pages/Network.svelte
@@ -691,6 +691,20 @@
         return;
       }
 
+      // Check if peer is already connected
+      const isAlreadyConnected = $peers.some(peer =>
+        peer.id === peerAddress ||
+        peer.address === peerAddress ||
+        peer.address.includes(peerAddress) ||
+        peerAddress.includes(peer.id)
+      );
+
+      if (isAlreadyConnected) {
+        showToast('Peer is already connected', 'info');
+        newPeerAddress = '';
+        return;
+      }
+
       try {
         showToast('Connecting to peer via DHT...', 'info');
         const currentPeerCount = $peers.length;
@@ -1879,16 +1893,18 @@
                         {#each peer.addresses as addr}
                           <div class="flex items-center justify-between gap-2">
                             <span class="text-xs font-mono break-all">{addr}</span>
-                            <Button
-                              size="sm"
-                              variant="outline"
-                              on:click={() => {
-                                newPeerAddress = addr
-                                showToast($t('network.peerDiscovery.peerAddedToInput'), 'success')
-                              }}
-                            >
-                              {$t('network.peerDiscovery.add')}
-                            </Button>
+                            {#if addr.includes('/p2p/')}
+                              <Button
+                                size="sm"
+                                variant="outline"
+                                on:click={() => {
+                                  newPeerAddress = addr
+                                  showToast($t('network.peerDiscovery.peerAddedToInput'), 'success')
+                                }}
+                              >
+                                {$t('network.peerDiscovery.add')}
+                              </Button>
+                            {/if}
                           </div>
                         {/each}
                       </div>


### PR DESCRIPTION
fix(network): fix misleading success message on peer connection

  The app showed "Successfully connected to peer!" immediately after a connection attempt, even when the connection
  actually failed. This gave users false feedback about connection status.

Solutions:
  - Removed the immediate success message after connect_to_peer invoke
  - Added connection verification by checking if peer count increases after 2 seconds
  - Show "Connection Success!" only if peer actually appears in Connected Peers list
  - Show "Connection failed. Peer may be unreachable or address invalid." if peer doesn't appear

Before:
<img width="1011" height="570" alt="스크린샷 2025-10-17 오후 5 39 59" src="https://github.com/user-attachments/assets/145274ae-b42f-44be-8f8a-02b3013328c6" />

After:
<img width="1011" height="781" alt="스크린샷 2025-10-17 오후 5 52 27" src="https://github.com/user-attachments/assets/6f0b596a-edd2-4b4c-84f1-4fdfc16c7bbf" />

<img width="980" height="550" alt="스크린샷 2025-10-17 오후 5 47 18" src="https://github.com/user-attachments/assets/4c1963d5-f8ea-48f1-9344-1f8a3e036a6d" />


  fix(network): improve peer connection UX and prevent duplicate connections

 Users could attempt to connect to already-connected peers, wasting time and causing confusion. Also incomplete multiaddresses (without /p2p/ peer IDs) showed "Add" buttons but couldn't be used for connections. No validation before attempting connections.

  Solutions:
  - Added duplicate peer detection before connection attempts
  - Show "Peer is already connected" message when attempting to connect to existing peers
  - Filter peer discovery addresses to only show "Add" buttons for complete multiaddrs containing /p2p/ component
  - Incomplete/observed addresses (like /ip4/10.245.250.25/tcp/58858) now display without "Add" buttons since they can't be used for direct connections

Before:
<img width="949" height="373" alt="스크린샷 2025-10-17 오후 5 59 28" src="https://github.com/user-attachments/assets/12fa7ea0-546e-4e87-ac0e-534600f006a9" />

After: 
<img width="949" height="299" alt="스크린샷 2025-10-17 오후 6 00 01" src="https://github.com/user-attachments/assets/6e90afca-35ff-4a76-9d0a-f5d0ad789dbe" />
