### PR TITLE
fix: resolve duplicate encrypted_key_bundle fields and async_path module error

### DIFF
--- a/src-tauri/src/dht.rs
+++ b/src-tauri/src/dht.rs
@@ -4144,7 +4144,6 @@ impl DhtService {
             parent_hash,
             cids: None,
             is_root,
-            encrypted_key_bundle: todo!(), // Use computed value, not hardcoded true
         })
     }
 

--- a/src-tauri/src/headless.rs
+++ b/src-tauri/src/headless.rs
@@ -246,7 +246,6 @@ pub async fn run_headless(args: CliArgs) -> Result<(), Box<dyn std::error::Error
             version: Some(1),
             cids: None,
             is_root: true,
-            encrypted_key_bundle: None,
         };
 
         dht_service.publish_file(example_metadata).await?;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -806,7 +806,7 @@ async fn start_dht_node(
         /* enable AutoRelay (after hotfix) */ final_enable_autorelay,
         preferred_relays.unwrap_or_default(),
         is_bootstrap.unwrap_or(false), // enable_relay_server only on bootstrap
-        Some(async_path::new(blockstore_db_path.as_os_str())),
+        Some(async_std::path::Path::new(blockstore_db_path.as_os_str())),
     )
     .await
     .map_err(|e| format!("Failed to start DHT: {}", e))?;
@@ -2344,7 +2344,6 @@ async fn upload_file_chunk(
             cids: Some(vec![root_cid.clone()]), // The root CID for retrieval
             encrypted_key_bundle: None,
             is_root: true,
-            encrypted_key_bundle: None,
         };
 
         // Store complete file data locally for seeding

--- a/src-tauri/src/reputation.rs
+++ b/src-tauri/src/reputation.rs
@@ -309,7 +309,6 @@ impl ReputationDhtService {
             parent_hash: None,
             cids: None, // Not needed for reputation events
             is_root: true,
-            encrypted_key_bundle: None,
         };
 
         dht_service.publish_file(metadata).await
@@ -360,7 +359,6 @@ impl ReputationDhtService {
             parent_hash: None,
             cids: None, // Not needed for merkle roots
             is_root: true,
-            encrypted_key_bundle: None,
         };
 
         dht_service.publish_file(metadata).await


### PR DESCRIPTION
# Summary
This PR fixes compilation errors caused by duplicate field definitions and an incorrect module reference in the Rust codebase.
# Changes Made
Removed duplicate encrypted_key_bundle fields in FileMetadata struct initializations across multiple files:
src/reputation.rs (2 locations)
src/dht.rs (1 location)
src/headless.rs (1 location)
src/main.rs (1 location)
Fixed module reference error in src/main.rs:
Changed async_path::new() to async_std::path::Path::new()
# Technical Details
The duplicate encrypted_key_bundle: None, fields were causing Rust compiler error E0062: field specified more than once. The async_path module was not defined, causing error E0433: failed to resolve: use of unresolved module or unlinked crate.
# Impact
✅ Resolves all compilation errors
✅ Maintains existing functionality
✅ No breaking changes to data structures
✅ Application now runs successfully
# Files Modified
src/reputation.rs
src/dht.rs
src/headless.rs
src/main.rs
# Testing
Application compiles successfully
DHT service starts and connects to peers normally
No runtime errors observed