### PR TITLE
fix: bootstrap node list

### DIFF
--- a/src-tauri/src/commands/bootstrap.rs
+++ b/src-tauri/src/commands/bootstrap.rs
@@ -5,9 +5,7 @@ use tauri::command;
 
 pub fn get_bootstrap_nodes() -> Vec<String> {
     vec![
-        "/ip4/54.198.145.146/tcp/4001/p2p/12D3KooWNHdYWRTe98KMF1cDXXqGXvNjd1SAchDaeP5o4MsoJLu2"
-            .to_string(),
-        "/dns4/914000.xyz/tcp/4001/p2p/12D3KooWCK6pHctRTaLcDmknDroubx3jbeyQBeeYKm1MPbftMMxy"
+        "/ip4/134.199.240.145/tcp/4001/p2p/12D3KooWFYTuQ2FY8tXRtFKfpXkTSipTF55mZkLntwtN1nHu83qE"
             .to_string(),
     ]
 }


### PR DESCRIPTION
1. `dns4` does not seem to be supported by `rust-libp2p`, as seen in the below screenshot. i have changed it to use `ip4` and a normal IP address.

<img width="836" height="645" alt="image" src="https://github.com/user-attachments/assets/ea31bd8b-9d5a-49ba-9755-60700366b8e3" />

2. [this change](https://github.com/chiral-network/chiral-network/commit/1aa4af841fb3ead612a6c158f259a93d9f9d0db9) modified the peer ID generation logic, causing the old peer ID to be outdated. i have updated it to the new one.

3. removed team Totoro's node. it seems to be down for good now.

