### PR TITLE
feat(dht): Implement dual lookup for info_hash

### DIFF
--- a/src-tauri/src/peer_selection.rs
+++ b/src-tauri/src/peer_selection.rs
@@ -20,6 +20,7 @@ pub struct PeerMetrics {
     pub total_bytes_transferred: u64,
     pub encryption_support: bool, // Supports encrypted transfers
     pub malicious_reports: u64,   // Number of malicious behavior reports
+    pub protocols: Vec<String>,   // Protocols supported by the peer
 }
 
 impl PeerMetrics {
@@ -43,6 +44,7 @@ impl PeerMetrics {
             total_bytes_transferred: 0,
             encryption_support: false,
             malicious_reports: 0,
+            protocols: Vec::new(),
         }
     }
 


### PR DESCRIPTION
Implemented a dual lookup mechanism to the DHT, enabling files to be discovered using a BitTorrent-compatible `info_hash` as an alternative to the native `merkle_root`. 

1.  A search for an `info_hash` first queries the DHT for an index record (`info_hash:<hash>`) which resolves to the file's `merkle_root`.
2.  Upon successfully finding the `merkle_root`, a second DHT query is automatically initiated to retrieve the full `FileMetadata`.