### PR TITLE
fix: show correct connected status in the menu bar

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1097,6 +1097,12 @@ async fn connect_to_peer(state: State<'_, AppState>, peer_address: String) -> Re
 }
 
 #[tauri::command]
+async fn is_dht_running(state: State<'_, AppState>) -> Result<bool, String> {
+    let dht_guard = state.dht.lock().await;
+    Ok(dht_guard.is_some())
+}
+
+#[tauri::command]
 async fn get_dht_peer_count(state: State<'_, AppState>) -> Result<usize, String> {
     let dht = {
         let dht_guard = state.dht.lock().await;

--- a/src/lib/services/networkService.ts
+++ b/src/lib/services/networkService.ts
@@ -1,27 +1,60 @@
 import { writable } from 'svelte/store';
 import { invoke } from '@tauri-apps/api/core';
+import { listen } from '@tauri-apps/api/event';
 
 // Export network status store
 export const networkStatus = writable<"connected" | "disconnected">("disconnected");
 
+// Track real-time DHT connection status
+let dhtConnectedPeerCount = 0;
+
+// Set up event listeners for DHT peer connection changes
+export function setupDhtEventListeners(): void {
+  // Listen for peer connections
+  listen<{ peer_id: string; address: string }>('dht_peer_connected', () => {
+    dhtConnectedPeerCount++;
+    console.log(`✅ DHT peer connected. Total connected peers: ${dhtConnectedPeerCount}`);
+    updateNetworkStatusFromDht();
+  }).catch((err) => console.error('Failed to listen to dht_peer_connected:', err));
+
+  // Listen for peer disconnections
+  listen<{ peer_id: string }>('dht_peer_disconnected', () => {
+    dhtConnectedPeerCount = Math.max(0, dhtConnectedPeerCount - 1);
+    console.log(`❌ DHT peer disconnected. Total connected peers: ${dhtConnectedPeerCount}`);
+    updateNetworkStatusFromDht();
+  }).catch((err) => console.error('Failed to listen to dht_peer_disconnected:', err));
+}
+
+// Update network status based on DHT peer count
+function updateNetworkStatusFromDht(): void {
+  if (dhtConnectedPeerCount > 0) {
+    networkStatus.set("connected");
+  } else {
+    networkStatus.set("disconnected");
+  }
+}
+
 // Function to update network status
 export async function updateNetworkStatus(): Promise<void> {
   try {
-    // Check Geth and DHT status in parallel
-    const [isGethRunning, dhtPeers, blockchainPeers] = await Promise.all([
-      invoke<boolean>('is_geth_running').catch(() => false),
-      invoke<number>('get_dht_peer_count').catch(() => 0),
-      invoke<number>('get_network_peer_count').catch(() => 0)
+    // Check if DHT is running and has peers
+    const [isDhtRunning, dhtPeers] = await Promise.all([
+      invoke<boolean>('is_dht_running').catch(() => false),
+      invoke<number>('get_dht_peer_count').catch(() => 0)
     ]);
     
+    // Update cached DHT peer count
+    dhtConnectedPeerCount = dhtPeers;
+    
     // Determine network connection status
-    if (isGethRunning && (dhtPeers > 0 || blockchainPeers > 0)) {
+    // Status is "connected" only if DHT is running AND has at least 1 peer
+    if (isDhtRunning && dhtPeers > 0) {
       networkStatus.set("connected");
     } else {
       networkStatus.set("disconnected");
     }
     
-    console.log(`🌐 Network status updated: ${isGethRunning ? 'Node running' : 'Node stopped'}, DHT peers: ${dhtPeers}, Blockchain peers: ${blockchainPeers}`);
+    console.log(`🌐 Network status updated: DHT ${isDhtRunning ? 'running' : 'stopped'}, DHT peers: ${dhtPeers}`);
     
   } catch (error) {
     console.error('Failed to update network status:', error);
@@ -33,10 +66,13 @@ export async function updateNetworkStatus(): Promise<void> {
 export function startNetworkMonitoring(): () => void {
   console.log('🔄 Starting network status monitoring');
   
+  // Set up event listeners for real-time DHT connection updates
+  setupDhtEventListeners();
+  
   // Check immediately
   updateNetworkStatus();
   
-  // Check every 3 seconds
+  // Check every 3 seconds as fallback
   const interval = setInterval(updateNetworkStatus, 3000);
   
   // Return cleanup function


### PR DESCRIPTION

<img width="1571" height="980" alt="image" src="https://github.com/user-attachments/assets/694e8918-5fec-4ea2-a786-6a7ebc1f78e9" />

<img width="1568" height="968" alt="image" src="https://github.com/user-attachments/assets/79c8d09a-7d61-4431-8eb3-efc57a9027b7" />


Behavior:

✅ Shows RED until user clicks "Connect to DHT" button
✅ Shows GREEN after DHT initializes and connects to at least 1 peer
✅ Updates in real-time when peers connect/disconnect

- Added is_dht_running() command to backend to check if DHT service is initialized
- Updated networkStatus logic to require both:
  1. DHT service is running (not just initialized)
  2. DHT has at least 1 connected peer
- Connection indicator now shows red until user clicks 'Connect to DHT' button
- Real-time event listeners still active for immediate updates when peers connect/disconnect
- Fixes false 'connected' status that was shown before DHT initialization