### PR TITLE
Fix/remove duplicate network page text

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -944,7 +944,7 @@
     "stop": "Stop Mining",
     "start": "Start Mining",
     "showLogs": "Show mining logs",
-    "networkPage": "Network page",
+    "networkPage": "Network Page.",
     "accountPage": "Account page",
     "networkStats": "Network Statistics",
     "networkHashRate": "Network Hash Rate",
@@ -1035,7 +1035,7 @@
       "intensity": "Intensity must be between 1 and 100",
       "noAccount": "Please create a Chiral Network account first in the Account page",
       "noAccountToStart": "Please create a Chiral Network account from the Account page to start mining",
-      "gethNotRunning": "Chiral node is not running. Please start it from the Network page",
+      "gethNotRunning": "Chiral node is not running. Please start it from the",
       "noAccountLink": "Please create a Chiral Network account from the"
     },
     "starting": "Starting mining... (may restart node if needed)",
@@ -1192,7 +1192,7 @@
       "title": "Relay Health & Monitoring"
     },
     "errors": {
-      "dhtNotRunning": "DHT is not running. Please start the network from the Network page.",
+      "dhtNotRunning": "DHT is not running. Please start the network from the ",
       "toggleFailed": "Failed to toggle relay server: {error}"
     },
     "monitor": {


### PR DESCRIPTION
The duplicate "Network page" text has been removed. The message will now properly display as:

"Chiral node is not running. Please start it from the Network page" (where "Network page" is a clickable link)
Instead of the previous:

"Chiral node is not running. Please start it from the Network page Network page"