### PR TITLE
feat(ui): Implement toggle behavior for reputation filters button

### DIFF
--- a/src/pages/Reputation.svelte
+++ b/src/pages/Reputation.svelte
@@ -450,10 +450,15 @@
       <!-- Filters and Sort Controls -->
       <div class="flex items-center justify-between mb-4 gap-2 flex-wrap">
         <!-- Filter Dropdown -->
-        <div class="relative">
-          <Button variant="outline" class="sm:w-auto" on:click={openFilters}>{$t('reputation.filters')}</Button>
+        <div class="relative" use:clickOutside>
+          <Button
+            variant="outline"
+            class="sm:w-auto"
+            on:click={() => (isFilterOpen ? (isFilterOpen = false) : openFilters())}
+            aria-haspopup="true"
+            aria-expanded={isFilterOpen}
+          >{$t('reputation.filters')}</Button>
           {#if isFilterOpen}
-            <div use:clickOutside>
               <Card class="absolute top-full mt-2 p-6 w-72 z-10">
                 <div class="space-y-6">
                   <!-- Trust Level Filter -->
@@ -503,7 +508,6 @@
                   <Button on:click={applyFilters}>{$t('reputation.apply')}</Button>
                 </div>
               </Card>
-            </div>
           {/if}
         </div>
 


### PR DESCRIPTION
## Priority

Priority 4 🟢: Minor Code Improvement (UI Polish)

## What

This PR updates the "Filters" button on the Reputation page to function as a toggle. Clicking the button now opens the filter panel if it's closed, and closes it if it's already open.

## Why

The previous behavior required users to click "Apply" or click outside the panel to close it. Allowing the button itself to close the panel is a more intuitive and standard UI pattern. This improves usability and aligns with the HCI principle of "User Control and Freedom" by providing an easy and predictable way to reverse an action.

## How

- The `on:click` handler for the "Filters" button in `Reputation.svelte` was modified to check the `isFilterOpen` state and toggle the panel's visibility.
- Added `aria-haspopup="true"` and `aria-expanded={isFilterOpen}` to the button for improved accessibility, making it clear to screen readers that the button controls a popup.

## Documentation Updates

None required for this change.

## Breaking Changes

None.
