### PR TITLE
feat: reduce border radius to half across all UI

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -25,7 +25,18 @@ export default {
         primary: accentPalette,
         // Backward-compatible alias so existing blue-* utilities follow accent settings.
         blue: accentPalette
-      }
+      },
+      borderRadius: {
+        none: '0',
+        sm: '0.0625rem',    // 1px (was 2px)
+        DEFAULT: '0.125rem', // 2px (was 4px)
+        md: '0.1875rem',    // 3px (was 6px)
+        lg: '0.25rem',      // 4px (was 8px)
+        xl: '0.375rem',     // 6px (was 12px)
+        '2xl': '0.5rem',    // 8px (was 16px)
+        '3xl': '0.75rem',   // 12px (was 24px)
+        full: '9999px',
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## Summary
- Override all Tailwind `borderRadius` values to 50% of their defaults in `tailwind.config.js`
- Affects every `rounded-*` class globally (~600 usages) with a single config change
- `rounded-full` preserved at `9999px` for circular elements (toggles, avatars)

| Token | Before | After |
|-------|--------|-------|
| `rounded-sm` | 2px | 1px |
| `rounded` | 4px | 2px |
| `rounded-md` | 6px | 3px |
| `rounded-lg` | 8px | 4px |
| `rounded-xl` | 12px | 6px |
| `rounded-2xl` | 16px | 8px |
| `rounded-3xl` | 24px | 12px |

## Test plan
- [ ] Visual review of all pages (wallet, network, download, drive, hosts, mining, account, settings, diagnostics)
- [ ] Verify toggle switches and circular indicators still render correctly (`rounded-full`)
- [ ] Check modals, cards, buttons, and inputs have reduced but consistent rounding

🤖 Generated with [Claude Code](https://claude.com/claude-code)