### PR TITLE
feat: added working geth bootstrap node

### DIFF
--- a/src-tauri/src/ethereum.rs
+++ b/src-tauri/src/ethereum.rs
@@ -202,7 +202,7 @@ impl GethProcess {
         }
 
         // Bootstrap node
-        let bootstrap_enode = "enode://ae987db6399b50addb75d7822bfad9b4092fbfd79cbfe97e6864b1f17d3e8fcd8e9e190ad109572c1439230fa688a9837e58f0b1ad7c0dc2bc6e4ab328f3991e@130.245.173.105:30303";
+        let bootstrap_enode = "enode://ae987db6399b50addb75d7822bfad9b4092fbfd79cbfe97e6864b1f17d3e8fcd8e9e190ad109572c1439230fa688a9837e58f0b1ad7c0dc2bc6e4ab328f3991e@130.245.173.105:30303,enode://b3ead5f07d0dbeda56023435a7c05877d67b055df3a8bf18f3d5f7c56873495cd4de5cf031ae9052827c043c12f1d30704088c79fb539c96834bfa74b78bf80b@20.85.124.187:30303";
 
         let mut cmd = Command::new(&geth_path);
         cmd.arg("--datadir")


### PR DESCRIPTION
Created a working bootstrap node for the geth binary to allow for P2P ledger sharing, etc. Added the bootstrap enode address to the start geth process function.