### PR TITLE
feat: explicitly set ethash consensus engine

### DIFF
--- a/genesis.json
+++ b/genesis.json
@@ -10,7 +10,8 @@
     "petersburgBlock": 0,
     "istanbulBlock": 0,
     "berlinBlock": 0,
-    "londonBlock": 0
+    "londonBlock": 0,
+    "ethash": {}
   },
   "difficulty": "0x400000",
   "gasLimit": "0x47b760",


### PR DESCRIPTION
Explicitly sets the consensus engine to ethash in the genesis.json file. This is to prevent geth from showing "consensus: unknown" in the logs, and to make sure that the geth node can find other geth nodes.