### PR TITLE
refactor: replace .unwrap() with safe error handling in analytics and…

### DIFF
--- a/src-tauri/src/analytics.rs
+++ b/src-tauri/src/analytics.rs
@@ -90,7 +90,7 @@ impl AnalyticsService {
     pub fn new() -> Self {
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .unwrap()
+            .unwrap_or(std::time::Duration::from_secs(0))
             .as_secs();
 
         Self {
@@ -138,7 +138,7 @@ impl AnalyticsService {
         bandwidth.upload_bytes += bytes;
         bandwidth.last_updated = SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .unwrap()
+            .unwrap_or(std::time::Duration::from_secs(0))
             .as_secs();
 
         let mut contribution = self.resource_contribution.lock().await;
@@ -153,7 +153,7 @@ impl AnalyticsService {
         bandwidth.download_bytes += bytes;
         bandwidth.last_updated = SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .unwrap()
+            .unwrap_or(std::time::Duration::from_secs(0))
             .as_secs();
 
         self.maybe_record_history().await;
@@ -267,7 +267,7 @@ impl AnalyticsService {
     async fn maybe_record_history(&self) {
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .unwrap()
+            .unwrap_or(std::time::Duration::from_secs(0))
             .as_secs();
 
         let mut last_update = self.last_history_update.lock().await;
@@ -365,7 +365,7 @@ impl AnalyticsService {
     pub async fn reset_stats(&self) {
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .unwrap()
+            .unwrap_or(std::time::Duration::from_secs(0))
             .as_secs();
 
         *self.current_bandwidth.lock().await = BandwidthStats {

--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -23,7 +23,7 @@ pub(crate) async fn generate_proxy_auth_token(
     // Calculate expiry time
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
+        .unwrap_or(std::time::Duration::from_secs(0))
         .as_secs();
     let expires_at = now + (expiry_hours as u64 * 3600);
 
@@ -110,7 +110,7 @@ fn generate_secure_token() -> String {
 fn is_token_expired(expires_at: u64) -> bool {
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
+        .unwrap_or(std::time::Duration::from_secs(0))
         .as_secs();
     now > expires_at
 }
@@ -119,7 +119,7 @@ fn is_token_expired(expires_at: u64) -> bool {
 fn cleanup_expired_tokens(store: &mut HashMap<String, ProxyAuthToken>) {
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
+        .unwrap_or(std::time::Duration::from_secs(0))
         .as_secs();
 
     store.retain(|_, token_data| !is_token_expired(token_data.expires_at));

--- a/src-tauri/src/two_fa.rs
+++ b/src-tauri/src/two_fa.rs
@@ -225,6 +225,9 @@ pub fn disable_2fa(app_handle: tauri::AppHandle, active_account: State<'_, Activ
 /// Sets the active account in the backend state (e.g., after a successful login).
 #[tauri::command]
 pub fn login(address: String, active_account: State<'_, ActiveAccount>) {
-    let mut address_lock = active_account.0.lock().unwrap();
-    *address_lock = Some(address);
+    if let Ok(mut address_lock) = active_account.0.lock() {
+        *address_lock = Some(address);
+    } else {
+        tracing::error!("Failed to acquire lock for active account during login");
+    }
 }


### PR DESCRIPTION
Replace panic-prone .unwrap() calls with proper error handling to improve application stability and prevent crashes from poisoned mutexes or time calculation failures.

**Changes in analytics.rs (5 instances):**
- AnalyticsService::new(): Use fallback timestamp of 0 on UNIX_EPOCH error
- record_upload(): Safe timestamp generation with fallback
- record_download(): Safe timestamp generation with fallback
- maybe_record_history(): Safe timestamp generation with fallback
- reset_stats(): Safe timestamp generation with fallback

**Changes in main.rs (11 instances):**
- get_blocks_mined(): Replace unwrap() with ? operator for cache lock - prevents panic if mutex is poisoned
- get_current_cpu_temperature(): Replace unwrap() with .ok()? for temperature_history mutex lock (2 instances)
- get_current_cpu_temperature(): Replace unwrap() with .ok()? for working_method mutex lock (4 instances)
- log_temperature_check(): Replace unwrap() with if let Ok() pattern for log_state mutex lock (4 instances)

**Changes in auth.rs (3 instances):**
- generate_proxy_auth_token(): Use unwrap_or_else fallback for UNIX_EPOCH time calculation
- is_token_expired(): Use unwrap_or fallback for UNIX_EPOCH time calculation
- cleanup_expired_tokens(): Use unwrap_or fallback for UNIX_EPOCH time calculation

**Changes in two_fa.rs (1 instance):**
- login(): Replace unwrap() with if let Ok() pattern for active_account mutex lock with error logging

**Total: 20 .unwrap() replacements across 4 files**