### PR TITLE
feat: dht networking implementation

### DIFF
--- a/src-tauri/src/headless.rs
+++ b/src-tauri/src/headless.rs
@@ -249,6 +249,8 @@ pub async fn run_headless(args: CliArgs) -> Result<(), Box<dyn std::error::Error
             encrypted_key_bundle: None,
             download_path: None,
             ftp_sources: None,
+            info_hash: None,
+            trackers: None,
         };
 
         dht_service.publish_file(example_metadata).await?;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2532,6 +2532,8 @@ async fn upload_file_chunk(
             is_root: true,
             download_path: None,
             ftp_sources: None,
+            info_hash: None,
+            trackers: None,
         };
 
         // Store complete file data locally for seeding

--- a/src-tauri/src/reputation.rs
+++ b/src-tauri/src/reputation.rs
@@ -35,6 +35,7 @@ pub enum EventType {
     DhtQueryAnswered,
     StorageOffered,
     MaliciousBehaviorReport,
+    TorrentChunkSeeded,
     FileShared,
     // Relay server events
     RelayReservationAccepted,
@@ -59,6 +60,7 @@ impl EventType {
             EventType::DhtQueryAnswered => 3.0,
             EventType::StorageOffered => 8.0,
             EventType::MaliciousBehaviorReport => -50.0,
+            EventType::TorrentChunkSeeded => 2.0, // Small reward for each chunk
             EventType::FileShared => 5.0,
             EventType::RelayReservationAccepted => 5.0,
             EventType::RelayCircuitEstablished => 10.0,
@@ -359,6 +361,8 @@ impl ReputationDhtService {
             is_root: true,
             download_path: None,
             ftp_sources: None,
+            info_hash: None,
+            trackers: None,
         };
 
         dht_service.publish_file(metadata).await
@@ -411,6 +415,8 @@ impl ReputationDhtService {
             is_root: true,
             download_path: None,
             ftp_sources: None,
+            info_hash: None,
+            trackers: None,
         };
 
         dht_service.publish_file(metadata).await


### PR DESCRIPTION
Extended DHT to Support Torrent Info Hashes:
- Modified DHT record struct to include optional info_hash.

Added Torrent Announcement Support:
- Allowed peers to advertise if they have torrent data available.
- Added method like announce_torrent(info_hash: String).

Integrated Reputation System with Torrent Activity:
- Reward peers who seed torrent data successfully.
- Recorded successful seeding in reputation ledger.
