### PR TITLE
add persistence to protocol selection for download and upload pages

### DIFF
--- a/src/lib/stores/protocolStore.ts
+++ b/src/lib/stores/protocolStore.ts
@@ -1,0 +1,55 @@
+// src/lib/stores/protocolStore.ts
+import { writable } from 'svelte/store';
+
+type Protocol = 'WebRTC' | 'Bitswap' | null;
+
+// Check if we're in a browser environment
+const isBrowser = typeof window !== 'undefined' && typeof localStorage !== 'undefined';
+
+// Initialize from localStorage if available
+const getInitialProtocol = (): Protocol => {
+  if (isBrowser) {
+    try {
+      const stored = localStorage.getItem('selectedProtocol');
+      return (stored as Protocol) || null;
+    } catch (e) {
+      console.warn('Failed to read from localStorage:', e);
+      return null;
+    }
+  }
+  return null;
+};
+
+function createProtocolStore() {
+  const { subscribe, set, update } = writable<Protocol>(getInitialProtocol());
+
+  return {
+    subscribe,
+    set: (value: Protocol) => {
+      if (isBrowser) {
+        try {
+          if (value) {
+            localStorage.setItem('selectedProtocol', value);
+          } else {
+            localStorage.removeItem('selectedProtocol');
+          }
+        } catch (e) {
+          console.warn('Failed to write to localStorage:', e);
+        }
+      }
+      set(value);
+    },
+    reset: () => {
+      if (isBrowser) {
+        try {
+          localStorage.removeItem('selectedProtocol');
+        } catch (e) {
+          console.warn('Failed to remove from localStorage:', e);
+        }
+      }
+      set(null);
+    }
+  };
+}
+
+export const selectedProtocol = createProtocolStore();

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -32,7 +32,9 @@
       "notFound": "Chiral node binary not found",
       "prompt": "Download the Core-Geth binary to run a local node",
       "button": "Download Chiral Node (~50 MB)",
-      "starting": "Starting download..."
+      "starting": "Starting download...",
+      "currentProtocol": "Current Protocol",
+      "changeProtocol": "Change Protocol"
     },
     "startingNode": "Starting Chiral node...",
     "pleaseWait": "Please wait, this may take a moment.",
@@ -1042,7 +1044,11 @@
       "publicKeyHint": "Enter the recipient's X25519 public key (hex format, 64 characters). The file will be encrypted so only they can decrypt it. Leave empty to encrypt for yourself.",
       "invalidPublicKey": "⚠️ Invalid public key format. Must be 64 hexadecimal characters.",
       "encryptedBadge": "Encrypted"
-    }
+    },
+    "currentProtocol": "Current Protocol",
+    "changeProtocol": "Change Protocol",
+    "webrtcDescription": "Fast peer-to-peer transfers using WebRTC",
+    "bitswapDescription": "IPFS-compatible block exchange protocol"
   },
   "bandwidthScheduling": {
     "title": "Bandwidth Scheduling",

--- a/src/pages/Download.svelte
+++ b/src/pages/Download.svelte
@@ -5,7 +5,7 @@
   import Label from '$lib/components/ui/label.svelte'
   import Badge from '$lib/components/ui/badge.svelte'
   import Progress from '$lib/components/ui/progress.svelte'
-  import { Search, Pause, Play, X, ChevronUp, ChevronDown, Settings, FolderOpen, File as FileIcon, FileText, FileImage, FileVideo, FileAudio, Archive, Code, FileSpreadsheet, Presentation, Globe, Blocks } from 'lucide-svelte'
+  import { Search, Pause, Play, X, ChevronUp, ChevronDown, Settings, FolderOpen, File as FileIcon, FileText, FileImage, FileVideo, FileAudio, Archive, Code, FileSpreadsheet, Presentation, Globe, Blocks, RefreshCw } from 'lucide-svelte'  
   import { files, downloadQueue, activeTransfers } from '$lib/stores'
   import { dhtService } from '$lib/dht'
   import DownloadSearchSection from '$lib/components/download/DownloadSearchSection.svelte'
@@ -18,21 +18,23 @@
   import { MultiSourceDownloadService, type MultiSourceProgress } from '$lib/services/multiSourceDownloadService'
   import { listen } from '@tauri-apps/api/event'
   import PeerSelectionService from '$lib/services/peerSelectionService'
-
+import { selectedProtocol as protocolStore } from '$lib/stores/protocolStore'
 
   import { invoke }  from '@tauri-apps/api/core';
 
   const tr = (k: string, params?: Record<string, any>) => (get(t) as any)(k, params)
 
-  // Protocol selection state
-  let selectedProtocol: 'WebRTC' | 'Bitswap';
-  let hasSelectedProtocol = false
+ // Protocol selection state
+  $: selectedProtocol = $protocolStore
+  $: hasSelectedProtocol = selectedProtocol !== null
 
   function handleProtocolSelect(protocol: 'WebRTC' | 'Bitswap') {
-    selectedProtocol = protocol
-    hasSelectedProtocol = true
+    protocolStore.set(protocol)
   }
 
+  function changeProtocol() {
+    protocolStore.reset()
+  }
   onMount(() => {
     initDownloadTelemetry()
 
@@ -1041,6 +1043,33 @@
       on:message={handleSearchMessage}
       isBitswap={selectedProtocol === 'Bitswap'}
     />
+    <!-- Protocol Indicator and Switcher -->
+    <Card class="p-4">
+      <div class="flex items-center justify-between">
+        <div class="flex items-center gap-3">
+          <div class="flex items-center justify-center w-10 h-10 bg-gradient-to-br from-blue-500/10 to-blue-500/5 rounded-lg border border-blue-500/20">
+            {#if selectedProtocol === 'WebRTC'}
+              <Globe class="h-5 w-5 text-blue-600" />
+            {:else}
+              <Blocks class="h-5 w-5 text-blue-600" />
+            {/if}
+          </div>
+          <div>
+            <p class="text-sm font-semibold">{$t('download.currentProtocol')}: {selectedProtocol}</p>
+            <p class="text-xs text-muted-foreground">
+              {selectedProtocol === 'WebRTC' ? $t('upload.webrtcDescription') : $t('upload.bitswapDescription')}
+            </p>
+          </div>
+        </div>
+        <button
+          on:click={changeProtocol}
+          class="inline-flex items-center justify-center h-9 rounded-md px-3 text-sm font-medium border border-input bg-background hover:bg-muted transition-colors"
+        >
+          <RefreshCw class="h-4 w-4 mr-2" />
+          {$t('download.changeProtocol')}
+        </button>
+      </div>
+    </Card>
   {/if}
 
   <!-- Unified Downloads List -->

--- a/src/pages/Upload.svelte
+++ b/src/pages/Upload.svelte
@@ -15,9 +15,9 @@
   import { dhtService } from '$lib/dht';
   import Label from '$lib/components/ui/label.svelte';
   import Input from '$lib/components/ui/input.svelte';
+  import { selectedProtocol as protocolStore } from '$lib/stores/protocolStore';
 
-  const tr = (k: string, params?: Record<string, any>): string => (get(t) as (key: string, params?: any) => string)(k, params)
-  // Check if running in Tauri environment
+  const tr = (k: string, params?: Record<string, any>): string => (get(t) as (key: string, params?: any) => string)(k, params)// Check if running in Tauri environment
   const isTauri = typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window
 
   // Enhanced file type detection with icons
@@ -64,12 +64,17 @@
   let storageError: string | null = null
   let lastChecked: Date | null = null
   let isUploading = false
-  let selectedProtocol: 'WebRTC' | 'Bitswap' | null = null
-  let hasSelectedProtocol = false
+  
+  // Protocol selection state
+  $: selectedProtocol = $protocolStore
+  $: hasSelectedProtocol = selectedProtocol !== null
 
   function handleProtocolSelect(protocol: 'WebRTC' | 'Bitswap') {
-    selectedProtocol = protocol
-    hasSelectedProtocol = true
+    protocolStore.set(protocol)
+  }
+
+  function changeProtocol() {
+    protocolStore.reset()
   }
 
   // Encrypted sharing state
@@ -794,6 +799,31 @@
   {:else}
     <Card>
       <div class="space-y-4" role="region">
+          <!-- Protocol Indicator and Switcher -->
+        <div class="flex items-center justify-between p-4 bg-muted/50 rounded-lg">
+          <div class="flex items-center gap-3">
+            <div class="flex items-center justify-center w-10 h-10 bg-gradient-to-br from-blue-500/10 to-blue-500/5 rounded-lg border border-blue-500/20">
+              {#if selectedProtocol === 'WebRTC'}
+                <Globe class="h-5 w-5 text-blue-600" />
+              {:else}
+                <Blocks class="h-5 w-5 text-blue-600" />
+              {/if}
+            </div>
+            <div>
+              <p class="text-sm font-semibold">{$t('upload.currentProtocol')}: {selectedProtocol}</p>
+              <p class="text-xs text-muted-foreground">
+                {selectedProtocol === 'WebRTC' ? $t('upload.webrtcDescription') : $t('upload.bitswapDescription')}
+              </p>
+            </div>
+          </div>
+          <button
+            on:click={changeProtocol}
+            class="inline-flex items-center justify-center h-9 rounded-md px-3 text-sm font-medium border border-input bg-background hover:bg-muted transition-colors"
+          >
+            <RefreshCw class="h-4 w-4 mr-2" />
+            {$t('upload.changeProtocol')}
+          </button>
+        </div>
         <div class="space-y-4">
           <!-- Drag & Drop Indicator -->
           {#if $files.filter(f => f.status === 'seeding' || f.status === 'uploaded').length === 0}


### PR DESCRIPTION
- Make selection of webrtc or bitswap protocols persistent 
- Create small section to indicate current protocol selection and allow changes to protocol
- Keep selected protocol consistent across download and upload pages