### PR TITLE
docs: Proposing New Document with Tauri Commands

### DIFF
--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -911,3 +911,7 @@ func main() {
 
 ## Testing
 Testing API documentation to be added here later.
+
+### Desktop Command Reference
+
+For Tauri command documentation (local desktop functionality), see the dedicated [Tauri Command Reference](tauri-commands.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,8 @@ Welcome to the Chiral Network documentation. This directory contains comprehensi
 ### Technical Documentation
 - [Technical Specifications](technical-specifications.md) - Detailed technical specs, protocols, and data structures
 - [Network Protocol](network-protocol.md) - P2P networking, DHT, NAT traversal, and relay infrastructure
-- [API Documentation](api-documentation.md) - Service APIs, Tauri commands, and integration guides
+- [API Documentation](api-documentation.md) - Service APIs and integration guides
+- [Tauri Command Reference](tauri-commands.md) - Desktop invoke commands and local services
 
 ### Implementation & Deployment
 - [Implementation Guide](implementation-guide.md) - Development workflows, coding standards, and best practices

--- a/docs/tauri-commands.md
+++ b/docs/tauri-commands.md
@@ -1,0 +1,137 @@
+# Tauri Command Reference
+
+Local functionality inside the desktop app is exposed through Tauri commands and accessed from the Svelte frontend with `invoke(...)`. These commands run on the user’s machine; they are not part of the public HTTP/WebSocket API.
+
+> **Usage Pattern**
+> ```ts
+> import { invoke } from '@tauri-apps/api/core';
+> await invoke('<command-name>', { /* parameters */ });
+> ```
+
+## Mining Control
+
+### `start_miner`
+- **Parameters**
+  - `address: string`
+  - `threads: number`
+  - `data_dir: string`
+- **Returns**: `void` (promise resolves on success)
+- **Description**: Starts CPU mining against the bundled geth instance. The command caches the etherbase address, tries `miner_setEtherbase`, and if unsupported restarts geth with the new configuration before issuing `miner_start`.
+- **Example**
+  ```ts
+  await invoke('start_miner', {
+    address: account.address,
+    threads: 4,
+    data_dir: '/Users/me/.chiral/geth-data'
+  });
+  ```
+
+### `stop_miner`
+- **Parameters**: *(none)*
+- **Returns**: `void`
+- **Description**: Stops any active mining threads via `miner_stop`.
+
+### `get_miner_status`
+- **Parameters**: *(none)*
+- **Returns**: `boolean` – `true` if mining is currently active.
+- **Description**: Convenience check used to toggle the mining UI.
+
+### `get_miner_hashrate`
+- **Parameters**: *(none)*
+- **Returns**: `string` – current hashrate reported by geth (e.g., `"125 MH/s"`).
+- **Description**: Pulls the miner hashrate from the local RPC.
+
+## Mining Insights
+
+### `get_current_block`
+- **Parameters**: *(none)*
+- **Returns**: `number` – current block height.
+- **Description**: Reads `eth_blockNumber` from the local geth RPC.
+
+### `get_network_stats`
+- **Parameters**: *(none)*
+- **Returns**: `[{ difficulty: string }, { hashrate: string }]` as a tuple.
+- **Description**: Fetches network difficulty and aggregate hashrate for dashboard displays.
+
+### `get_miner_logs`
+- **Parameters**
+  - `data_dir: string`
+  - `lines: number`
+- **Returns**: `string[]` – newest log lines.
+- **Description**: Tails the miner log located in the provided geth data directory.
+- **Example**
+  ```ts
+  const logs = await invoke<string[]>('get_miner_logs', {
+    data_dir: '/Users/me/.chiral/geth-data',
+    lines: 200
+  });
+  ```
+
+### `get_miner_performance`
+- **Parameters**
+  - `data_dir: string`
+- **Returns**: `{ blocksFound: number; averageHashrate: number }`
+- **Description**: Parses miner logs to surface blocks found and average hashrate.
+
+### `get_blocks_mined`
+- **Parameters**
+  - `address: string`
+- **Returns**: `number` – total blocks credited to the address.
+- **Description**: Queries the local node and caches the result briefly (500 ms) to avoid repeated heavy calls.
+
+### `get_recent_mined_blocks_pub`
+- **Parameters**
+  - `address: string`
+  - `lookback: number`
+  - `limit: number`
+- **Returns**: `Array<{ hash: string; timestamp: number; reward?: number }>`
+- **Description**: Retrieves recent mined block metadata for history UIs.
+
+## Mining Pools *(Mock Data)*
+
+These commands currently operate on in-memory mock data to support “progressive decentralization.” They do **not** contact live pool infrastructure.
+
+### `discover_mining_pools`
+- **Parameters**: *(none)*
+- **Returns**: `MiningPool[]`
+- **Description**: Combines predefined and user-created mock pools after a simulated discovery delay.
+
+### `create_mining_pool`
+- **Parameters**
+  - `address: string`
+  - `name: string`
+  - `description: string`
+  - `fee_percentage: number`
+  - `min_payout: number`
+  - `payment_method: string`
+  - `region: string`
+- **Returns**: `MiningPool`
+- **Description**: Registers a mock pool owned by the caller and stores it in the in-memory directory.
+
+### `join_mining_pool`
+- **Parameters**
+  - `pool_id: string`
+  - `address: string`
+- **Returns**: `JoinedPoolInfo`
+- **Description**: Simulates joining a pool and produces placeholder stats. Errors if a pool is already “connected.”
+
+### `leave_mining_pool`
+- **Parameters**: *(none)*
+- **Returns**: `void`
+- **Description**: Clears the current mock pool membership with a simulated disconnect delay.
+
+### `get_current_pool_info`
+- **Parameters**: *(none)*
+- **Returns**: `JoinedPoolInfo | null`
+- **Description**: Returns the stored mock pool session if one exists.
+
+### `get_pool_stats`
+- **Parameters**: *(none)*
+- **Returns**: `PoolStats | null`
+- **Description**: Generates synthetic stats (shares, hashrate, payout) based on elapsed “mining time.”
+
+### `update_pool_discovery`
+- **Parameters**: *(none)*
+- **Returns**: `void`
+- **Description**: Mutates the mock pool list (miner counts, block times) to emulate new network data.
+


### PR DESCRIPTION
Currently in the repository we have an docs/api-documentation.md, but in our repository we do not have any current APIs implemented.  

However, we do have many tauri-commands as that's how we're letting our Svelte frontend communicate with our Rust backend.  

Having a tauri-commands document for developers will be useful in such a format as this will give us an easier way to glance at what work has been done in certain areas and may help with DRY principles as some functionality could already be implemented without a developer realizing.  

I did not want to remove the API-documentation in it's entirety as I'm not entirely sure if we will have APIs in the future. 

