### PR TITLE
critical fix: change Windows linker to enable compilation

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.x86_64-pc-windows-msvc]
+linker = "rust-lld.exe"


### PR DESCRIPTION
As mentioned in #564 , Windows users cannot currently compile the project. In that issue, our team mentioned a solution to fix this, which was using a better linker.

This PR adds `.cargo/config.toml` which is where the default Microsoft linker can be changed. The PR should also be merged as soon as possible so other Windows users can work on the project again.