### PR TITLE
fix: download geth UX

### DIFF
--- a/src/pages/Network.svelte
+++ b/src/pages/Network.svelte
@@ -1298,7 +1298,7 @@
       {#if isCheckingGeth}
         <div class="text-center py-8">
           <RefreshCw class="h-12 w-12 text-blue-500 mx-auto mb-2 animate-spin" />
-          <p class="text-sm text-muted-foreground mb-1">Checking if Geth is installed...</p>
+          <p class="text-sm text-muted-foreground mb-1">Checking if Geth is downloaded...</p>
           <p class="text-xs text-muted-foreground">Please wait while we check your system</p>
         </div>
       {:else if !isGethInstalled}


### PR DESCRIPTION
Previously, when the user went to the Network page and they already had Geth installed, they would see "Download Geth" button, but then it would suddenly turn into the "Start Node" button. That transition was not really user friendly. Also, nothing would happen if the user pressed on "Download Geth" when they already had it installed. 

Now we display "Checking if Geth is downloaded..." and then go to one of 2 cases depending on if Geth is installed downloaded: "Download Geth" or "Start Node".