### PR TITLE
Fix: Enable file downloads for both WebRTC and Bitswap protocols

### DIFF
--- a/src/lib/dht.ts
+++ b/src/lib/dht.ts
@@ -41,6 +41,7 @@ export interface FileMetadata {
   seeders: string[];
   createdAt: number;
   merkleRoot?: string;
+  downloadPath?: string;
   mimeType?: string;
   isEncrypted: boolean;
   encryptionMethod?: string;
@@ -250,11 +251,19 @@ export class DhtService {
     }
   }
 
-  async downloadFile(fileMetadata: FileMetadata): Promise<FileMetadata> {
-    try {
-      console.log("Initiating download for file:", fileMetadata.fileHash);
-      
-      // Get storage path from settings
+async downloadFile(fileMetadata: FileMetadata): Promise<FileMetadata> {
+  try {
+    console.log("Initiating download for file:", fileMetadata.fileHash);
+    
+    // Use the downloadPath from metadata if provided, otherwise fall back to settings
+    let resolvedStoragePath: string;
+    
+    if (fileMetadata.downloadPath) {
+      // Use the path that was already selected by the user in the file dialog
+      resolvedStoragePath = fileMetadata.downloadPath;
+      console.log("Using provided download path:", resolvedStoragePath);
+    } else {
+      // Fallback to settings path (old behavior)
       const stored = localStorage.getItem("chiralSettings");
       let storagePath = "."; // Default fallback
 
@@ -268,13 +277,15 @@ export class DhtService {
       }
       
       // Construct full file path
-      let resolvedStoragePath = storagePath;
       if (storagePath.startsWith("~")) {
         const home = await homeDir();
         resolvedStoragePath = storagePath.replace("~", home);
+      } else {
+        resolvedStoragePath = storagePath;
       }
       resolvedStoragePath += "/" + fileMetadata.fileName;
-
+      console.log("Using settings storage path:", resolvedStoragePath);
+    }
       // IMPORTANT: Set up the event listener BEFORE invoking the backend
       // to avoid race condition where event fires before we're listening
       const metadataPromise = new Promise<FileMetadata>((resolve, reject) => {

--- a/src/pages/Download.svelte
+++ b/src/pages/Download.svelte
@@ -194,6 +194,16 @@ import { selectedProtocol as protocolStore } from '$lib/stores/protocolStore'
                 // Process payment for Bitswap download (only once per file)
                 console.log('💰 Bitswap download completed, processing payment...');
                 const paymentAmount = paymentService.calculateDownloadCost(completedFile.size);
+                
+                // Skip payment check for free files (price = 0)
+    if (paymentAmount === 0) {
+        console.log('Free file, skipping payment');
+        paidFiles.add(completedFile.hash);
+        showNotification(`Download complete! "${completedFile.name}" (Free)`, 'success');
+        
+    }
+
+
                 const seederPeerId = completedFile.seederAddresses?.[0];
                 const seederWalletAddress = paymentService.isValidWalletAddress(completedFile.uploaderAddress)
                     ? completedFile.uploaderAddress!
@@ -272,6 +282,49 @@ import { selectedProtocol as protocolStore } from '$lib/stores/protocolStore'
           }
         });
 
+
+        // Listen for WebRTC download completion
+        const unlistenWebRTCComplete = await listen('webrtc_download_complete', async (event) => {
+          const data = event.payload as {
+            fileHash: string;
+            fileName: string;
+            fileSize: number;
+            data: number[]; // Array of bytes
+          };
+
+          // Find the file in our downloads
+          const downloadedFile = $files.find(f => f.hash === data.fileHash);
+  
+          if (downloadedFile && downloadedFile.downloadPath) {
+            try {
+              // Write the file to disk at the user's chosen location
+              const { writeFile } = await import('@tauri-apps/plugin-fs');
+              const fileData = new Uint8Array(data.data);
+              await writeFile(downloadedFile.downloadPath, fileData);
+      
+              console.log(`✅ File saved to: ${downloadedFile.downloadPath}`);
+      
+              // Update status to completed
+              files.update(f => f.map(file => 
+                file.hash === data.fileHash
+                ? { ...file, status: 'completed', progress: 100 }
+                  : file
+              ));
+      
+              showNotification(`Successfully saved "${data.fileName}"`, 'success');
+            } catch (error) {
+              console.error('Failed to save file:', error);
+              showNotification(`Failed to save file: ${error}`, 'error');
+
+              files.update(f => f.map(file =>
+                file.hash === data.fileHash
+                  ? { ...file, status: 'failed' }
+                  : file
+              ));
+            }
+          }
+        });
+
         // Cleanup listeners on destroy
         return () => {
           unlistenProgress()
@@ -281,6 +334,7 @@ import { selectedProtocol as protocolStore } from '$lib/stores/protocolStore'
           unlistenBitswapProgress()
           unlistenDownloadCompleted()
           unlistenDhtError()
+          unlistenWebRTCComplete()
         }
       } catch (error) {
         console.error('Failed to setup event listeners:', error)
@@ -770,80 +824,127 @@ import { selectedProtocol as protocolStore } from '$lib/stores/protocolStore'
     console.log('  ✅ Added file to files store, current protocol:', selectedProtocol)
 
     if (selectedProtocol === "Bitswap"){
-      console.log('  🔍 Starting Bitswap download for:', downloadingFile.name)
+  console.log('  🔍 Starting Bitswap download for:', downloadingFile.name)
 
-      // CRITICAL: Bitswap requires CIDs to download
-      if (!downloadingFile.cids || downloadingFile.cids.length === 0) {
-        console.error('  ❌ No CIDs found for Bitswap download')
+  // CRITICAL: Bitswap requires CIDs to download
+  if (!downloadingFile.cids || downloadingFile.cids.length === 0) {
+    console.error('  ❌ No CIDs found for Bitswap download')
+    files.update(f => f.map(file =>
+      file.id === downloadingFile.id
+        ? { ...file, status: 'failed' }
+        : file
+    ))
+    showNotification(
+      `Cannot download "${downloadingFile.name}": This file was not uploaded via Bitswap and has no CIDs. Please use WebRTC protocol instead.`,
+      'error',
+      8000
+    )
+    return
+  }
+
+  // Verify seeders are available
+  if (!downloadingFile.seederAddresses || downloadingFile.seederAddresses.length === 0) {
+    console.error('  ❌ No seeders found for download')
+    files.update(f => f.map(file =>
+      file.id === downloadingFile.id
+        ? { ...file, status: 'failed' }
+        : file
+    ))
+    showNotification(
+      `Cannot download "${downloadingFile.name}": No seeders are currently online for this file.`,
+      'error',
+      6000
+    )
+    return
+  }
+
+  // 🆕 ADD FILE SAVE DIALOG FOR BITSWAP
+  try {
+    const { save } = await import('@tauri-apps/plugin-dialog');
+    
+    // Show file save dialog
+    const outputPath = await save({
+      defaultPath: downloadingFile.name,
+      filters: [{
+        name: 'All Files',
+        extensions: ['*']
+      }]
+    });
+
+    if (!outputPath) {
+      // User cancelled the save dialog
+      files.update(f => f.map(file =>
+        file.id === downloadingFile.id
+          ? { ...file, status: 'canceled' }
+          : file
+      ));
+      return;
+    }
+
+    console.log('✅ User selected save location:', outputPath);
+
+    // Update file with download path
+    files.update(f => f.map(file =>
+      file.id === downloadingFile.id
+        ? { ...file, downloadPath: outputPath }
+        : file
+    ));
+
+    // Now start the actual Bitswap download with the output path
+    const metadata = {
+      fileHash: downloadingFile.hash,
+      fileName: downloadingFile.name,
+      fileSize: downloadingFile.size,
+      seeders: downloadingFile.seederAddresses,
+      createdAt: Date.now(),
+      isEncrypted: downloadingFile.isEncrypted || false,
+      version: downloadingFile.version,
+      manifest: downloadingFile.manifest ? JSON.stringify(downloadingFile.manifest) : undefined,
+      cids: downloadingFile.cids,
+      downloadPath: outputPath // 🔥 PASS THE OUTPUT PATH
+    }
+
+    console.log('🔍 FULL metadata being sent:', JSON.stringify(metadata, null, 2));
+    
+    console.log('  📤 Calling dhtService.downloadFile with metadata:', metadata)
+    console.log('  📦 CIDs:', downloadingFile.cids)
+    console.log('  👥 Seeders:', downloadingFile.seederAddresses)
+    console.log('  💾 Download path:', outputPath)
+
+    // Start the download asynchronously
+    dhtService.downloadFile(metadata)
+      .then((result) => {
+        console.log('  ✅ Bitswap download completed for:', downloadingFile.name, result)
+        showNotification(`Successfully downloaded "${downloadingFile.name}"`, 'success')
+      })
+      .catch((error) => {
+        console.error('  ❌ Bitswap download failed:', error)
+        const errorMessage = error instanceof Error ? error.message : String(error)
+
         files.update(f => f.map(file =>
           file.id === downloadingFile.id
             ? { ...file, status: 'failed' }
             : file
         ))
-        showNotification(
-          `Cannot download "${downloadingFile.name}": This file was not uploaded via Bitswap and has no CIDs. Please use WebRTC protocol instead.`,
-          'error',
-          8000
-        )
-        return
-      }
 
-      // Verify seeders are available
-      if (!downloadingFile.seederAddresses || downloadingFile.seederAddresses.length === 0) {
-        console.error('  ❌ No seeders found for download')
-        files.update(f => f.map(file =>
-          file.id === downloadingFile.id
-            ? { ...file, status: 'failed' }
-            : file
-        ))
         showNotification(
-          `Cannot download "${downloadingFile.name}": No seeders are currently online for this file.`,
+          `Download failed for "${downloadingFile.name}": ${errorMessage}`,
           'error',
           6000
         )
-        return
-      }
-
-      // Now that file is in store, start the actual Bitswap download
-      const metadata = {
-        fileHash: downloadingFile.hash,
-        fileName: downloadingFile.name,
-        fileSize: downloadingFile.size,
-        seeders: downloadingFile.seederAddresses,
-        createdAt: Date.now(),
-        isEncrypted: downloadingFile.isEncrypted || false,
-        version: downloadingFile.version,
-        manifest: downloadingFile.manifest ? JSON.stringify(downloadingFile.manifest) : undefined,
-        cids: downloadingFile.cids
-      }
-      console.log('  📤 Calling dhtService.downloadFile with metadata:', metadata)
-      console.log('  📦 CIDs:', downloadingFile.cids)
-      console.log('  👥 Seeders:', downloadingFile.seederAddresses)
-
-      // Start the download asynchronously - don't await here so chunk events can be processed
-      // The file_content event listener in onMount will handle completion
-      dhtService.downloadFile(metadata)
-        .then((result) => {
-          console.log('  ✅ Bitswap download completed for:', downloadingFile.name, result)
-          showNotification(`Successfully downloaded "${downloadingFile.name}"`, 'success')
-        })
-        .catch((error) => {
-          console.error('  ❌ Bitswap download failed:', error)
-          const errorMessage = error instanceof Error ? error.message : String(error)
-
-          files.update(f => f.map(file =>
-            file.id === downloadingFile.id
-              ? { ...file, status: 'failed' }
-              : file
-          ))
-
-          showNotification(
-            `Download failed for "${downloadingFile.name}": ${errorMessage}`,
-            'error',
-            6000
-          )
-        })
-    } else {
+      })
+  } catch (error) {
+    console.error('Failed to open save dialog:', error);
+    files.update(f => f.map(file =>
+      file.id === downloadingFile.id
+        ? { ...file, status: 'failed' }
+        : file
+    ))
+    showNotification('Failed to open save dialog', 'error');
+    return;
+  }
+} 
+    else {
       console.log('  🎬 Simulating download')
       simulateDownloadProgress(downloadingFile.id)
     }
@@ -950,7 +1051,7 @@ import { selectedProtocol as protocolStore } from '$lib/stores/protocolStore'
         console.log(`💰 Payment required: ${paymentAmount.toFixed(6)} Chiral for ${fileToDownload.name}`);
 
         // Check if user has sufficient balance
-        if (!paymentService.hasSufficientBalance(paymentAmount)) {
+        if (paymentAmount > 0 && !paymentService.hasSufficientBalance(paymentAmount)) {
           showNotification(
             `Insufficient balance. Need ${paymentAmount.toFixed(4)} Chiral, have ${$wallet.balance.toFixed(4)} Chiral`,
             'error',


### PR DESCRIPTION
**Problems**

1. Files weren't downloading at all - Both WebRTC and Bitswap downloads were failing to save files to disk
2. WebRTC downloads: Files were received but never written to the user's computer
3. Bitswap downloads: Files were being saved to the wrong location (project's src-tauri folder instead of user's chosen location)
4. Free files (0 Chiral): Payment validation was blocking all downloads with "Insufficient balance. Need 0.0000 Chiral, have 0.0000 Chiral" error

**Solutions**
**WebRTC Protocol:**
- Added webrtc_download_complete event listener in frontend to receive complete file data from backend
- Modified assemble_file_from_chunks in webrtc_service.rs to emit event with file data when download completes
- Frontend now writes received file data to user's chosen location from file save dialog

**Bitswap Protocol:**

- Added file save dialog prompt before starting Bitswap downloads (was completely missing)
- Fixed downloadPath being ignored in dht.ts - was using settings path instead of user-selected path
- Added downloadPath field to FileMetadata interface to pass user's chosen location through the download pipeline
- Fixed get_available_download_path() function that was converting absolute paths to relative paths
- Updated backend to preserve and use absolute file paths throughout the download-finalize flow

**Payment Processing:**

- Added check to skip payment validation for free files (price = 0 Chiral) in both WebRTC and Bitswap flows
- Files with 0 cost now download without blocking payment errors

Result
✅ Files now actually download and save to disk
✅ Both protocols save files to user-selected locations
✅ Free files download without payment errors
✅ Downloaded files are accessible via "Show in Folder" button