### PR TITLE
docs: Updated documentation to reflect current bootstrap nodes responsibilities

### DIFF
--- a/docs/implementation-guide.md
+++ b/docs/implementation-guide.md
@@ -432,6 +432,22 @@ pub async fn download_file(
 }
 ```
 
+### Running the Bootstrap DHT Node
+
+To keep discovery healthy, run at least one headless instance flagged as the bootstrap node:
+
+```bash
+# From the repo root
+./run-bootstrap.sh --port 4001 --log-level info --enable-geth
+```
+
+The script builds (if necessary) and launches `chiral-network --headless --is-bootstrap`, which:
+
+- Disables provider record storage and AutoRelay so the node stays focused on routing DHT traffic
+- Starts the bundled Geth process when `--enable-geth` (or `ENABLE_GETH=true`) is supplied so the bootstrap host maintains local chain state; keep mining disabled so this node remains a neutral router
+
+Regular peers should omit `--is-bootstrap`; they rely on the configured `bootstrap_nodes` list to dial the bootstrap instance and populate their routing tables.
+
 ## Phase 4: Integration Testing
 
 ### NAT reachability instrumentation

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -76,7 +76,8 @@ All nodes are equal and can simultaneously seed files (earning cryptocurrency), 
 
 ### 1. True Decentralization
 
-- No centralized storage or servers
+- No centralized storage or servers for file data
+- We keep a long-lived bootstrap DHT node online for fast peer discovery; it stores no file data, and any peer can assume the role if maintained like a service
 - All nodes are equal - everyone can seed, leech, relay, and mine
 - Files only available while peers actively seed them (no permanent storage)
 - Distributed consensus through blockchain (for mining only)


### PR DESCRIPTION
While investigating whether our application was properly updating the blockchain ledger and reading through the documentation, I found the documentation was lacking when it came to the bootstrap node.  

The documentation doesn't explain to the developer that the bootstrap node is what's helping our DHT stay updated and allows for the peer discovery to happen. Additionally, the documentation doesn't point out that the boostrap node is also running a geth (go-ethereum) node that is allowing the other nodes to peer with it in order for the ledger to be shared.  

This is important to point out for developers and for any LLMs reading our code base as go-ethereum already implements a lot of the functionality we need, we need to just verify that it is happening rather than re-inventing the wheel and creating our own memory pool functionality (As seen by #575, this is a right step towards verifying that our blockchain is working). 

I hope this PR helps clear up any confusion on the current documentation! Please feel free to ask any questions in the comments. 