### PR TITLE
feat signaling test: stabilize signaling server/client tests and readiness

### DIFF
--- a/src/lib/services/server/server.cjs
+++ b/src/lib/services/server/server.cjs
@@ -1,7 +1,45 @@
 // WebSocket signaling server for peer discovery and WebRTC signaling
 const WebSocket = require("ws");
-const port = process.env.PORT || 9000;
-const wss = new WebSocket.Server({ port: parseInt(port) });
+const port = parseInt(process.env.PORT || "9000", 10);
+// Bind explicitly to IPv4 loopback to avoid IPv6/::1 resolution issues in tests
+const host = process.env.HOST || "127.0.0.1";
+const wss = new WebSocket.Server({ port, host });
+
+// Emit a clear listening message only after the underlying server is actually
+// listening. This prevents tests from racing on a premature stdout log.
+try {
+  const underlying = wss._server;
+  if (underlying && typeof underlying.on === "function") {
+    underlying.on("listening", () => {
+      console.log(`[SignalingServer] listening on ws://${host}:${port}`);
+    });
+    underlying.on("error", (err) => {
+      console.error("[SignalingServer] underlying server error:", err);
+    });
+  } else {
+    // Fallback: if no underlying server, print immediately
+    console.log(`[SignalingServer] listening on ws://${host}:${port}`);
+  }
+} catch (e) {
+  console.error("[SignalingServer] failed to attach listening handler", e);
+  console.log(`[SignalingServer] listening on ws://${host}:${port}`);
+}
+
+// Graceful shutdown helpers for test harnesses
+process.on("SIGTERM", () => {
+  try {
+    wss.close(() => process.exit(0));
+  } catch (e) {
+    process.exit(0);
+  }
+});
+process.on("SIGINT", () => {
+  try {
+    wss.close(() => process.exit(0));
+  } catch (e) {
+    process.exit(0);
+  }
+});
 
 // Track connected peers
 const peers = new Map(); // clientId -> WebSocket


### PR DESCRIPTION
Server: wait for underlying server 'listening' event before printing ready log and add error logging
SignalingService: add configurable wsConnectTimeoutMs (env: SIGNALLING_CONNECT_TIMEOUT_MS, default 5000)
Tests: force HOST=127.0.0.1 for spawned server processes, wait for real listening message and fail early if process exits, use 127.0.0.1 in clients, increase per-test timeouts