### PR TITLE
fix(settings): fix save storage settings

### DIFF
--- a/src/pages/Settings.svelte
+++ b/src/pages/Settings.svelte
@@ -84,8 +84,8 @@
     enableBandwidthScheduling: false,
     bandwidthSchedules: [],
   };
-  let localSettings: AppSettings = get(settings); 
-  let savedSettings: AppSettings = get(settings);
+  let localSettings: AppSettings = JSON.parse(JSON.stringify(get(settings)));
+  let savedSettings: AppSettings = JSON.parse(JSON.stringify(localSettings));
   let hasChanges = false;
   let fileInputEl: HTMLInputElement | null = null;
   let selectedLanguage: string | undefined = undefined;
@@ -475,8 +475,8 @@
     // Set the store, which ensures it is available globally
     settings.set({ ...defaultSettings, ...loadedSettings }); 
     // Update local state from the store after loading
-    localSettings = get(settings); 
-    savedSettings = get(settings); 
+    localSettings = JSON.parse(JSON.stringify(get(settings)));
+    savedSettings = JSON.parse(JSON.stringify(localSettings)); 
   } catch (e) {
     console.error("Failed to load settings:", e);
   }
@@ -1402,7 +1402,7 @@ function sectionMatches(section: string, query: string) {
         variant="outline"
         size="xs"
         disabled={!hasChanges}
-        on:click={() => (localSettings = { ...savedSettings })}
+        on:click={() => (localSettings = JSON.parse(JSON.stringify(savedSettings)))}
         class={`transition-colors duration-200 ${!hasChanges ? "cursor-not-allowed opacity-50" : ""}`}
       >
         {$t("actions.cancel")}


### PR DESCRIPTION
Previously, updating the storage path field did not enable the **“Save Settings”** button.

This fix ensures the button now enables correctly when the storage path changes, allowing settings to be saved directly through the UI.