### PR TITLE
feat(dht/manager) added basic processing for separate aes-key dht publishing

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -79,6 +79,7 @@ uuid = { version = "1.0", features = ["v4", "serde"] }
 tauri-plugin-fs = "2"
 ed25519-dalek = { version = "2.0", features = ["rand_core", "serde"] }
 memmap2 = "0.9"
+serde_bytes = "0.11.19"
 
 [dev-dependencies]
 tempfile = "3.8"


### PR DESCRIPTION
This new feature allows separate publishing of canonical AES keys on the DHT. Essentially, users will have to request the AES key to decrypt files/chunks as well. Why is this important:
- Helps make sure the same AES key is used for encryption across seeders (these are still secured under a second layer of encryption using asymmetric encryption based on recipient keys).
- Separate encryption during file publishing from publishing of AES keys, which is dependent upon the recipient, unlike file encryption.
- Allows consistent CIDs among chunk hashes. Before, chunk CIDs would differ because they were based on the encrypted chunks itself (nature of BITSWAP), and AES keys would differ across seeders. 
- **Violated major principle of chiral network.** Identical chunks among different seeders would have different CIDs. Would not allow chunk retrieval from different storage nodes.

Implementation:
- Added basic code/structs for necessary functionality in requesting AES keys
- Created tauri command in `main.rs` to request keys: `request_file_access`.
- Edited the `encrypt_file_for_recipient` function to omit AES key bundling when publishing file metadata (now a separate step)
- Created explicit canonical encryption in manager.rs by altering encryption process.

Next Steps:
- Implement DHT backend for AES publishing
- Integrate publishing of AES-key/key bundle