### PR TITLE
refactor: replace .expect() with proper Result error handling

### DIFF
--- a/src-tauri/src/dht.rs
+++ b/src-tauri/src/dht.rs
@@ -2912,7 +2912,13 @@ async fn run_dht_node(
                                         info!("Chunk offsets: {:?}", chunk_offsets);
 
                                         info!("About to create ActiveDownload for file: {}", metadata.merkle_root);
-                                        let download_path = PathBuf::from_str(metadata.download_path.as_ref().expect("Error: download_path not defined"));
+                                        let download_path = match metadata.download_path.as_ref() {
+                                            Some(path_str) => PathBuf::from_str(path_str),
+                                            None => {
+                                                error!("Download path not defined for file: {}", metadata.merkle_root);
+                                                return;
+                                            }
+                                        };
                                         let download_path = match download_path {
                                             Ok(path) => get_available_download_path(path).await,
                                             Err(e) => {
@@ -4983,12 +4989,17 @@ impl DhtService {
         // Use the new relay-aware transport builder
         let transport = build_transport_with_relay(&local_key, relay_transport, proxy_address)?;
 
+        // Extract behaviour or return error if already taken
+        let behaviour_instance = behaviour.take().ok_or_else(|| {
+            Box::<dyn Error>::from("behaviour already taken")
+        })?;
+
         // Create the swarm
         let mut swarm = SwarmBuilder::with_existing_identity(local_key)
             .with_tokio()
             .with_other_transport(|_| Ok(transport))
-            .expect("Failed to create libp2p transport")
-            .with_behaviour(move |_| behaviour.take().expect("behaviour already taken"))?
+            .map_err(|e| format!("Failed to create libp2p transport: {}", e))?
+            .with_behaviour(move |_| behaviour_instance)?
             .with_swarm_config(
                 |c| c.with_idle_connection_timeout(Duration::from_secs(300)), // 5 minutes
             )


### PR DESCRIPTION
Replace panic-inducing .expect() calls with proper error propagation:

- keystore.rs: PBKDF2 key derivation now returns Result
  - derive_key() returns Result<[u8; 32], String> with error propagation
  - Updated encrypt_data() and decrypt_data() to handle Result
  - Changed try_decrypt() to accept Option-returning closures
  - All callers updated to use ? operator for error propagation

- dht.rs: Network initialization and file downloads use safe error handling
  - download_path .expect() replaced with Option checking and early return
  - libp2p transport creation .expect() replaced with .map_err()
  - behaviour extraction .expect() replaced with .ok_or_else() before use

These changes prevent application crashes on crypto errors, missing metadata, and network initialization failures. Errors are now properly propagated up the call stack for graceful handling.