### PR TITLE
refactor(dht): Refine FtpSourceInfo structure for FTP integration

### DIFF
--- a/src-tauri/src/headless.rs
+++ b/src-tauri/src/headless.rs
@@ -255,7 +255,7 @@ pub async fn run_headless(args: CliArgs) -> Result<(), Box<dyn std::error::Error
             trackers: None,
         };
 
-        dht_service.publish_file(example_metadata).await?;
+        dht_service.publish_file(example_metadata, None).await?;
         info!("Published bootstrap file metadata");
     } else {
         info!("Connecting to bootstrap nodes: {:?}", bootstrap_nodes);

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -730,7 +730,7 @@ async fn upload_versioned_file(
                 .await;
         }
 
-        dht.publish_file(metadata.clone()).await?;
+        dht.publish_file(metadata.clone(), None).await?;
         Ok(metadata)
     } else {
         Err("DHT not running".into())
@@ -2260,7 +2260,7 @@ async fn upload_file_to_network(
                     ft.store_file_data(file_hash.clone(), file_name.to_string(), file_data.clone())
                         .await;
 
-                    match dht.publish_file(metadata.clone()).await {
+                    match dht.publish_file(metadata.clone(), None).await {
                         Ok(_) => info!("Published file metadata to DHT: {}", file_hash),
                         Err(e) => warn!("Failed to publish file metadata to DHT: {}", e),
                     }
@@ -2756,7 +2756,7 @@ async fn upload_file_chunk(
 
         // Publish to DHT
         if let Some(dht) = dht_opt {
-            dht.publish_file(metadata.clone()).await?;
+            dht.publish_file(metadata.clone(), None).await?;
         } else {
             return Err("DHT not running".into());
         }
@@ -4658,7 +4658,7 @@ async fn upload_and_publish_file(
                 .await; // Store with Merkle root as key
         }
 
-        dht.publish_file(metadata).await?;
+        dht.publish_file(metadata, None).await?;
         version
     } else {
         1 // Default to v1 if DHT not running

--- a/src-tauri/src/reputation.rs
+++ b/src-tauri/src/reputation.rs
@@ -367,7 +367,7 @@ impl ReputationDhtService {
             trackers: None,
         };
 
-        dht_service.publish_file(metadata).await
+        dht_service.publish_file(metadata, None).await
     }
 
     pub async fn retrieve_reputation_events(
@@ -423,7 +423,7 @@ impl ReputationDhtService {
             trackers: None,
         };
 
-        dht_service.publish_file(metadata).await
+        dht_service.publish_file(metadata, None).await
     }
 }
 


### PR DESCRIPTION
Following up on the work for FTP support from a previous PR ([#547](https://github.com/chiral-network/chiral-network/pull/547)), this PR refines the FtpSourceInfo structure within FileMetadata.

- Simplifies FtpSourceInfo by removing fields not suitable for public DHT storage, ensuring only necessary metadata (URL, username, capabilities) is included.
- Emphasizes the use of sanitization methods like `for_dht_storage` during the publishing process to guarantee sensitive information (like passwords) is excluded from DHT records.
- This structural refinement prepares for subsequent tasks involving secure, local credential handling for initiating FTP downloads.