### PR TITLE
feat: Add BitTorrentHandler skeleton

### DIFF
--- a/src-tauri/src/bittorrent.rs
+++ b/src-tauri/src/bittorrent.rs
@@ -1,0 +1,66 @@
+//! Skeleton for BitTorrent protocol handling.
+//!
+//! Basic structure for integrating BitTorrent functionality
+//! for downloading and seeding files. The current implementation contains stubs
+//! with logging to trace function calls, intended for future integration with a
+//! full BitTorrent client library.
+
+use anyhow::Result;
+use std::path::Path;
+use tracing::{info, instrument};
+
+/// A trait for handling BitTorrent operations like downloading and seeding.
+#[async_trait::async_trait]
+pub trait TorrentHandler {
+    /// Downloads a torrent from a magnet link or torrent file.
+    ///
+    /// # Arguments
+    ///
+    /// * `torrent_source` - A string representing the magnet link or path to a .torrent file.
+    /// * `download_path` - The path where the downloaded content should be saved.
+    async fn download(&self, torrent_source: &str, download_path: &Path) -> Result<()>;
+
+    /// Creates a torrent for a given file or directory and starts seeding it.
+    ///
+    /// # Arguments
+    ///
+    /// * `content_path` - The path to the file or directory to be seeded.
+    async fn seed(&self, content_path: &Path) -> Result<()>;
+}
+
+/// A handler for BitTorrent operations.
+///
+/// This struct is a placeholder for a real BitTorrent client implementation.
+#[derive(Debug, Default)]
+pub struct BitTorrentHandler {}
+
+impl BitTorrentHandler {
+    /// Creates a new `BitTorrentHandler`.
+    pub fn new() -> Self {
+        info!("BitTorrentHandler initialized");
+        Self {}
+    }
+}
+
+#[async_trait::async_trait]
+impl TorrentHandler for BitTorrentHandler {
+    #[instrument(skip(self), fields(source = %torrent_source, path = %download_path.display()))]
+    async fn download(&self, torrent_source: &str, download_path: &Path) -> Result<()> {
+        info!("Starting torrent download (stub)");
+        // TODO: Implement actual torrent download logic.
+        // This would involve parsing the torrent source, connecting to trackers/DHT,
+        // finding peers, and downloading pieces.
+        println!("Simulating download of '{}' to '{}'", torrent_source, download_path.display());
+        Ok(())
+    }
+
+    #[instrument(skip(self), fields(path = %content_path.display()))]
+    async fn seed(&self, content_path: &Path) -> Result<()> {
+        info!("Starting to seed content (stub)");
+        // TODO: Implement actual torrent creation and seeding logic.
+        // This would involve creating a .torrent file from the content,
+        // and announcing it to trackers or the DHT to become a seeder.
+        println!("Simulating seeding of '{}'", content_path.display());
+        Ok(())
+    }
+}


### PR DESCRIPTION
Initial skeleton for BitTorrent protocol handling. Creates a new `BitTorrentHandler` struct and a `TorrentHandler` trait with stubbed `download` and `seed` methods. Will continue implementation, this is just the skeleton.