### PR TITLE
docs: Fix file hash format inconsistencies

### DIFF
--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -59,7 +59,7 @@ encryption_key: string (optional)
 ```json
 {
   "success": true,
-  "file_hash": "0xa7d8f9e8c7b6a5d4f3e2d1c0b9a8d7f6e5d4c3b2a1098765432100abcdef123456",
+  "file_hash": "a7d8f9e8c7b6a5d4f3e2d1c0b9a8d7f6e5d4c3b2a1098765432100abcdef123456",
   "chunks": [
     {
       "index": 0,
@@ -105,7 +105,7 @@ GET /api/v1/files/{file_hash}/info
 
 ```json
 {
-  "file_hash": "0xa7d8f9e8c7b6a5d4f3e2d1c0b9a8d7f6e5d4c3b2a1098765432100abcdef123456",
+  "file_hash": "a7d8f9e8c7b6a5d4f3e2d1c0b9a8d7f6e5d4c3b2a1098765432100abcdef123456",
   "file_name": "document.pdf",
   "file_size": 10485760,
   "mime_type": "application/pdf",
@@ -159,7 +159,7 @@ GET /api/v1/files/list
 {
   "files": [
     {
-      "file_hash": "0xa7d8f9e8c7b6a5d4f3e2d1c0b9a8d7f6e5d4c3b2a1098765432100abcdef123456",
+      "file_hash": "a7d8f9e8c7b6a5d4f3e2d1c0b9a8d7f6e5d4c3b2a1098765432100abcdef123456",
       "name": "document.pdf",
       "size": 10485760,
       "uploaded_at": 1234567890,
@@ -574,7 +574,7 @@ ws.onopen = () => {
     JSON.stringify({
       type: "subscribe",
       channels: ["blocks", "transactions", "peers", "files"],
-    }),
+    })
   );
 };
 ```
@@ -632,7 +632,7 @@ ws.onopen = () => {
 {
   "type": "file_progress",
   "data": {
-    "file_hash": "0xa7d8f9e8c7b6a5d4f3e2d1c0b9a8d7f6e5d4c3b2a1098765432100abcdef123456",
+    "file_hash": "a7d8f9e8c7b6a5d4f3e2d1c0b9a8d7f6e5d4c3b2a1098765432100abcdef123456",
     "action": "upload" | "download",
     "progress": 75.5,
     "speed": 1048576,
@@ -670,7 +670,7 @@ ws.onopen = () => {
 ```json
 {
   "type": "request_chunk",
-  "file_hash": "0xa7d8f9e8c7b6a5d4f3e2d1c0b9a8d7f6e5d4c3b2a1098765432100abcdef123456",
+  "file_hash": "a7d8f9e8c7b6a5d4f3e2d1c0b9a8d7f6e5d4c3b2a1098765432100abcdef123456",
   "chunk_index": 5,
   "peer_id": "12D3KooWExample"
 }
@@ -730,7 +730,7 @@ ws.onopen = () => {
   "jsonrpc": "2.0",
   "method": "chiral_getFileInfo",
   "params": [
-    "0xa7d8f9e8c7b6a5d4f3e2d1c0b9a8d7f6e5d4c3b2a1098765432100abcdef123456"
+    "a7d8f9e8c7b6a5d4f3e2d1c0b9a8d7f6e5d4c3b2a1098765432100abcdef123456"
   ],
   "id": 1
 }
@@ -766,19 +766,19 @@ ws.onopen = () => {
 
 ### Application Error Codes
 
-| Code | Name               | Description                   |
-| ---- | ------------------ | ----------------------------- |
-| 1000 | NETWORK_ERROR      | Network connectivity issue    |
-| 1001 | TIMEOUT            | Operation timed out           |
-| 1002 | INVALID_HASH       | Invalid file hash format      |
-| 1003 | FILE_NOT_FOUND     | File not in network           |
-| 1004 | INSUFFICIENT_FUNDS | Not enough balance            |
-| 1005 | PERMISSION_DENIED  | Access not authorized         |
+| Code | Name               | Description                    |
+| ---- | ------------------ | ------------------------------ |
+| 1000 | NETWORK_ERROR      | Network connectivity issue     |
+| 1001 | TIMEOUT            | Operation timed out            |
+| 1002 | INVALID_HASH       | Invalid file hash format       |
+| 1003 | FILE_NOT_FOUND     | File not in network            |
+| 1004 | INSUFFICIENT_FUNDS | Not enough balance             |
+| 1005 | PERMISSION_DENIED  | Access not authorized          |
 | 1006 | STORAGE_FULL       | Node provider capacity reached |
-| 1007 | INVALID_CHUNK      | Chunk verification failed     |
-| 1008 | PEER_UNREACHABLE   | Cannot connect to peer        |
-| 1009 | INVALID_SIGNATURE  | Transaction signature invalid |
-| 1010 | NONCE_TOO_LOW      | Transaction nonce too low     |
+| 1007 | INVALID_CHUNK      | Chunk verification failed      |
+| 1008 | PEER_UNREACHABLE   | Cannot connect to peer         |
+| 1009 | INVALID_SIGNATURE  | Transaction signature invalid  |
+| 1010 | NONCE_TOO_LOW      | Transaction nonce too low      |
 
 ## Rate Limiting
 
@@ -910,6 +910,7 @@ func main() {
 ```
 
 ## Testing
+
 Testing API documentation to be added here later.
 
 ### Desktop Command Reference

--- a/docs/technical-specifications.md
+++ b/docs/technical-specifications.md
@@ -251,14 +251,14 @@ Message Structure:
 
 ### Algorithms
 
-| Purpose                | Algorithm   | Parameters                |
-| ---------------------- | ----------- | ------------------------- |
-| **File Hashing**       | Keccak-256  | 256-bit output            |
-| **File Encryption**    | AES-256-GCM | 256-bit key, 96-bit nonce |
-| **Key Derivation**     | PBKDF2      | SHA-256, 100k iterations  |
-| **Digital Signatures** | ECDSA       | secp256k1 curve           |
-| **Account Addresses**  | Keccak-256  | Last 20 bytes of hash     |
-| **Random Generation**  | CSPRNG      | System entropy            |
+| Purpose                | Algorithm   | Parameters                          |
+| ---------------------- | ----------- | ----------------------------------- |
+| **File Hashing**       | SHA-256     | 256-bit output, plain hex (no `0x`) |
+| **File Encryption**    | AES-256-GCM | 256-bit key, 96-bit nonce           |
+| **Key Derivation**     | PBKDF2      | SHA-256, 100k iterations            |
+| **Digital Signatures** | ECDSA       | secp256k1 curve                     |
+| **Account Addresses**  | Keccak-256  | Last 20 bytes of hash (with `0x`)   |
+| **Random Generation**  | CSPRNG      | System entropy                      |
 
 ### Key Management
 
@@ -274,10 +274,10 @@ Master Key (from mnemonic)
 
 ### Transaction Types
 
-| Type                | Description          | Base Gas Cost |
-| ------------------- | -------------------- | ------------- |
-| **Transfer**        | Send coins           | 21,000 gas    |
-| **File Access**     | Access stored file   | 30,000 gas    |
+| Type            | Description        | Base Gas Cost |
+| --------------- | ------------------ | ------------- |
+| **Transfer**    | Send coins         | 21,000 gas    |
+| **File Access** | Access stored file | 30,000 gas    |
 
 ### Transaction Structure
 
@@ -343,12 +343,14 @@ Handshake {
 
 ### File Hash Format
 
-The file hash is the hex-encoded SHA-256 Merkle root of the file's original chunks. It is a standard 64-character hexadecimal string.
+The file hash is the hex-encoded SHA-256 Merkle root of the file's original chunks. It is a standard 64-character hexadecimal string **without** the `0x` prefix.
 
 **Format**: `<merkle_root_hash>`
 **Example**: `7d8f9e8c7b6a5d4f3e2d1c0b9a8d7f6e5d4c3b2a17d8f9e8c7b6a5d4f3e2d1c0`
 
-- **Hash**: SHA-256 Merkle root in hex (64 chars)
+- **Hash**: SHA-256 Merkle root in hex (64 chars, no `0x` prefix)
+
+**Note**: File hashes do NOT use the `0x` prefix. This distinguishes them from Ethereum-style addresses and blockchain hashes, which DO use the `0x` prefix.
 
 (Note: The `version` of a file is tracked as a separate field in the DHT Record, not as part of the hash string itself.)
 
@@ -366,18 +368,18 @@ Example: 0x742d35Cc6634C0532925a3b8D0C9e0c8b346b983
 
 ### System Error Codes
 
-| Code | Name               | Description                   |
-| ---- | ------------------ | ----------------------------- |
-| 1000 | NETWORK_ERROR      | Network connectivity issue    |
-| 1001 | TIMEOUT            | Operation timed out           |
-| 1002 | INVALID_HASH       | Invalid file hash format      |
-| 1003 | FILE_NOT_FOUND     | File not in network           |
-| 1004 | INSUFFICIENT_FUNDS | Not enough balance            |
-| 1005 | PERMISSION_DENIED  | Access not authorized         |
+| Code | Name               | Description                                |
+| ---- | ------------------ | ------------------------------------------ |
+| 1000 | NETWORK_ERROR      | Network connectivity issue                 |
+| 1001 | TIMEOUT            | Operation timed out                        |
+| 1002 | INVALID_HASH       | Invalid file hash format                   |
+| 1003 | FILE_NOT_FOUND     | File not in network                        |
+| 1004 | INSUFFICIENT_FUNDS | Not enough balance                         |
+| 1005 | PERMISSION_DENIED  | Access not authorized                      |
 | 1006 | STORAGE_FULL       | Local storage capacity reached (this peer) |
-| 1007 | INVALID_CHUNK      | Chunk verification failed     |
-| 1008 | DHT_TIMEOUT        | DHT lookup timeout            |
-| 1009 | PEER_UNREACHABLE   | Cannot connect to peer        |
+| 1007 | INVALID_CHUNK      | Chunk verification failed                  |
+| 1008 | DHT_TIMEOUT        | DHT lookup timeout                         |
+| 1009 | PEER_UNREACHABLE   | Cannot connect to peer                     |
 
 ## Quality of Service
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1246,6 +1246,7 @@
       "integrity": "sha512-nJsV36+o7rZUDlrnSduMNl11+RoDE1cKqOI0yUEBCcqFoAZOk47TwD3dPKS2WmRutke9StXnzsPBslY7prDM9w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@sveltejs/vite-plugin-svelte-inspector": "^5.0.0",
         "debug": "^4.4.1",
@@ -1637,6 +1638,7 @@
       "integrity": "sha512-TGf22kon8KW+DeKaUmOibKWktRY8b2NSAZNdtWh798COm1NWx8+xJ6iFBtk3IvLdv6+LGLJLRlyhrhEDZWargQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.45.0",
         "@typescript-eslint/types": "8.45.0",
@@ -1914,6 +1916,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2177,6 +2180,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.3",
         "caniuse-lite": "^1.0.30001741",
@@ -2743,6 +2747,7 @@
       "integrity": "sha512-hB4FIzXovouYzwzECDcUkJ4OcfOEkXTv2zRY6B9bkwjx/cprAq0uvm1nl7zvQ0/TsUk0zQiN4uPfJpB9m+rPMQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3594,6 +3599,7 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -4076,6 +4082,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4129,6 +4136,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -4329,6 +4337,7 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -4819,6 +4828,7 @@
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.39.3.tgz",
       "integrity": "sha512-7Jwus6iXviGZAvhqbeYu3NNHA6LGyQ8EbmjdAhJUDade5rrW6g9VnBbRhUuYX4pMZLHozijsFolt88zvKPfsbQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -5006,6 +5016,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
       "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -5265,6 +5276,7 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5333,6 +5345,7 @@
       "integrity": "sha512-SRYIB8t/isTwNn8vMB3MR6E+EQZM/WG1aKmmIUCfDXfVvKfc20ZpamngWHKzAmmu9ppsgxsg4b2I7c90JZudIQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -6907,6 +6920,7 @@
       "integrity": "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",


### PR DESCRIPTION
This PR fixes inconsistencies in file hash format documentation and corrects the hash algorithm specification.

- Removed incorrect `0x` prefix from all file hash examples across API documentation to match the actual implementation which uses plain 64-character hexadecimal strings
- Corrected cryptographic algorithm from Keccak-256 to SHA-256 for file hashing in technical specifications to align with the codebase
- Added clear documentation distinguishing file hashes (plain hex, no prefix) from blockchain hashes (Ethereum-style with `0x` prefix) to prevent confusion between content addressing and payment layers