### PR TITLE
feat(Network): Add cancel connection functionality to DHT

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -88,6 +88,8 @@
       "retry": "Retry Connection",
       "connect": "Connect to DHT Network",
       "stop": "Stop DHT",
+      "cancel": "Cancel Connection",
+      "connectionCancelled": "Connection cancelled",
       "log": "Connection Log",
       "connectingToBootstrap": "Connecting to bootstrap node...",
       "attempt": "Attempt #{connectionAttempts}",


### PR DESCRIPTION
## feat(Network): Add Cancel Connection Functionality to DHT

### Summary

This PR adds a cancel button to the Network page, allowing users to abort DHT connection attempts while connecting. The feature improves user experience by providing control over long-running or stalled network operations.

### Highlights

- Introduces a cancel button that appears during DHT connection attempts.
- Implements state management to handle connection cancellation and UI updates.
- Adds notification and translation keys for cancellation feedback.
- Updates `Network.svelte` and `en.json` to support the new functionality.

### Impact

This enhancement empowers users to interrupt DHT connection processes, reducing frustration and improving responsiveness. 


<img width="2057" height="547" alt="dht-connecting-cancel" src="https://github.com/user-attachments/assets/5dced71c-b277-431b-a043-4efa897b6d03" />
