### PR TITLE
restored bitswap as selectable protocol in peer selection modal

### DIFF
--- a/src/lib/components/download/DownloadSearchSection.svelte
+++ b/src/lib/components/download/DownloadSearchSection.svelte
@@ -41,7 +41,7 @@
   let showPeerSelectionModal = false;
   let selectedFile: FileMetadata | null = null;
   let peerSelectionMode: 'auto' | 'manual' = 'auto';
-  let selectedProtocol: 'http' | 'webrtc' = 'http';
+  let selectedProtocol: 'http' | 'webrtc' | 'bitswap' = 'http';
   let availablePeers: PeerInfo[] = [];
   let autoSelectionInfo: Array<{peerId: string; score: number; metrics: any}> | null = null;
 
@@ -573,7 +573,7 @@
       await handleHttpDownload(selectedFile, selectedPeers);
     } else {
       // WebRTC download flow (existing)
-      console.log(`🔍 DEBUG: Initiating WebRTC download for file: ${selectedFile.fileName}`);
+      console.log(`🔍 DEBUG: Initiating ${selectedProtocol} download for file: ${selectedFile.fileName}`);
 
       const fileWithSelectedPeers: FileMetadata & { peerAllocation?: any[] } = {
         ...selectedFile,

--- a/src/lib/components/download/PeerSelectionModal.svelte
+++ b/src/lib/components/download/PeerSelectionModal.svelte
@@ -25,7 +25,7 @@
   export let peers: PeerInfo[];
   export let mode: 'auto' | 'manual' = 'auto';
   export let autoSelectionInfo: Array<{peerId: string; score: number; metrics: any}> | null = null;
-  export let protocol: 'http' | 'webrtc' = 'http'; // Default to HTTP for WebRTC flow
+  export let protocol: 'http' | 'webrtc' | 'bitswap' = 'http'; 
   export let isTorrent = false; // Flag to indicate torrent download (no peer selection needed)
 
   const dispatch = createEventDispatcher<{
@@ -132,7 +132,7 @@
             </p>
           </div>
         {:else}
-        <!-- Protocol Selection (HTTP vs WebRTC only - Bitswap doesn't use peer selection) -->
+        <!-- Protocol Selection -->
         <div class="space-y-2">
           <div class="text-sm font-semibold text-foreground/90">Transfer Protocol</div>
           <div class="flex gap-2">
@@ -152,12 +152,22 @@
               <Wifi class="h-4 w-4 mr-2" />
               WebRTC
             </Button>
+            <Button
+              variant={protocol === 'bitswap' ? 'default' : 'outline'}
+              size="sm"
+              on:click={() => protocol = 'bitswap'}
+            >
+              <Zap class="h-4 w-4 mr-2" />
+              Bitswap
+            </Button>
           </div>
           <p class="text-xs text-muted-foreground">
             {#if protocol === 'http'}
               HTTP: Simple and fast for nodes with public IP addresses
             {:else if protocol === 'webrtc'}
               WebRTC: Peer-to-peer with NAT traversal (works behind firewalls)
+            {:else if protocol === 'bitswap'}
+              Bitswap: A peer-to-peer data exchange protocol for content-addressed data.
             {/if}
           </p>
         </div>

--- a/src/lib/components/download/SearchResultCard.svelte
+++ b/src/lib/components/download/SearchResultCard.svelte
@@ -24,7 +24,7 @@
   let showDownloadConfirmDialog = false;
   let showPaymentConfirmDialog = false;
   let showSeedersSelection = false;
-  let selectedSeederIndex: number | null = null;
+  let selectedSeederIndex: number | null = 0;
 
   // Use reactive wallet balance from store
   $: userBalance = $wallet.balance;
@@ -62,12 +62,19 @@
   }
 
   async function handleDownload() {
+    // Skipping payment confirmation for now
     // Always show initial download confirmation dialog first
-    // showDownloadConfirmDialog = true;
+    // showDownloadConfirmDialog = true; 
+
     const freshSeeders = await dhtService.getSeedersForFile(metadata.fileHash);
     metadata.seeders = freshSeeders; 
     console.log("🔍 DEBUG: Seeders fetched:", freshSeeders);
-    showSeedersSelection = true
+
+    // Bitswap note: manual seeder selection was for demo purposes to show 
+    // peer-selection capability; now switching to intelligent peer selection.
+    // showSeedersSelection = true 
+
+    proceedWithDownload();
 
   }
 


### PR DESCRIPTION
The new Peer Selection modal previously only listed HTTP and WebRTC, omitting Bitswap.
Bitswap has peer selection support (see PR [#600](https://github.com/chiral-network/chiral-network/pull/600)) and has been reinstated as an option.

Also, restored auto save download to storage path defined in settings following docs for Bitswap.
