### PR TITLE
feat(settings): add storage path validation, default path retrieval, and Windows directory format

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1854,6 +1854,26 @@ fn detect_locale() -> String {
 }
 
 #[tauri::command]
+fn get_default_storage_path(app: tauri::AppHandle) -> Result<String, String> {
+    let app_data_dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("Could not get app data directory: {}", e))?;
+    
+    let storage_path = app_data_dir.join("Storage");
+    
+    storage_path
+        .to_str()
+        .map(|s| s.to_string())
+        .ok_or_else(|| "Failed to convert path to string".to_string())
+}
+
+#[tauri::command]
+fn check_directory_exists(path: String) -> bool {
+    Path::new(&path).is_dir()
+}
+
+#[tauri::command]
 async fn start_file_transfer_service(
     app: tauri::AppHandle,
     state: State<'_, AppState>,
@@ -3851,6 +3871,8 @@ fn main() {
             connect_to_peer,
             get_dht_events,
             detect_locale,
+            get_default_storage_path,
+            check_directory_exists,
             get_dht_health,
             get_dht_peer_count,
             get_dht_peer_id,


### PR DESCRIPTION
- On Windows, the local storage directory is displayed in the Windows directory format 
- When the user enters a directory that does not exist, a warning is shown

Before:
<img width="2470" height="785" alt="dir_not_exist_no_warning" src="https://github.com/user-attachments/assets/c7f8dd4a-5571-4559-8a9e-e112292f2165" />
<img width="2417" height="822" alt="unix_dir" src="https://github.com/user-attachments/assets/e88d90e9-abfc-4a94-a394-85531fe6c46e" />

After:
<img width="2450" height="835" alt="dir_not_exist" src="https://github.com/user-attachments/assets/61191e82-1737-4dab-85a0-e30257f69361" />
<img width="2450" height="755" alt="windows-dir-format" src="https://github.com/user-attachments/assets/32eb7b80-5c8c-40bf-9118-60bbb75bf8bf" />
