### PR TITLE
feat: Integrating Bandwidth Scheduling with the rest of the program

### DIFF
--- a/src-tauri/src/bandwidth.rs
+++ b/src-tauri/src/bandwidth.rs
@@ -1,0 +1,137 @@
+use std::time::{Duration, Instant};
+use tokio::sync::Mutex;
+use tokio::time::sleep;
+
+/// Simple token-bucket based bandwidth controller shared between upload and download paths.
+pub struct BandwidthController {
+    inner: Mutex<Inner>,
+}
+
+struct Inner {
+    upload: TokenBucket,
+    download: TokenBucket,
+}
+
+impl BandwidthController {
+    pub fn new() -> Self {
+        Self {
+            inner: Mutex::new(Inner {
+                upload: TokenBucket::unlimited(),
+                download: TokenBucket::unlimited(),
+            }),
+        }
+    }
+
+    pub async fn set_limits(&self, upload_kbps: u64, download_kbps: u64) {
+        let mut inner = self.inner.lock().await;
+        inner.upload.set_limit(upload_kbps);
+        inner.download.set_limit(download_kbps);
+    }
+
+    pub async fn acquire_upload(&self, bytes: usize) {
+        self.acquire(bytes, Direction::Upload).await;
+    }
+
+    pub async fn acquire_download(&self, bytes: usize) {
+        self.acquire(bytes, Direction::Download).await;
+    }
+
+    async fn acquire(&self, bytes: usize, direction: Direction) {
+        if bytes == 0 {
+            return;
+        }
+
+        loop {
+            let wait = {
+                let mut inner = self.inner.lock().await;
+                let bucket = match direction {
+                    Direction::Upload => &mut inner.upload,
+                    Direction::Download => &mut inner.download,
+                };
+                bucket.consume(bytes)
+            };
+
+            match wait {
+                None => break,
+                Some(delay) if delay.is_zero() => break,
+                Some(delay) => sleep(delay).await,
+            }
+        }
+    }
+}
+
+enum Direction {
+    Upload,
+    Download,
+}
+
+struct TokenBucket {
+    limit_bytes_per_sec: Option<f64>,
+    tokens: f64,
+    capacity: f64,
+    last_refill: Instant,
+}
+
+impl TokenBucket {
+    fn unlimited() -> Self {
+        Self {
+            limit_bytes_per_sec: None,
+            tokens: f64::INFINITY,
+            capacity: f64::INFINITY,
+            last_refill: Instant::now(),
+        }
+    }
+
+    fn set_limit(&mut self, limit_kbps: u64) {
+        if limit_kbps == 0 {
+            self.limit_bytes_per_sec = None;
+            self.tokens = f64::INFINITY;
+            self.capacity = f64::INFINITY;
+            self.last_refill = Instant::now();
+            return;
+        }
+
+        let limit = (limit_kbps as f64) * 1024.0; // Convert KB/s to bytes/s.
+        self.limit_bytes_per_sec = Some(limit);
+        self.capacity = limit * 2.0; // Allow up to ~2 seconds of burst.
+        self.tokens = self.tokens.min(self.capacity);
+        self.last_refill = Instant::now();
+    }
+
+    fn consume(&mut self, bytes: usize) -> Option<Duration> {
+        let limit = match self.limit_bytes_per_sec {
+            None => return None,
+            Some(limit) if limit <= f64::EPSILON => return None,
+            Some(limit) => limit,
+        };
+
+        self.refill(limit);
+
+        let required = bytes as f64;
+        if self.tokens >= required {
+            self.tokens -= required;
+            None
+        } else {
+            let deficit = required - self.tokens;
+            self.tokens = 0.0;
+            let wait_secs = deficit / limit;
+            if wait_secs <= 0.0 {
+                None
+            } else {
+                Some(Duration::from_secs_f64(wait_secs))
+            }
+        }
+    }
+
+    fn refill(&mut self, limit: f64) {
+        let now = Instant::now();
+        let elapsed = now.duration_since(self.last_refill).as_secs_f64();
+        if elapsed <= 0.0 {
+            return;
+        }
+
+        let new_tokens = elapsed * limit;
+        self.tokens = (self.tokens + new_tokens).min(self.capacity);
+        self.last_refill = now;
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 // Library exports for testing
 pub mod analytics;
+pub mod bandwidth;
 pub mod multi_source_download;
 
 // Download source abstraction

--- a/src-tauri/src/webrtc_service.rs
+++ b/src-tauri/src/webrtc_service.rs
@@ -1,6 +1,7 @@
 use crate::encryption::{decrypt_aes_key, encrypt_aes_key, EncryptedAesKeyBundle, FileEncryption};
 use crate::file_transfer::FileTransferService;
 use crate::keystore::Keystore;
+use crate::bandwidth::BandwidthController;
 use crate::manager::{ChunkInfo, FileManifest};
 use crate::stream_auth::{AuthMessage, StreamAuthService};
 use aes_gcm::aead::Aead;
@@ -201,6 +202,7 @@ pub struct WebRTCService {
     keystore: Arc<Mutex<Keystore>>,
     active_private_key: Arc<Mutex<Option<String>>>,
     stream_auth: Arc<Mutex<StreamAuthService>>, // Stream authentication
+    bandwidth: Arc<BandwidthController>,
 }
 
 impl WebRTCService {
@@ -208,6 +210,7 @@ impl WebRTCService {
         app_handle: tauri::AppHandle,
         file_transfer_service: Arc<FileTransferService>,
         keystore: Arc<Mutex<Keystore>>,
+        bandwidth: Arc<BandwidthController>,
     ) -> Result<Self, String> {
         let (cmd_tx, cmd_rx) = mpsc::channel(100);
         let (event_tx, event_rx) = mpsc::channel(100);
@@ -225,6 +228,7 @@ impl WebRTCService {
             keystore.clone(),
             active_private_key.clone(),
             stream_auth.clone(),
+            bandwidth.clone(),
         ));
 
         Ok(WebRTCService {
@@ -237,6 +241,7 @@ impl WebRTCService {
             keystore,
             active_private_key,
             stream_auth,
+            bandwidth,
         })
     }
 
@@ -255,6 +260,7 @@ impl WebRTCService {
         keystore: Arc<Mutex<Keystore>>,
         active_private_key: Arc<Mutex<Option<String>>>,
         stream_auth: Arc<Mutex<StreamAuthService>>,
+        bandwidth: Arc<BandwidthController>,
     ) {
         while let Some(cmd) = cmd_rx.recv().await {
             match cmd {
@@ -269,6 +275,7 @@ impl WebRTCService {
                         &keystore,
                         &active_private_key,
                         &stream_auth,
+                        &bandwidth,
                     )
                     .await;
                 }
@@ -287,11 +294,12 @@ impl WebRTCService {
                         &connections,
                         &keystore,
                         &stream_auth,
+                        &bandwidth,
                     )
                     .await;
                 }
                 WebRTCCommand::SendFileChunk { peer_id, chunk } => {
-                    Self::handle_send_chunk(&peer_id, &chunk, &connections).await;
+                    Self::handle_send_chunk(&peer_id, &chunk, &connections, &bandwidth).await;
                 }
                 WebRTCCommand::RequestFileChunk {
                     peer_id,
@@ -324,6 +332,7 @@ impl WebRTCService {
         keystore: &Arc<Mutex<Keystore>>,
         active_private_key: &Arc<Mutex<Option<String>>>,
         stream_auth: &Arc<Mutex<StreamAuthService>>,
+        bandwidth: &Arc<BandwidthController>,
     ) {
         info!("Establishing WebRTC connection with peer: {}", peer_id);
 
@@ -372,6 +381,7 @@ impl WebRTCService {
         let keystore_clone = keystore.clone();
         let active_private_key_clone = Arc::new(active_private_key.clone());
         let stream_auth_clone = stream_auth.clone();
+        let bandwidth_clone = bandwidth.clone();
 
         let app_handle_clone = app_handle.clone();
         data_channel.on_message(Box::new(move |msg: DataChannelMessage| {
@@ -382,6 +392,7 @@ impl WebRTCService {
             let keystore = keystore_clone.clone();
             let active_private_key = active_private_key_clone.clone();
             let stream_auth = stream_auth_clone.clone();
+            let bandwidth = bandwidth_clone.clone();
 
             let app_handle_for_task = app_handle_clone.clone();
             Box::pin(async move {
@@ -395,6 +406,7 @@ impl WebRTCService {
                     &active_private_key,
                     &stream_auth,
                     app_handle_for_task,
+                    bandwidth,
                 )
                 .await;
             })
@@ -586,6 +598,7 @@ impl WebRTCService {
         connections: &Arc<Mutex<HashMap<String, PeerConnection>>>,
         keystore: &Arc<Mutex<Keystore>>,
         stream_auth: &Arc<Mutex<StreamAuthService>>,
+        bandwidth: &Arc<BandwidthController>,
     ) {
         info!(
             "Handling file request from peer {}: {}",
@@ -611,6 +624,7 @@ impl WebRTCService {
                 connections,
                 keystore,
                 stream_auth,
+                bandwidth,
             )
             .await
             {
@@ -637,7 +651,10 @@ impl WebRTCService {
         peer_id: &str,
         chunk: &FileChunk,
         connections: &Arc<Mutex<HashMap<String, PeerConnection>>>,
+        bandwidth: &Arc<BandwidthController>,
     ) {
+        bandwidth.acquire_upload(chunk.data.len()).await;
+
         let mut conns = connections.lock().await;
         if let Some(connection) = conns.get_mut(peer_id) {
             if let Some(dc) = &connection.data_channel {
@@ -695,6 +712,7 @@ impl WebRTCService {
         active_private_key: &Arc<Mutex<Option<String>>>,
         stream_auth: &Arc<Mutex<StreamAuthService>>,
         app_handle: tauri::AppHandle,
+        bandwidth: Arc<BandwidthController>,
     ) {
         if let Ok(text) = std::str::from_utf8(&msg.data) {
             // Try to parse as FileChunk
@@ -710,6 +728,7 @@ impl WebRTCService {
                     &active_private_key,
                     stream_auth,
                     &app_handle,
+                    &bandwidth,
                 )
                 .await;
                 let _ = event_tx
@@ -736,6 +755,7 @@ impl WebRTCService {
                     connections,
                     keystore,
                     stream_auth,
+                    &bandwidth,
                 )
                 .await;
             }
@@ -757,6 +777,7 @@ impl WebRTCService {
                             connections,
                             keystore,
                             stream_auth,
+                            &bandwidth,
                         )
                         .await;
                     }
@@ -882,6 +903,7 @@ impl WebRTCService {
                             &active_private_key,
                             stream_auth,
                             &app_handle,
+                            &bandwidth,
                         )
                         .await;
                     }
@@ -906,6 +928,7 @@ impl WebRTCService {
         connections: &Arc<Mutex<HashMap<String, PeerConnection>>>,
         keystore: &Arc<Mutex<Keystore>>,
         stream_auth: &Arc<Mutex<StreamAuthService>>,
+        bandwidth: &Arc<BandwidthController>,
     ) -> Result<(), String> {
         // Get file data from local storage
         let file_data = match file_transfer_service
@@ -1036,7 +1059,7 @@ impl WebRTCService {
             };
 
             // Send chunk via WebRTC data channel
-            Self::handle_send_chunk(peer_id, &chunk, connections).await;
+            Self::handle_send_chunk(peer_id, &chunk, connections, bandwidth).await;
 
             // Update progress
             {
@@ -1103,6 +1126,7 @@ impl WebRTCService {
         active_private_key: &Arc<Mutex<Option<String>>>,
         stream_auth: &Arc<Mutex<StreamAuthService>>,
         app_handle: &tauri::AppHandle,
+        bandwidth: &Arc<BandwidthController>,
     ) {
         // 1. Verify stream authentication first
         if let Some(ref auth_msg) = chunk.auth_message {
@@ -1151,11 +1175,14 @@ impl WebRTCService {
         };
 
         // Verify chunk checksum
+        let chunk_len = final_chunk_data.len();
         let calculated_checksum = Self::calculate_chunk_checksum(&final_chunk_data);
         if calculated_checksum != chunk.checksum {
             warn!("Chunk checksum mismatch for file {}", chunk.file_hash);
             return;
         }
+
+        bandwidth.acquire_download(chunk_len).await;
 
         let mut conns = connections.lock().await;
         if let Some(connection) = conns.get_mut(peer_id) {
@@ -1275,6 +1302,7 @@ impl WebRTCService {
         let keystore_clone = Arc::new(self.keystore.clone());
         let active_private_key_clone = Arc::new(self.active_private_key.clone());
         let stream_auth_clone = Arc::new(self.stream_auth.clone());
+        let bandwidth_clone = self.bandwidth.clone();
 
         let app_handle_clone = self.app_handle.clone();
         data_channel.on_message(Box::new(move |msg: DataChannelMessage| {
@@ -1285,6 +1313,7 @@ impl WebRTCService {
             let keystore = keystore_clone.clone();
             let active_private_key = active_private_key_clone.clone();
             let stream_auth = stream_auth_clone.clone();
+            let bandwidth = bandwidth_clone.clone();
 
             let app_handle_for_task = app_handle_clone.clone();
             Box::pin(async move {
@@ -1298,6 +1327,7 @@ impl WebRTCService {
                     &active_private_key,
                     &stream_auth,
                     app_handle_for_task,
+                    bandwidth,
                 )
                 .await;
             })
@@ -1443,6 +1473,7 @@ impl WebRTCService {
         let keystore_clone = Arc::new(self.keystore.clone());
         let active_private_key_clone = Arc::new(self.active_private_key.clone());
         let stream_auth_clone = Arc::new(self.stream_auth.clone());
+        let bandwidth_clone = self.bandwidth.clone();
 
         let app_handle_clone = self.app_handle.clone();
         data_channel.on_message(Box::new(move |msg: DataChannelMessage| {
@@ -1453,6 +1484,7 @@ impl WebRTCService {
             let keystore = keystore_clone.clone();
             let active_private_key = active_private_key_clone.clone();
             let stream_auth = stream_auth_clone.clone();
+            let bandwidth = bandwidth_clone.clone();
 
             let app_handle_for_task = app_handle_clone.clone();
             Box::pin(async move {
@@ -1466,6 +1498,7 @@ impl WebRTCService {
                     &active_private_key,
                     &stream_auth,
                     app_handle_for_task,
+                    bandwidth,
                 )
                 .await;
             })
@@ -1756,10 +1789,12 @@ pub async fn init_webrtc_service(
     file_transfer_service: Arc<FileTransferService>,
     app_handle: tauri::AppHandle,
     keystore: Arc<Mutex<Keystore>>,
+    bandwidth: Arc<BandwidthController>,
 ) -> Result<(), String> {
     let mut service = WEBRTC_SERVICE.lock().await;
     if service.is_none() {
-        let webrtc_service = WebRTCService::new(app_handle, file_transfer_service, keystore).await?;
+        let webrtc_service =
+            WebRTCService::new(app_handle, file_transfer_service, keystore, bandwidth).await?;
         *service = Some(Arc::new(webrtc_service));
     }
     Ok(())

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -391,6 +391,24 @@ export interface BandwidthScheduleEntry {
   enabled: boolean;
 }
 
+export interface ActiveBandwidthLimits {
+  uploadLimitKbps: number;
+  downloadLimitKbps: number;
+  source: "default" | "schedule";
+  scheduleId?: string;
+  scheduleName?: string;
+  nextChangeAt?: number;
+}
+
+const defaultActiveBandwidthLimits: ActiveBandwidthLimits = {
+  uploadLimitKbps: 0,
+  downloadLimitKbps: 0,
+  source: "default",
+  nextChangeAt: undefined,
+  scheduleId: undefined,
+  scheduleName: undefined,
+};
+
 // Interface for Application Settings
 export interface AppSettings {
   storagePath: string;
@@ -477,3 +495,7 @@ export const settings = writable<AppSettings>({
   bandwidthSchedules: [],
   pricePerMb: 0.001, // Default price: 0.001, until ability to set pricePerMb is there, then change to 0.001 Chiral per MB
 });
+
+export const activeBandwidthLimits = writable<ActiveBandwidthLimits>(
+  defaultActiveBandwidthLimits
+);


### PR DESCRIPTION
Files Changed:
src-tauri/src/bandwidth.rs (new)
src-tauri/src/lib.rs (updated to export the bandwidth module) src-tauri/src/main.rs (updated to own BandwidthController, expose new command, wire controller into startup/cleanup) src-tauri/src/webrtc_service.rs (updated to throttle uploads/downloads and react to limit changes) src/App.svelte (watches scheduler output and invokes backend command) src/lib/services/bandwidthScheduler.ts (publishes active limits + next change metadata) src/lib/stores.ts (new ActiveBandwidthLimits shape + writable store) src/pages/Settings.svelte (shows live limits; no i18n strings yet)

What:
Added a shared token-bucket BandwidthController so both upload and download paths can observe a single rate limiter. The Tauri state now owns that controller and exposes a set_bandwidth_limits command; WebRTC chunk send/receive paths call acquire_upload / acquire_download so transfers throttle in real time

Why:
Before, schedules only computed numbers in the UI; no transfer path consumed them. This wiring lets caps actually constrain throughput. Centralizing limits in a controller keeps future protocols (HTTP, FTP) from duplicating throttle logic and gives a single knob the UI can twist. 

Before:
<img width="987" height="452" alt="BandwidthBefore" src="https://github.com/user-attachments/assets/5f18ddd1-7a8e-4b15-a735-9cb7c49b2eb1" />

After:
<img width="971" height="560" alt="BandwidthAfter" src="https://github.com/user-attachments/assets/e38a3289-f2e5-4e92-a43c-19479d352bf0" />
