### PR TITLE
feat: add Ed2k download source abstraction

### DIFF
--- a/src-tauri/src/download_scheduler.rs
+++ b/src-tauri/src/download_scheduler.rs
@@ -2,7 +2,7 @@
 // Example integration of unified download source abstraction
 // This module demonstrates how to use DownloadSource in scheduling and logging
 
-use crate::download_source::{DownloadSource, FtpSourceInfo, HttpSourceInfo, P2pSourceInfo};
+use crate::download_source::{DownloadSource, Ed2kSourceInfo, FtpSourceInfo, HttpSourceInfo, P2pSourceInfo};
 use crate::ftp_client;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -129,6 +129,9 @@ impl DownloadScheduler {
             DownloadSource::Ftp(info) => {
                 self.handle_ftp_download(task_id, info)
             }
+            DownloadSource::Ed2k(info) => {
+                self.handle_ed2k_download(task_id, info)
+            }
         }
     }
 
@@ -207,6 +210,22 @@ impl DownloadScheduler {
         Ok(())
     }
 
+    fn handle_ed2k_download(&self, task_id: &str, info: &Ed2kSourceInfo) -> Result<(), String> {
+        info!(
+            task_id = %task_id,
+            server_url = %info.server_url,
+            file_hash = %info.file_hash,
+            file_size = info.file_size,
+            "Initiating Ed2k download (placeholder)"
+        );
+
+        // TODO: Implement actual Ed2k download logic in PR #2
+        // This is a placeholder to satisfy the match arm requirement
+        warn!("Ed2k downloads are not yet fully implemented");
+
+        Ok(())
+    }
+
     /// Get statistics about source types in use
     pub fn get_source_statistics(&self) -> SourceStatistics {
         let mut stats = SourceStatistics::default();
@@ -217,6 +236,7 @@ impl DownloadScheduler {
                     DownloadSource::P2p(_) => stats.p2p_count += 1,
                     DownloadSource::Http(_) => stats.http_count += 1,
                     DownloadSource::Ftp(_) => stats.ftp_count += 1,
+                    DownloadSource::Ed2k(_) => stats.ed2k_count += 1,
                 }
             }
         }
@@ -267,6 +287,7 @@ pub struct SourceStatistics {
     pub p2p_count: usize,
     pub http_count: usize,
     pub ftp_count: usize,
+    pub ed2k_count: usize,
 }
 
 #[cfg(test)]

--- a/src-tauri/src/download_source.rs
+++ b/src-tauri/src/download_source.rs
@@ -18,6 +18,9 @@ pub enum DownloadSource {
 
     /// FTP/FTPS download
     Ftp(FtpSourceInfo),
+
+    /// ed2k (eDonkey2000) download
+    Ed2k(Ed2kSourceInfo),
 }
 
 /// Information about a P2P download source
@@ -97,6 +100,32 @@ pub struct FtpSourceInfo {
     pub timeout_secs: Option<u64>,
 }
 
+/// Information about an ed2k (eDonkey2000) download source
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Ed2kSourceInfo {
+    /// ed2k server URL (e.g., "ed2k://|server|176.103.48.36|4661|/")
+    pub server_url: String,
+
+    /// ed2k file hash (MD4 hash in hex format)
+    pub file_hash: String,
+
+    /// File size in bytes
+    pub file_size: u64,
+
+    /// Optional file name
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub file_name: Option<String>,
+
+    /// List of known sources (IP:Port pairs)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sources: Option<Vec<String>>,
+
+    /// Connection timeout in seconds
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timeout_secs: Option<u64>,
+}
+
 // Default value functions
 fn default_verify_ssl() -> bool {
     true
@@ -113,6 +142,7 @@ impl DownloadSource {
             DownloadSource::P2p(_) => "P2P",
             DownloadSource::Http(_) => "HTTP",
             DownloadSource::Ftp(_) => "FTP",
+            DownloadSource::Ed2k(_) => "ED2K",
         }
     }
 
@@ -138,6 +168,14 @@ impl DownloadSource {
                     format!("FTP: {}", info.url)
                 }
             }
+            DownloadSource::Ed2k(info) => {
+                // Display file name if available, otherwise show hash prefix
+                if let Some(name) = &info.file_name {
+                    format!("ED2K: {}", name)
+                } else {
+                    format!("ED2K: {}", &info.file_hash[..8.min(info.file_hash.len())])
+                }
+            }
         }
     }
 
@@ -147,6 +185,10 @@ impl DownloadSource {
             DownloadSource::P2p(info) => info.peer_id.clone(),
             DownloadSource::Http(info) => info.url.clone(),
             DownloadSource::Ftp(info) => info.url.clone(),
+            DownloadSource::Ed2k(info) => {
+                // Use file hash as identifier
+                info.file_hash.clone()
+            }
         }
     }
 
@@ -156,6 +198,7 @@ impl DownloadSource {
             DownloadSource::P2p(info) => info.supports_encryption,
             DownloadSource::Http(info) => info.url.starts_with("https://"),
             DownloadSource::Ftp(info) => info.use_ftps,
+            DownloadSource::Ed2k(_) => false, // ed2k protocol does not natively support encryption
         }
     }
 
@@ -169,6 +212,10 @@ impl DownloadSource {
             DownloadSource::Http(_) => {
                 // HTTP is secondary
                 50
+            }
+            DownloadSource::Ed2k(_) => {
+                // ed2k is between FTP and HTTP (P2P nature but legacy protocol)
+                30
             }
             DownloadSource::Ftp(_) => {
                 // FTP is fallback
@@ -284,5 +331,110 @@ mod tests {
             timeout_secs: None,
         });
         assert_eq!(http.display_name(), "HTTP: cdn.example.com");
+    }
+
+    #[test]
+    fn test_ed2k_source_creation() {
+        let source = DownloadSource::Ed2k(Ed2kSourceInfo {
+            server_url: "ed2k://|server|176.103.48.36|4661|/".to_string(),
+            file_hash: "31D6CFE0D16AE931B73C59D7E0C089C0".to_string(),
+            file_size: 9728000,
+            file_name: Some("ubuntu.iso".to_string()),
+            sources: Some(vec!["192.168.1.1:4662".to_string()]),
+            timeout_secs: Some(30),
+        });
+
+        assert_eq!(source.source_type(), "ED2K");
+        assert!(!source.supports_encryption());
+        assert_eq!(source.priority_score(), 30);
+        assert_eq!(source.display_name(), "ED2K: ubuntu.iso");
+    }
+
+    #[test]
+    fn test_ed2k_source_without_filename() {
+        let source = DownloadSource::Ed2k(Ed2kSourceInfo {
+            server_url: "ed2k://|server|176.103.48.36|4661|/".to_string(),
+            file_hash: "31D6CFE0D16AE931B73C59D7E0C089C0".to_string(),
+            file_size: 9728000,
+            file_name: None,
+            sources: None,
+            timeout_secs: Some(30),
+        });
+
+        assert_eq!(source.display_name(), "ED2K: 31D6CFE0");
+        assert_eq!(source.identifier(), "31D6CFE0D16AE931B73C59D7E0C089C0");
+    }
+
+    #[test]
+    fn test_ed2k_priority_score() {
+        let ed2k = DownloadSource::Ed2k(Ed2kSourceInfo {
+            server_url: "ed2k://|server|176.103.48.36|4661|/".to_string(),
+            file_hash: "31D6CFE0D16AE931B73C59D7E0C089C0".to_string(),
+            file_size: 1024,
+            file_name: None,
+            sources: None,
+            timeout_secs: None,
+        });
+
+        let ftp = DownloadSource::Ftp(FtpSourceInfo {
+            url: "ftp://ftp.example.com/file.zip".to_string(),
+            username: None,
+            encrypted_password: None,
+            passive_mode: true,
+            use_ftps: false,
+            timeout_secs: None,
+        });
+
+        let http = DownloadSource::Http(HttpSourceInfo {
+            url: "https://example.com/file.zip".to_string(),
+            auth_header: None,
+            verify_ssl: true,
+            headers: None,
+            timeout_secs: None,
+        });
+
+        let p2p = DownloadSource::P2p(P2pSourceInfo {
+            peer_id: "12D3KooW".to_string(),
+            multiaddr: None,
+            reputation: Some(80),
+            supports_encryption: true,
+            protocol: None,
+        });
+
+        // Verify priority order: P2P (180) > HTTP (50) > ED2K (30) > FTP (25)
+        assert!(p2p.priority_score() > http.priority_score());
+        assert!(http.priority_score() > ed2k.priority_score());
+        assert!(ed2k.priority_score() > ftp.priority_score());
+
+        assert_eq!(ed2k.priority_score(), 30);
+        assert_eq!(ftp.priority_score(), 25);
+        assert_eq!(http.priority_score(), 50);
+        assert_eq!(p2p.priority_score(), 180);
+    }
+
+    #[test]
+    fn test_ed2k_serialization() {
+        let ed2k_info = Ed2kSourceInfo {
+            server_url: "ed2k://|server|176.103.48.36|4661|/".to_string(),
+            file_hash: "31D6CFE0D16AE931B73C59D7E0C089C0".to_string(),
+            file_size: 1024000,
+            file_name: Some("test.iso".to_string()),
+            sources: Some(vec!["192.168.1.1:4662".to_string()]),
+            timeout_secs: Some(60),
+        };
+
+        let source = DownloadSource::Ed2k(ed2k_info);
+        let json = serde_json::to_string(&source).unwrap();
+
+        // Verify JSON contains expected fields
+        assert!(json.contains("\"type\":\"ed2k\""));
+        assert!(json.contains("\"serverUrl\""));
+        assert!(json.contains("\"fileHash\""));
+        assert!(json.contains("\"fileSize\":1024000"));
+        assert!(json.contains("\"fileName\":\"test.iso\""));
+
+        // Deserialize and verify
+        let deserialized: DownloadSource = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.source_type(), "ED2K");
     }
 }

--- a/src-tauri/src/multi_source_download.rs
+++ b/src-tauri/src/multi_source_download.rs
@@ -511,6 +511,10 @@ impl MultiSourceDownloadService {
                 DownloadSource::Http(http_info) => {
                     self.start_http_download(file_hash, http_info.clone(), chunk_ids).await?;
                 }
+                DownloadSource::Ed2k(_ed2k_info) => {
+                    // TODO: Implement Ed2k connection in PR #2
+                    tracing::warn!("Ed2k downloads not yet implemented");
+                }
             }
         }
 
@@ -1198,6 +1202,10 @@ impl MultiSourceDownloadService {
                     DownloadSource::Http(_) => {
                         // HTTP connections are typically closed automatically
                         // No explicit cleanup needed for HTTP
+                    }
+                    DownloadSource::Ed2k(_) => {
+                        // TODO: Implement Ed2k connection cleanup in PR #2
+                        // Ed2k connections will be managed similarly to FTP
                     }
                 }
             }


### PR DESCRIPTION
- Add Ed2kSourceInfo struct to download_source.rs
- Add Ed2k variant to DownloadSource enum
- Implement all required methods for Ed2k sources
  - source_type() returns 'ED2K'
  - display_name() shows filename or hash prefix
  - identifier() returns file hash
  - supports_encryption() returns false (no native encryption)
  - priority_score() returns 30 (between FTP and HTTP)
- Add comprehensive unit tests for Ed2k sources
  - test_ed2k_source_creation
  - test_ed2k_source_without_filename
  - test_ed2k_priority_score
  - test_ed2k_serialization
- Add placeholder handlers in multi_source_download.rs and download_scheduler.rs
  -

This is part 1 of the Ed2k integration (Download Source Abstraction). Next PRs will implement the actual download logic and integration.