### PR TITLE
fix: first time wizard log in

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -284,8 +284,7 @@ struct AppState {
     bittorrent_handler: Arc<bittorrent_handler::BitTorrentHandler>,
 }
 
-/// Tauri command to trigger a download.
-/// It takes a string identifier (like a magnet link) and uses the ProtocolManager.
+/// Tauri command to create a new Chiral account
 #[tauri::command]
 async fn create_chiral_account(state: State<'_, AppState>) -> Result<EthAccount, String> {
     let account = create_new_account()?;

--- a/src/lib/components/wallet/FirstRunWizard.svelte
+++ b/src/lib/components/wallet/FirstRunWizard.svelte
@@ -2,13 +2,11 @@
   import Card from '$lib/components/ui/card.svelte'
   import Button from '$lib/components/ui/button.svelte'
   import MnemonicWizard from './MnemonicWizard.svelte'
-  import { etcAccount, wallet } from '$lib/stores'
-  import { invoke } from '@tauri-apps/api/core'
+  import { etcAccount, wallet, miningState } from '$lib/stores'
   import { showToast } from '$lib/toast'
   import { t } from 'svelte-i18n'
 
   export let onComplete: () => void
-  export let onSkip: () => void
 
   let showMnemonicWizard = false
   let mode: 'welcome' | 'mnemonic' = 'welcome'
@@ -18,18 +16,19 @@
     showMnemonicWizard = true
   }
 
-  function handleSkipForNow() {
-    // Set flag that user skipped first-run
-    localStorage.setItem('chiral_first_run_skipped', 'true')
-    showToast($t('account.firstRun.skipped'), 'info')
-    onSkip()
-  }
-
   async function handleMnemonicComplete(ev: { mnemonic: string, passphrase: string, account: { address: string, privateKeyHex: string, index: number, change: number }, name?: string }) {
     try {
       // Set as active account
       etcAccount.set({ address: ev.account.address, private_key: '0x' + ev.account.privateKeyHex })
-      wallet.update(w => ({ ...w, address: ev.account.address }))
+      wallet.update(w => ({ ...w, address: ev.account.address, balance: 0 }))
+
+      // Reset mining state for new account
+      miningState.update(state => ({
+        ...state,
+        totalRewards: 0,
+        blocksFound: 0,
+        recentBlocks: []
+      }))
 
       // Mark first-run as complete
       localStorage.setItem('chiral_first_run_complete', 'true')
@@ -41,6 +40,38 @@
     } catch (error) {
       console.error('Failed to complete first-run setup:', error)
       showToast($t('account.firstRun.error'), 'error')
+    }
+  }
+
+  async function handleCreateTestWallet() {
+    try {
+      // Generate a random test address (this is NOT secure, just for testing)
+      const randomBytes = new Uint8Array(20)
+      crypto.getRandomValues(randomBytes)
+      const testAddress = '0x' + Array.from(randomBytes).map(b => b.toString(16).padStart(2, '0')).join('')
+      const testPrivateKey = '0x' + Array.from(new Uint8Array(32)).map(() => Math.floor(Math.random() * 256).toString(16).padStart(2, '0')).join('')
+
+      // Set as active account
+      etcAccount.set({ address: testAddress, private_key: testPrivateKey })
+      wallet.update(w => ({ ...w, address: testAddress, balance: 10 }))
+
+      // Reset mining state for new account
+      miningState.update(state => ({
+        ...state,
+        totalRewards: 10,
+        blocksFound: 5,
+        recentBlocks: []
+      }))
+
+      // Mark first-run as complete
+      localStorage.setItem('chiral_first_run_complete', 'true')
+
+      showToast('⚠️ TEST WALLET CREATED - DO NOT USE FOR REAL FUNDS!', 'success')
+
+      onComplete()
+    } catch (error) {
+      console.error('Failed to create test wallet:', error)
+      showToast('Failed to create test wallet', 'error')
     }
   }
 
@@ -74,14 +105,27 @@
           <Button on:click={handleCreateNewWallet} class="w-full py-6 text-lg">
             {$t('account.firstRun.createWallet')}
           </Button>
+          
+          <div class="relative">
+            <div class="absolute inset-0 flex items-center">
+              <span class="w-full border-t border-muted"></span>
+            </div>
+            <div class="relative flex justify-center text-xs uppercase">
+              <span class="bg-background px-2 text-muted-foreground">For Testing Only</span>
+            </div>
+          </div>
 
-          <Button on:click={handleSkipForNow} variant="outline" class="w-full">
-            {$t('account.firstRun.skipForNow')}
+          <Button 
+            on:click={handleCreateTestWallet} 
+            variant="outline" 
+            class="w-full py-4 border-amber-500/50 text-amber-600 dark:text-amber-400 hover:bg-amber-500/10"
+          >
+            ⚠️ Create Test Wallet (10 Chiral) - DO NOT USE FOR REAL FUNDS
           </Button>
         </div>
 
         <p class="text-xs text-center text-muted-foreground">
-          {$t('account.firstRun.skipWarning')}
+          {$t('account.firstRun.requiresWallet')}
         </p>
       </div>
     </Card>

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -168,9 +168,9 @@ const dummyFiles: FileItem[] = [
 ];
 
 const dummyWallet: WalletInfo = {
-  address: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb1",
-  balance: 1000.5,
-  pendingTransactions: 5,
+  address: "",
+  balance: 0,
+  pendingTransactions: 0,
 };
 
 // Additional dummy data

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -504,17 +504,9 @@
       "reason2": "Secure your funds with encrypted recovery phrase",
       "reason3": "Transfer coins to other users on the network",
       "createWallet": "Create New Wallet",
-      "skipForNow": "Skip for Now (Create Temporary Account)",
-      "skipWarning": "If you skip, a temporary account will be created when you start mining. You can create a permanent wallet anytime from the Account page.",
-      "skipped": "First-run setup skipped. A temporary account will be created when needed.",
+      "requiresWallet": "A wallet is required to mine, earn rewards, and transfer Chiral. Your recovery phrase will be generated in the next step.",
       "accountCreated": "Wallet created successfully! You can now start mining.",
       "error": "Failed to create account. Please try again."
-    },
-    "upgradeAccount": {
-      "title": "Secure Your Mining Rewards!",
-      "description": "You're using a temporary account. Save it to an encrypted keystore or create an HD wallet to protect your mining rewards from being lost.",
-      "saveToKeystore": "Save to Keystore",
-      "createHDWallet": "Create HD Wallet"
     }
   },
   "wallet": {

--- a/src/pages/Account.svelte
+++ b/src/pages/Account.svelte
@@ -3,7 +3,7 @@
   import Card from '$lib/components/ui/card.svelte'
   import Input from '$lib/components/ui/input.svelte'
   import Label from '$lib/components/ui/label.svelte'
-  import { Wallet, Copy, ArrowUpRight, ArrowDownLeft, History, Coins, Plus, Import, BadgeX, KeyRound, FileText, AlertCircle } from 'lucide-svelte'
+  import { Wallet, Copy, ArrowUpRight, ArrowDownLeft, History, Coins, Plus, Import, BadgeX, KeyRound, FileText } from 'lucide-svelte'
   import DropDown from "$lib/components/ui/dropDown.svelte";
   import { wallet, etcAccount, blacklist} from '$lib/stores' 
   import { walletService } from '$lib/wallet';
@@ -588,10 +588,6 @@
             keystoreSaveMessage = tr('keystore.successSimulated');
         }
         keystorePassword = ''; // Clear password after saving
-
-        // Clear temporary account flags after successful save
-        localStorage.removeItem('chiral_temp_account_mining');
-        localStorage.removeItem('chiral_first_run_skipped');
         localStorage.setItem('chiral_first_run_complete', 'true');
     } catch (error) {
         console.error('Failed to save to keystore:', error);
@@ -749,10 +745,6 @@
     etcAccount.set({ address: ev.account.address, private_key: '0x' + ev.account.privateKeyHex });
     wallet.update(w => ({ ...w, address: ev.account.address }));
     if (isGethRunning) { await fetchBalance(); }
-
-    // Clear temporary account flags after creating HD wallet
-    localStorage.removeItem('chiral_temp_account_mining');
-    localStorage.removeItem('chiral_first_run_skipped');
     localStorage.setItem('chiral_first_run_complete', 'true');
   }
   function onHDAccountsChange(updated: HDAccountItem[]) {
@@ -1337,30 +1329,7 @@
     <p class="text-muted-foreground mt-2">{$t('account.subtitle')}</p>
   </div>
 
-  <!-- Temporary Account Upgrade Alert -->
-  {#if $etcAccount && localStorage.getItem('chiral_temp_account_mining') === 'true' && localStorage.getItem('chiral_first_run_skipped') === 'true'}
-    <div class="bg-amber-500/10 border border-amber-500/30 rounded-lg p-4">
-      <div class="flex items-start gap-3">
-        <AlertCircle class="h-5 w-5 text-amber-500 flex-shrink-0 mt-0.5" />
-        <div class="flex-1 space-y-2">
-          <h3 class="font-semibold text-amber-900 dark:text-amber-100">
-            {$t('account.upgradeAccount.title')}
-          </h3>
-          <p class="text-sm text-amber-800 dark:text-amber-200">
-            {$t('account.upgradeAccount.description')}
-          </p>
-          <div class="flex flex-wrap gap-2 mt-3">
-            <Button size="sm" on:click={() => document.getElementById('keystore-section')?.scrollIntoView({ behavior: 'smooth', block: 'center' })}>
-              {$t('account.upgradeAccount.saveToKeystore')}
-            </Button>
-            <Button size="sm" variant="outline" on:click={openCreateMnemonic}>
-              {$t('account.upgradeAccount.createHDWallet')}
-            </Button>
-          </div>
-        </div>
-      </div>
-    </div>
-  {/if}
+
 
 {#if showMnemonicWizard}
   <MnemonicWizard

--- a/src/pages/Mining.svelte
+++ b/src/pages/Mining.svelte
@@ -579,9 +579,6 @@
       isTemporaryAccount = true
       showTemporaryAccountWarning = true
 
-      // Track that this account has been used for mining
-      localStorage.setItem('chiral_temp_account_mining', 'true')
-
       return tempAccount
     } catch (e) {
       console.error('Failed to create temporary account:', e)

--- a/src/pages/Settings.svelte
+++ b/src/pages/Settings.svelte
@@ -408,17 +408,17 @@
         // Download as file
         settingsBackupService.downloadBackupFile(result.data);
         backupMessage = {
-          text: translate('settingsBackup.messages.exportSuccess'),
+          text: $t('settingsBackup.messages.exportSuccess'),
           type: 'success'
         };
-        showToast(translate('settingsBackup.messages.exportSuccess'), 'success');
+        showToast($t('settingsBackup.messages.exportSuccess'), 'success');
       } else {
         throw new Error(result.error || 'Export failed');
       }
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : 'Unknown error';
       backupMessage = {
-        text: translate('settingsBackup.messages.exportError', { values: { error: errorMsg } }),
+        text: $t('settingsBackup.messages.exportError', { values: { error: errorMsg } }),
         type: 'error'
       };
       showToast(backupMessage.text, 'error');
@@ -456,13 +456,13 @@
           
           if (result.warnings && result.warnings.length > 0) {
             backupMessage = {
-              text: translate('settingsBackup.messages.importWarnings', { values: { warnings: result.warnings.join(', ') } }),
+              text: $t('settingsBackup.messages.importWarnings', { values: { warnings: result.warnings.join(', ') } }),
               type: 'warning'
             };
             showToast(backupMessage.text, 'warning');
           } else {
             backupMessage = {
-              text: translate('settingsBackup.messages.importSuccess'),
+              text: $t('settingsBackup.messages.importSuccess'),
               type: 'success'
             };
             showToast(backupMessage.text, 'success');
@@ -476,7 +476,7 @@
       } catch (error) {
         const errorMsg = error instanceof Error ? error.message : 'Unknown error';
         backupMessage = {
-          text: translate('settingsBackup.messages.importError', { values: { error: errorMsg } }),
+          text: $t('settingsBackup.messages.importError', { values: { error: errorMsg } }),
           type: 'error'
         };
         showToast(backupMessage.text, 'error');


### PR DESCRIPTION
- Fixed first-run wizard to actually log in with the account in the account page. Before, the account was still not added.
- Added automatic navigation to Account page after wizard completion to prevent users getting stuck on blank screen
- Reset wallet balance and mining state to zero when creating new accounts to prevent displaying cached balance from previous sessions
- Added test wallet creation button with 10 Chiral for quick testing without full mnemonic setup process (clearly marked as testing-only)
- Fixed various .svelte errors