### PR TITLE
fix: align torrent page notifications with app standard

### DIFF
--- a/src/pages/TorrentDownload.svelte
+++ b/src/pages/TorrentDownload.svelte
@@ -226,7 +226,7 @@
         placeholder="magnet:?xt=urn:btih:..."
         class="flex-grow p-2 border rounded-md bg-background"
       />
-      <button on:click={startDownload} disabled={!magnetLink.trim()} class="px-4 py-2 bg-primary text-primary-foreground rounded-md disabled:opacity-50">Download</button>
+      <button on:click={startDownload} disabled={!magnetLink.trim()} class="px-4 py-2 bg-primary text-primary-foreground rounded-md disabled:opacity-50 hover:bg-primary/90 transition-colors">Download</button>
     </div>
   </div>
 
@@ -255,7 +255,7 @@
         on:change={handleDownloadFileSelect}
         class="hidden"
       />
-      <button on:click={startDownload} disabled={!downloadSelectedFileName} class="px-4 py-2 bg-primary text-primary-foreground rounded-md disabled:opacity-50">Download</button>
+      <button on:click={startDownload} disabled={!downloadSelectedFileName} class="px-4 py-2 bg-primary text-primary-foreground rounded-md disabled:opacity-50 hover:bg-primary/90 transition-colors">Download</button>
     </div>
   </div>
 
@@ -275,7 +275,7 @@
         on:change={handleSeedFileSelect}
         class="hidden"
       />
-      <button on:click={startSeeding} disabled={!seedSelectedFileName} class="px-4 py-2 bg-green-600 text-white rounded-md disabled:opacity-50">Seed File</button>
+      <button on:click={startSeeding} disabled={!seedSelectedFileName} class="px-4 py-2 bg-green-600 text-white rounded-md disabled:opacity-50 hover:bg-green-700 transition-colors">Seed File</button>
     </div>
     {#if newlySeededMagnet}
       <div class="mt-4 p-3 bg-background rounded-md border">


### PR DESCRIPTION
## Priority

Priority 4 🟢: Minor Code (UI Feature & Bug Fix)

## What

This pull request fixes a bug where the "Copied to clipboard!" notification was not appearing on the Torrents page. It also updates all other notifications on that page to use the application's standard toast system for consistency and adds a hover over the buttons.

## Why

The "Copy" button for a newly seeded magnet link was not providing any user feedback, leading to a confusing user experience. The root cause was that `TorrentDownload.svelte` was using a different, non-functional toast implementation (`toast.info`) compared to the working one (`showToast`) used in other pages like `Account.svelte`. This change unifies the notification system on the Torrents page, making it consistent with the rest of the application.

## How

1.  **Changed Import**: In `src/pages/TorrentDownload.svelte`, the import was changed from `'$lib/stores/toastStore'` to `'$lib/toast'`.
2.  **Updated Function Calls**: All calls to `toast.info()`, `toast.success()`, and `toast.error()` were replaced with the standard `showToast()` function.
3.  **Consistent Behavior**: This ensures that notifications for copying a magnet link, starting a seed, and completing a download now all use the same reliable and visible toast component as the `Account` page.

## Breaking Changes

None.

UI:
<img width="1710" height="1761" alt="image" src="https://github.com/user-attachments/assets/9d00578d-6cdc-4bc2-bd23-526256d28b61" />
